### PR TITLE
test: switch /etc probe from /etc/os-release to /etc/group

### DIFF
--- a/crates/sandlock-cli/tests/cli_test.rs
+++ b/crates/sandlock-cli/tests/cli_test.rs
@@ -40,7 +40,7 @@ fn test_run_exit_code() {
 #[test]
 fn test_run_denied_path() {
     let output = sandlock_bin()
-        .args(["run", "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "--", "cat", "/etc/os-release"])
+        .args(["run", "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "--", "cat", "/etc/group"])
         .output()
         .expect("failed to run");
     assert!(!output.status.success(), "Should fail without /etc readable");

--- a/crates/sandlock-core/src/chroot/resolve.rs
+++ b/crates/sandlock-core/src/chroot/resolve.rs
@@ -192,12 +192,12 @@ mod tests {
 
     #[test]
     fn test_confine_absolute() {
-        assert_eq!(confine("/etc/os-release"), PathBuf::from("/etc/os-release"));
+        assert_eq!(confine("/etc/group"), PathBuf::from("/etc/group"));
     }
 
     #[test]
     fn test_confine_dotdot_at_root() {
-        assert_eq!(confine("/../../etc/os-release"), PathBuf::from("/etc/os-release"));
+        assert_eq!(confine("/../../etc/group"), PathBuf::from("/etc/group"));
     }
 
     #[test]
@@ -218,8 +218,8 @@ mod tests {
     #[test]
     fn test_to_virtual_path() {
         assert_eq!(
-            to_virtual_path(Path::new("/rootfs"), Path::new("/rootfs/etc/os-release")),
-            Some(PathBuf::from("/etc/os-release"))
+            to_virtual_path(Path::new("/rootfs"), Path::new("/rootfs/etc/group")),
+            Some(PathBuf::from("/etc/group"))
         );
     }
 
@@ -249,9 +249,9 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
         std::fs::create_dir_all(root.join("etc")).unwrap();
-        std::fs::write(root.join("etc/os-release"), "ID=test\n").unwrap();
+        std::fs::write(root.join("etc/group"), "root:x:0:\n").unwrap();
 
-        let fd = openat2_in_root(root, "/etc/os-release", libc::O_RDONLY, 0);
+        let fd = openat2_in_root(root, "/etc/group", libc::O_RDONLY, 0);
         match fd {
             Ok(fd) => unsafe { libc::close(fd) },
             Err(libc::ENOSYS) => return, // kernel too old
@@ -265,10 +265,10 @@ mod tests {
         let root = tmp.path();
         std::fs::create_dir_all(root.join("a")).unwrap();
 
-        let fd = openat2_in_root(root, "/../../../etc/os-release", libc::O_PATH, 0);
+        let fd = openat2_in_root(root, "/../../../etc/group", libc::O_PATH, 0);
         match fd {
             // RESOLVE_IN_ROOT clamps ".." at the root, so this resolves
-            // to <root>/etc/os-release which doesn't exist → ENOENT.
+            // to <root>/etc/group which doesn't exist → ENOENT.
             Err(libc::ENOENT) => {}
             Err(libc::ENOSYS) => return,
             Ok(fd) => {
@@ -373,7 +373,7 @@ mod tests {
         let root = tmp.path();
         std::fs::create_dir_all(root.join("a")).unwrap();
 
-        let result = resolve_in_root(root, "/a/../../etc/os-release");
+        let result = resolve_in_root(root, "/a/../../etc/group");
         // Either resolves within root or returns None — never escapes.
         if let Some((host, _)) = result {
             assert!(host.starts_with(root));

--- a/crates/sandlock-core/src/procfs.rs
+++ b/crates/sandlock-core/src/procfs.rs
@@ -940,7 +940,7 @@ mod tests {
         assert_eq!(extract_proc_pid("/proc/cpuinfo"), None);
         assert_eq!(extract_proc_pid("/proc/meminfo"), None);
         assert_eq!(extract_proc_pid("/proc/net/tcp"), None);
-        assert_eq!(extract_proc_pid("/etc/os-release"), None);
+        assert_eq!(extract_proc_pid("/etc/group"), None);
         assert_eq!(extract_proc_pid("/proc/"), None);
     }
 

--- a/crates/sandlock-core/tests/integration/test_extra_handlers.rs
+++ b/crates/sandlock-core/tests/integration/test_extra_handlers.rs
@@ -206,7 +206,7 @@ async fn empty_extras_preserves_default_behaviour() {
 async fn extra_handler_runs_after_builtin_returns_continue() {
     let policy = base_policy().build().unwrap();
     let out = temp_out("openat-cross");
-    let cmd = format!("cat /etc/os-release; echo $? > {}", out.display());
+    let cmd = format!("cat /etc/group; echo $? > {}", out.display());
 
     let openat_calls = Arc::new(AtomicUsize::new(0));
     let openat_in_handler = Arc::clone(&openat_calls);
@@ -261,7 +261,7 @@ async fn builtin_non_continue_blocks_extra() {
     let policy = base_policy().build().unwrap();
     let out = temp_out("openat-blocked-by-builtin");
     let cmd = format!(
-        "cat /proc/1/cmdline; cat /etc/os-release; echo $? > {}",
+        "cat /proc/1/cmdline; cat /etc/group; echo $? > {}",
         out.display()
     );
 
@@ -292,11 +292,11 @@ async fn builtin_non_continue_blocks_extra() {
     let _ = std::fs::remove_file(&out);
     let paths = observed.lock().unwrap();
 
-    let saw_etc_os_release = paths.iter().any(|p| p == "/etc/os-release");
+    let saw_etc_group = paths.iter().any(|p| p == "/etc/group");
     let saw_proc_pid = paths.iter().any(|p| p.starts_with("/proc/1/"));
 
     assert!(
-        saw_etc_os_release,
+        saw_etc_group,
         "extra must observe non-blocked openats, got paths: {:?}",
         *paths,
     );

--- a/crates/sandlock-core/tests/integration/test_landlock.rs
+++ b/crates/sandlock-core/tests/integration/test_landlock.rs
@@ -57,8 +57,8 @@ async fn test_cannot_read_outside_allowed() {
         .build()
         .unwrap();
 
-    // /etc is NOT in fs_read, so cat /etc/os-release should fail
-    let result = Sandbox::run(&policy, Some("test"), &["cat", "/etc/os-release"])
+    // /etc is NOT in fs_read, so cat /etc/group should fail
+    let result = Sandbox::run(&policy, Some("test"), &["cat", "/etc/group"])
         .await
         .unwrap();
     assert!(!result.success(), "cat should fail without /etc in fs_read");

--- a/crates/sandlock-core/tests/integration/test_sandbox.rs
+++ b/crates/sandlock-core/tests/integration/test_sandbox.rs
@@ -41,7 +41,7 @@ async fn test_denied_path() {
         .fs_read("/proc")
         .build()
         .unwrap();
-    let result = Sandbox::run(&policy, Some("test"), &["cat", "/etc/os-release"]).await.unwrap();
+    let result = Sandbox::run(&policy, Some("test"), &["cat", "/etc/group"]).await.unwrap();
     assert!(!result.success());
 }
 
@@ -134,7 +134,7 @@ async fn test_nested_sandbox() {
         .build()
         .unwrap();
 
-    // Inner: does NOT allow /etc — run cat /etc/os-release, should fail
+    // Inner: does NOT allow /etc — run cat /etc/group, should fail
     let inner = Policy::builder()
         .fs_read("/usr").fs_read("/lib").fs_read_if_exists("/lib64").fs_read("/bin")
         .fs_read("/proc")
@@ -159,10 +159,10 @@ async fn test_nested_sandbox() {
     // Sequential sandboxes: first sandbox applies Landlock + seccomp,
     // second sandbox from the same parent gets EBUSY on seccomp
     // but Landlock stacks. Verify both work independently.
-    let r1 = Sandbox::run(&outer, Some("test"), &["cat", "/etc/os-release"]).await.unwrap();
+    let r1 = Sandbox::run(&outer, Some("test"), &["cat", "/etc/group"]).await.unwrap();
     assert!(r1.success(), "outer should allow /etc");
 
-    let r2 = Sandbox::run(&inner, Some("test"), &["cat", "/etc/os-release"]).await.unwrap();
+    let r2 = Sandbox::run(&inner, Some("test"), &["cat", "/etc/group"]).await.unwrap();
     assert!(!r2.success(), "inner should deny /etc");
 }
 
@@ -195,7 +195,7 @@ async fn test_nested_sandbox_via_cli() {
         .unwrap();
 
     let inner_cmd = format!(
-        "{} run -r /usr -r /lib{} -r /bin -r /proc -- cat /etc/os-release",
+        "{} run -r /usr -r /lib{} -r /bin -r /proc -- cat /etc/group",
         bin, lib64_arg
     );
     let result = Sandbox::run(


### PR DESCRIPTION
## Summary

Follow-up to commit 4f9b2eb (the /etc/passwd test-leak fix), which switched the canonical "denied read" probe to `/etc/os-release`. That choice broke CI on Debian/Ubuntu/Fedora runners because `/etc/os-release` is a symlink to `/usr/lib/os-release` on those distros — Landlock checks the resolved file, so reads succeeded whenever `/usr` was in `fs_read`, defeating four assertions:

- `test_landlock::test_cannot_read_outside_allowed`
- `test_sandbox::test_denied_path`
- `test_sandbox::test_nested_sandbox`
- `test_sandbox::test_nested_sandbox_via_cli`

Switches every probe to `/etc/group`: real (never-symlinked) file on every Linux distro with users, innocuous content, and no virtualization handler in sandlock.

## Test plan

- [x] `cargo test --release -p sandlock-core --test integration` — all 14 affected tests pass locally
- [x] `cargo test --release -p sandlock-core --lib -- chroot::resolve procfs::tests` — 21 unit tests pass
- [x] `cargo test --release -p sandlock-cli --test cli_test` — CLI denied-path test passes
- [ ] CI green on Ubuntu runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)