### PR TITLE
release: build aarch64 Linux binaries and wheels (#21)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,17 +10,22 @@ permissions:
   contents: read
 
 jobs:
-  # Build Rust binaries and shared library
-  # Pinned to ubuntu-22.04 (glibc 2.35) so release binaries run on older
-  # distros (Ubuntu 22.04+, Debian 12+, RHEL 9+). ubuntu-latest tracks the
-  # newest glibc and would exclude those hosts.
+  # Build Rust binaries and shared library.
+  # x86_64 is pinned to ubuntu-22.04 (glibc 2.35) so release binaries run on
+  # older distros (Ubuntu 22.04+, Debian 12+, RHEL 9+). aarch64 builds on
+  # ubuntu-24.04-arm (glibc 2.39) — the runner matches the rest of CI; older
+  # aarch64 distros can build from source until a 22.04-arm runner is wired in.
   build:
     name: Build (${{ matrix.target }})
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64-unknown-linux-gnu]
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runs-on: ubuntu-22.04
+          - target: aarch64-unknown-linux-gnu
+            runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 
@@ -69,10 +74,20 @@ jobs:
           name: sdist
           path: python/dist/*.tar.gz
 
-  # Build pre-compiled wheels so users don't need a Rust toolchain
+  # Build pre-compiled wheels so users don't need a Rust toolchain.
+  # Each arch builds natively (x86_64 on ubuntu-latest, aarch64 on the ARM
+  # runner) — avoids QEMU emulation, which is ~5–10× slower for Rust builds.
   wheels:
-    name: Build wheels
-    runs-on: ubuntu-latest
+    name: Build wheels (${{ matrix.arch }})
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runs-on: ubuntu-latest
+          - arch: aarch64
+            runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 
@@ -83,7 +98,7 @@ jobs:
           output-dir: wheelhouse
         env:
           CIBW_BUILD: "cp310-manylinux* cp311-manylinux* cp312-manylinux* cp313-manylinux*"
-          CIBW_ARCHS_LINUX: x86_64
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_BEFORE_ALL_LINUX: >
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y &&
             echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.bashrc
@@ -92,7 +107,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.arch }}
           path: wheelhouse/*.whl
 
   # Test
@@ -158,8 +173,9 @@ jobs:
       - name: Download wheels
         uses: actions/download-artifact@v4
         with:
-          name: wheels
+          pattern: wheels-*
           path: dist/
+          merge-multiple: true
 
       - name: Publish to PyPI
         env:


### PR DESCRIPTION
## Summary

Closes the only real packaging gap behind #21: aarch64 Linux. The reporter's "no prebuilt binary" framing was a misread — `release.yml` already publishes `sandlock-x86_64-unknown-linux-gnu.tar.gz` to GitHub Releases on every `v*` tag (43 downloads on v0.6.0). What was missing is the aarch64 counterpart, plus aarch64 manylinux wheels.

This PR extends the existing matrix without restructuring the workflow:

- **`build` job** — adds `aarch64-unknown-linux-gnu` running on `ubuntu-24.04-arm`. Native build, no QEMU, no `cross`. x86_64 stays on `ubuntu-22.04` so its glibc 2.35 floor is unchanged.
- **`wheels` job** — splits into a 2-element matrix so each arch builds natively. cibuildwheel under QEMU is 5–10× slower for Rust, and ARM runners are free for public repos.
- **`publish-pypi` job** — switches the wheels download to `pattern: wheels-*` + `merge-multiple: true` since artifact names are now arch-suffixed.

Result on the next tagged release:
- `sandlock-x86_64-unknown-linux-gnu.tar.gz` (unchanged)
- `sandlock-aarch64-unknown-linux-gnu.tar.gz` (new)
- `cp3{10,11,12,13}-manylinux_x86_64` wheels (unchanged)
- `cp3{10,11,12,13}-manylinux_aarch64` wheels (new)

## Caveats

- **glibc 2.39 floor on aarch64.** `ubuntu-24.04-arm` is the only ARM runner used elsewhere in this repo (`ci.yml`), so I matched it. That excludes Debian 12 / RHEL 9 / Ubuntu 22.04 aarch64. If that matters, follow-ups: switch to `ubuntu-22.04-arm` once verified, or add `aarch64-unknown-linux-musl` for a fully-static fallback.
- **No README change** — install instructions can be revised once the aarch64 artifacts are actually live on a tagged release.

## Test plan

- [ ] Trigger via `workflow_dispatch` on this branch — confirm both `build` matrix legs succeed and produce the expected tarballs as workflow artifacts.
- [ ] Confirm both `wheels` matrix legs produce wheels named `*manylinux_x86_64*.whl` and `*manylinux_aarch64*.whl`.
- [ ] Spot-check artifact naming so `github-release`'s `artifacts/**/*.tar.gz` glob still picks up both binary tarballs (it should — sdist already worked the same way).
- [ ] On a tagged release, verify `pip install sandlock` from a fresh aarch64 host (e.g. AWS Graviton) installs the aarch64 wheel and exits without `command not found` for `sandlock-mcp`.
- [ ] Verify `tar -xzf sandlock-aarch64-unknown-linux-gnu.tar.gz && ./sandlock --version` works on an aarch64 Linux box with glibc ≥ 2.39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)