### PR TITLE
core: drain seccomp notifications via AsyncFd, remove per-sandbox blocking thread

### DIFF
--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -1785,9 +1785,25 @@ impl Sandbox {
             });
 
             let extra_handlers = std::mem::take(&mut self.rt_mut().extra_handlers);
+            let (startup_tx, startup_rx) = tokio::sync::oneshot::channel();
             self.rt_mut().notif_handle = Some(tokio::spawn(
-                notif::supervisor(notif_fd, ctx, extra_handlers),
+                notif::supervisor(notif_fd, ctx, extra_handlers, startup_tx),
             ));
+            // Wait for the supervisor to register the notif fd with the IO
+            // driver before we release the child to execve. Otherwise an
+            // early traced syscall would queue a notification on a fd no
+            // one is polling, and the child would block until the next
+            // `block_on` re-enters the runtime. Critical for current-thread
+            // runtimes, harmless overhead for multi-thread.
+            match startup_rx.await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => return Err(SandboxRuntimeError::Io(e).into()),
+                Err(_) => {
+                    return Err(SandboxRuntimeError::Child(
+                        "seccomp supervisor exited during startup".into(),
+                    ).into());
+                }
+            }
 
             let la_resource = Arc::clone(&res_state);
             self.rt_mut().loadavg_handle = Some(tokio::spawn(async move {

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -1108,8 +1108,21 @@ pub async fn supervisor(
     notif_fd: OwnedFd,
     ctx: Arc<super::ctx::SupervisorCtx>,
     pending_handlers: Vec<(i64, std::sync::Arc<dyn super::dispatch::Handler>)>,
+    startup: tokio::sync::oneshot::Sender<io::Result<()>>,
 ) {
-    let fd = notif_fd.as_raw_fd();
+    // Register the notif fd with the Tokio IO driver so we can wait for
+    // readiness via epoll instead of a dedicated blocking thread.
+    let async_fd = match tokio::io::unix::AsyncFd::with_interest(
+        notif_fd,
+        tokio::io::Interest::READABLE,
+    ) {
+        Ok(fd) => fd,
+        Err(err) => {
+            let _ = startup.send(Err(err));
+            return;
+        }
+    };
+    let fd = async_fd.get_ref().as_raw_fd();
 
     // Build the dispatch table once at startup.
     let dispatch_table = Arc::new(super::dispatch::build_dispatch_table(
@@ -1122,28 +1135,10 @@ pub async fn supervisor(
     // Try to enable sync wakeup (Linux 6.7+, ignore error on older kernels).
     try_set_sync_wakeup(fd);
 
-    // SECCOMP_IOCTL_NOTIF_RECV blocks regardless of O_NONBLOCK, so we
-    // receive notifications in a blocking thread and send them to the
-    // async handler via a channel.  This guarantees we never miss a
-    // notification — the thread is always blocked in recv_notif ready
-    // for the next one.
-    //
-    // Notifications are processed sequentially (not spawned) to avoid
-    // mutex contention between concurrent handlers.
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<SeccompNotif>();
-
-    std::thread::spawn(move || {
-        loop {
-            match recv_notif(fd) {
-                Ok(notif) => {
-                    if tx.send(notif).is_err() {
-                        break; // receiver dropped — supervisor shutting down
-                    }
-                }
-                Err(_) => break, // fd closed — child exited
-            }
-        }
-    });
+    // The IO driver has the fd registered; subsequent block_on cycles
+    // can resume this task and pick up readiness events. Tell the
+    // caller it is safe to release the child.
+    let _ = startup.send(Ok(()));
 
     // Periodic sweep as a defensive backstop in case pidfd-based
     // lifecycle cleanup misses an entry (e.g. pidfd_open failed for a
@@ -1152,8 +1147,61 @@ pub async fn supervisor(
     // still per-child pidfd readiness in `spawn_pid_watcher`.
     let gc = tokio::spawn(process_index_gc(Arc::clone(&ctx.processes)));
 
-    while let Some(notif) = rx.recv().await {
-        handle_notification(notif, &ctx, &dispatch_table, fd).await;
+    // SECCOMP_IOCTL_NOTIF_RECV is a blocking ioctl that ignores
+    // O_NONBLOCK on the notif fd (see kernel/seccomp.c
+    // `seccomp_notify_recv`, which calls `wait_event_interruptible`
+    // unconditionally). So we cannot call it speculatively. The
+    // notif fd does implement `seccomp_notify_poll` and fires
+    // EPOLLIN whenever an INIT-state notification is queued, so we:
+    //
+    //   1. Wait for readiness via AsyncFd (one EPOLLET edge per
+    //      wake_up_poll batch).
+    //   2. Re-arm immediately so any new arrivals during drain queue
+    //      a fresh edge.
+    //   3. Drain the queue using `poll(timeout=0)` as a non-blocking
+    //      probe before each recv. This is required because tokio's
+    //      AsyncFd is edge-triggered: a burst of arrivals between
+    //      our `clear_ready` and the next `readable().await` would
+    //      coalesce into a single event, so the recv side must drain
+    //      to empty before re-awaiting.
+    //
+    // Notifications are processed sequentially (not spawned) to avoid
+    // mutex contention between concurrent handlers.
+    'outer: loop {
+        let mut ready = match async_fd.readable().await {
+            Ok(r) => r,
+            Err(_) => break 'outer,
+        };
+        ready.clear_ready();
+        drop(ready);
+
+        loop {
+            let mut pfd = libc::pollfd {
+                fd,
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            let r = unsafe { libc::poll(&mut pfd, 1, 0) };
+            if r > 0 && (pfd.revents & libc::POLLIN) != 0 {
+                match recv_notif(fd) {
+                    Ok(notif) => {
+                        handle_notification(notif, &ctx, &dispatch_table, fd).await;
+                        continue;
+                    }
+                    Err(err) if err.raw_os_error() == Some(libc::EINTR) => continue,
+                    Err(_) => break 'outer,
+                }
+            }
+            // No POLLIN. POLLHUP/POLLERR/POLLNVAL on the notif fd are
+            // terminal (filter released or fd invalid); leaving them
+            // unhandled would busy-spin because tokio keeps reporting
+            // the fd ready. Otherwise the queue is just empty for now,
+            // so go back to awaiting an edge.
+            if (pfd.revents & (libc::POLLHUP | libc::POLLERR | libc::POLLNVAL)) != 0 {
+                break 'outer;
+            }
+            break;
+        }
     }
 
     gc.abort();

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -257,6 +257,47 @@ fn recv_notif(fd: RawFd) -> io::Result<SeccompNotif> {
     }
 }
 
+/// Result of a non-blocking probe on the seccomp notif fd.
+enum NotifFdState {
+    /// At least one INIT-state notification is queued. `recv_notif`
+    /// will return without blocking.
+    Pending,
+    /// No notifications and no terminal flags. Wait for the next
+    /// epoll edge before probing again.
+    Empty,
+    /// `POLLHUP`/`POLLERR`/`POLLNVAL` set, or `poll(2)` itself failed:
+    /// filter has been released or the fd is invalid. The supervisor
+    /// should exit; subsequent waits would busy-spin because epoll
+    /// keeps reporting the fd ready.
+    Terminal,
+}
+
+/// Non-blocking probe of the seccomp notif fd.
+///
+/// `SECCOMP_IOCTL_NOTIF_RECV` ignores `O_NONBLOCK` and calls
+/// `wait_event_interruptible` unconditionally (kernel/seccomp.c
+/// `seccomp_notify_recv`). So `recv_notif` cannot be invoked
+/// speculatively to detect an empty queue. This helper uses
+/// `poll(timeout=0)` as a non-blocking predictor: if POLLIN is set
+/// the kernel will hand us a notification without blocking; if a
+/// terminal flag is set the fd will keep waking AsyncFd until the
+/// supervisor exits.
+fn probe_notif_fd(fd: RawFd) -> NotifFdState {
+    let mut pfd = libc::pollfd {
+        fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    let r = unsafe { libc::poll(&mut pfd, 1, 0) };
+    if r > 0 && (pfd.revents & libc::POLLIN) != 0 {
+        return NotifFdState::Pending;
+    }
+    if r < 0 || (pfd.revents & (libc::POLLHUP | libc::POLLERR | libc::POLLNVAL)) != 0 {
+        return NotifFdState::Terminal;
+    }
+    NotifFdState::Empty
+}
+
 /// Send a response with SECCOMP_USER_NOTIF_FLAG_CONTINUE.
 fn respond_continue(fd: RawFd, id: u64) -> io::Result<()> {
     let resp = SeccompNotifResp {
@@ -1147,23 +1188,12 @@ pub async fn supervisor(
     // still per-child pidfd readiness in `spawn_pid_watcher`.
     let gc = tokio::spawn(process_index_gc(Arc::clone(&ctx.processes)));
 
-    // SECCOMP_IOCTL_NOTIF_RECV is a blocking ioctl that ignores
-    // O_NONBLOCK on the notif fd (see kernel/seccomp.c
-    // `seccomp_notify_recv`, which calls `wait_event_interruptible`
-    // unconditionally). So we cannot call it speculatively. The
-    // notif fd does implement `seccomp_notify_poll` and fires
-    // EPOLLIN whenever an INIT-state notification is queued, so we:
-    //
-    //   1. Wait for readiness via AsyncFd (one EPOLLET edge per
-    //      wake_up_poll batch).
-    //   2. Re-arm immediately so any new arrivals during drain queue
-    //      a fresh edge.
-    //   3. Drain the queue using `poll(timeout=0)` as a non-blocking
-    //      probe before each recv. This is required because tokio's
-    //      AsyncFd is edge-triggered: a burst of arrivals between
-    //      our `clear_ready` and the next `readable().await` would
-    //      coalesce into a single event, so the recv side must drain
-    //      to empty before re-awaiting.
+    // Edge-triggered drain: each `readable().await` returns once per
+    // epoll edge, then we drain the kernel queue via `probe_notif_fd`
+    // until empty. The drain is necessary because tokio's AsyncFd is
+    // edge-triggered and `recv_notif` does not signal "would block",
+    // so a burst of arrivals between two `readable().await` calls
+    // would coalesce into a single wake event.
     //
     // Notifications are processed sequentially (not spawned) to avoid
     // mutex contention between concurrent handlers.
@@ -1176,31 +1206,18 @@ pub async fn supervisor(
         drop(ready);
 
         loop {
-            let mut pfd = libc::pollfd {
-                fd,
-                events: libc::POLLIN,
-                revents: 0,
-            };
-            let r = unsafe { libc::poll(&mut pfd, 1, 0) };
-            if r > 0 && (pfd.revents & libc::POLLIN) != 0 {
-                match recv_notif(fd) {
-                    Ok(notif) => {
-                        handle_notification(notif, &ctx, &dispatch_table, fd).await;
-                        continue;
-                    }
-                    Err(err) if err.raw_os_error() == Some(libc::EINTR) => continue,
-                    Err(_) => break 'outer,
+            match probe_notif_fd(fd) {
+                NotifFdState::Pending => {
+                    let notif = match recv_notif(fd) {
+                        Ok(n) => n,
+                        Err(e) if e.raw_os_error() == Some(libc::EINTR) => continue,
+                        Err(_) => break 'outer,
+                    };
+                    handle_notification(notif, &ctx, &dispatch_table, fd).await;
                 }
+                NotifFdState::Empty => break,
+                NotifFdState::Terminal => break 'outer,
             }
-            // No POLLIN. POLLHUP/POLLERR/POLLNVAL on the notif fd are
-            // terminal (filter released or fd invalid); leaving them
-            // unhandled would busy-spin because tokio keeps reporting
-            // the fd ready. Otherwise the queue is just empty for now,
-            // so go back to awaiting an edge.
-            if (pfd.revents & (libc::POLLHUP | libc::POLLERR | libc::POLLNVAL)) != 0 {
-                break 'outer;
-            }
-            break;
         }
     }
 


### PR DESCRIPTION
## Summary

Replaces the per-sandbox blocking-recv thread in the seccomp supervisor with a tokio AsyncFd registration on the notif fd. Each live sandbox is now one fewer OS thread parked in \`ioctl(SECCOMP_IOCTL_NOTIF_RECV)\`.

Independent of #49: this branch is rooted on \`origin/main\`. The two PRs touch disjoint files (FFI/Python vs. \`sandlock-core\`) and should merge cleanly in either order.

## What changes

**\`seccomp/notif.rs\`** — supervisor rewrite:
- Wraps \`notif_fd\` in \`tokio::io::unix::AsyncFd\` (READABLE interest).
- On each epoll edge, drains the kernel queue via a \`libc::poll(timeout=0)\` probe + \`recv_notif\`. The probe is required because \`SECCOMP_IOCTL_NOTIF_RECV\` ignores \`O_NONBLOCK\` (kernel/seccomp.c's \`wait_event_interruptible\`), so we can't speculatively recv to detect an empty queue, and tokio AsyncFd is edge-triggered.
- Treats \`POLLHUP | POLLERR | POLLNVAL\` without \`POLLIN\` as terminal — filter has been released or fd is invalid. Without this the supervisor would busy-spin: AsyncFd keeps reporting the fd ready post-child-exit, and a naive \"only POLLIN matters\" check loops forever.
- Drops the \`std::thread::spawn\` + mpsc relay entirely.

**\`sandbox.rs\`** — supervisor startup synchronization:
- Adds a \`oneshot::Sender<io::Result<()>>\` that the supervisor signals after AsyncFd registration completes.
- \`do_create\` awaits the signal before releasing the child to execve. This forward-compats with \`current_thread\` runtimes (#49), where the supervisor would otherwise never get a chance to run before \`block_on\` returns.

Second commit is a refactor of the drain loop into a \`NotifFdState\` enum (\`Pending\` / \`Empty\` / \`Terminal\`) + \`probe_notif_fd\` helper. Same behavior, three-arm \`match\` reads in English; the POLLHUP-spin bug becomes structurally hard to reintroduce.

## Why this is the right pattern

- The seccomp notif fd implements \`seccomp_notify_poll\` which fires \`EPOLLIN\` whenever an INIT-state notification is queued, so it's a first-class epoll source.
- \`recv_notif\` does not block when the queue is non-empty (\`wait_event_interruptible\`'s condition is checked at entry), so poll-then-recv is race-free for our single-consumer-per-filter topology.
- A previous attempt at this pattern on the \`dev\` branch (commit \`5638239\`, later abandoned) hit the POLLHUP-spin bug; we caught it via \`test_checkpoint_app_state_roundtrip\` deadlock and fixed it explicitly.

## Test plan

- [x] \`cargo test --lib --tests\` — 557 tests pass (skipping doctests due to an unrelated rustdoc/libLLVM issue on the dev machine).
- [x] \`pytest python/tests/\` — 247 tests pass in 15s.
- [x] \`test_checkpoint_app_state_roundtrip\` (the regression that surfaced the POLLHUP-spin bug during development) passes in 0.11s.