### PR TITLE
ci: pin release build to ubuntu-22.04 for older glibc compat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,12 @@ permissions:
 
 jobs:
   # Build Rust binaries and shared library
+  # Pinned to ubuntu-22.04 (glibc 2.35) so release binaries run on older
+  # distros (Ubuntu 22.04+, Debian 12+, RHEL 9+). ubuntu-latest tracks the
+  # newest glibc and would exclude those hosts.
   build:
     name: Build (${{ matrix.target }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Pins the release `build` job to `ubuntu-22.04` (glibc 2.35) so released `sandlock` binaries run on Ubuntu 22.04+, Debian 12+, and RHEL 9+.
- glibc is forward-compatible, so the 22.04 binary continues to work on every newer host. Shipping a separate `ubuntu-latest` build would gain nothing.
- Other jobs (`sdist`, `wheels`, `test`, publish, release) stay on `ubuntu-latest` since they don't ship host-linked binaries (wheels already build inside `manylinux` containers).

Fixes #16

## Test plan
- [ ] Trigger a release (or a `workflow_dispatch` run) and confirm `sandlock-x86_64-unknown-linux-gnu.tar.gz` is built on the 22.04 runner.
- [ ] Download the tarball on a Ubuntu 22.04 host and run `./sandlock --version` to confirm it loads (no `GLIBC_2.39 not found`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)