### PR TITLE
Fix COW statx and execve for files in the upper layer

### DIFF
--- a/crates/sandlock-core/src/context.rs
+++ b/crates/sandlock-core/src/context.rs
@@ -340,6 +340,8 @@ pub fn notif_syscalls(policy: &Sandbox, sandbox_name: Option<&str>) -> Vec<u32> 
     if policy.workdir.is_some() && policy.fs_isolation == FsIsolation::None {
         nrs.extend_from_slice(&[
             libc::SYS_openat as u32,
+            libc::SYS_execve as u32,
+            libc::SYS_execveat as u32,
             libc::SYS_unlinkat as u32,
             libc::SYS_mkdirat as u32,
             libc::SYS_renameat2 as u32,

--- a/crates/sandlock-core/src/cow/dispatch.rs
+++ b/crates/sandlock-core/src/cow/dispatch.rs
@@ -162,12 +162,12 @@ pub(crate) async fn handle_cow_open(
 
     let nr = notif.data.nr as i64;
 
-    // open(path, flags, mode):     args[0]=path, args[1]=flags
-    // openat(dirfd, path, flags):  args[0]=dirfd, args[1]=path, args[2]=flags
-    let (path_ptr, dirfd, flags) = if Some(nr) == arch::SYS_OPEN {
-        (notif.data.args[0], libc::AT_FDCWD as i64, notif.data.args[1])
+    // open(path, flags, mode):         args[0]=path, args[1]=flags, args[2]=mode
+    // openat(dirfd, path, flags, mode): args[0]=dirfd, args[1]=path, args[2]=flags, args[3]=mode
+    let (path_ptr, dirfd, flags, mode) = if Some(nr) == arch::SYS_OPEN {
+        (notif.data.args[0], libc::AT_FDCWD as i64, notif.data.args[1], notif.data.args[2])
     } else {
-        (notif.data.args[1], notif.data.args[0] as i64, notif.data.args[2])
+        (notif.data.args[1], notif.data.args[0] as i64, notif.data.args[2], notif.data.args[3])
     };
 
     let rel_path = match read_path(notif, path_ptr, notif_fd) {
@@ -248,7 +248,12 @@ pub(crate) async fn handle_cow_open(
         Ok(c) => c,
         Err(_) => return NotifAction::Continue,
     };
-    let fd = unsafe { libc::open(c_path.as_ptr(), open_flags, 0o666) };
+    // Honor the child's requested creation mode (masked to permission bits).
+    // Hardcoding 0o666 dropped the execute bits, so a binary copied into the
+    // workdir (e.g. `cp /bin/echo m`) landed in upper non-executable and
+    // `./m` failed with EACCES. The kernel ignores mode unless O_CREAT is set.
+    let create_mode = (mode & 0o7777) as libc::c_uint;
+    let fd = unsafe { libc::open(c_path.as_ptr(), open_flags, create_mode) };
     if fd < 0 {
         return NotifAction::Continue;
     }
@@ -801,7 +806,13 @@ pub(crate) async fn handle_cow_stat(
     NotifAction::ReturnValue(0)
 }
 
-/// Handle statx — resolve path then let kernel handle (complex struct).
+/// Handle statx — resolve the path to upper/lower and run statx ourselves.
+///
+/// We cannot return Continue when the file exists: on Continue the kernel
+/// re-runs statx against the original (un-redirected) path, which for a
+/// COW-only file lives only in the upper layer and is invisible to the
+/// kernel under the lower workdir → ENOENT. So mirror `handle_cow_stat`:
+/// statx the resolved path in the supervisor and write the buffer back.
 pub(crate) async fn handle_cow_statx(
     notif: &SeccompNotif,
     cow_state: &Arc<Mutex<CowState>>,
@@ -810,27 +821,169 @@ pub(crate) async fn handle_cow_statx(
 ) -> NotifAction {
     // statx(dirfd, pathname, flags, mask, statxbuf)
     let dirfd = notif.data.args[0] as i64;
-    let virtual_cwd = current_virtual_cwd(processes, notif.pid).await;
-    let path = match read_path(notif, notif.data.args[1], notif_fd) {
-        Some(p) => resolve_at_path_with_virtual(notif, dirfd, &p, virtual_cwd.as_deref()),
-        None => return NotifAction::Continue,
-    };
+    let flags = notif.data.args[2] as i32;
+    let mask = notif.data.args[3] as u32;
+    let statxbuf_addr = notif.data.args[4];
 
-    let st = cow_state.lock().await;
-    let cow = match st.branch.as_ref() {
-        Some(c) => c,
-        None => return NotifAction::Continue,
-    };
-
-    let path = map_cow_upper_path(cow, &path);
-    if !cow.has_changes() || !cow.matches(&path) {
+    // AT_EMPTY_PATH stats the dirfd itself, no path resolution needed.
+    // The fd was already redirected at open time, so let the kernel handle it.
+    if (flags & libc::AT_EMPTY_PATH) != 0 {
         return NotifAction::Continue;
     }
 
-    match cow.handle_stat(&path) {
-        Some(_) => NotifAction::Continue, // exists, let kernel handle
-        None => NotifAction::Errno(libc::ENOENT), // deleted
+    let virtual_cwd = current_virtual_cwd(processes, notif.pid).await;
+    let path = match read_path(notif, notif.data.args[1], notif_fd) {
+        Some(p) if !p.is_empty() => resolve_at_path_with_virtual(notif, dirfd, &p, virtual_cwd.as_deref()),
+        _ => return NotifAction::Continue,
+    };
+
+    let real_path = {
+        let st = cow_state.lock().await;
+        let cow = match st.branch.as_ref() {
+            Some(c) => c,
+            None => return NotifAction::Continue,
+        };
+
+        let path = map_cow_upper_path(cow, &path);
+        if !cow.has_changes() || !cow.matches(&path) {
+            return NotifAction::Continue;
+        }
+
+        match cow.handle_stat(&path) {
+            Some(p) => p,
+            None => return NotifAction::Errno(libc::ENOENT), // deleted or absent
+        }
+    };
+
+    let c_path = match std::ffi::CString::new(real_path.to_str().unwrap_or("")) {
+        Ok(c) => c,
+        Err(_) => return NotifAction::Continue,
+    };
+    let mut stx_buf = vec![0u8; 256]; // sizeof(struct statx)
+    let ret = unsafe {
+        libc::syscall(
+            libc::SYS_statx,
+            libc::AT_FDCWD,
+            c_path.as_ptr(),
+            flags,
+            mask,
+            stx_buf.as_mut_ptr(),
+        )
+    };
+    if ret < 0 {
+        let errno = std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or(libc::EIO);
+        return NotifAction::Errno(errno);
     }
+
+    if write_child_mem(notif_fd, notif.id, notif.pid, statxbuf_addr, &stx_buf).is_err() {
+        return NotifAction::Continue;
+    }
+    NotifAction::ReturnValue(0)
+}
+
+// ============================================================
+// execve / execveat handler
+// ============================================================
+
+/// Handle execve/execveat under COW: when the binary resolves into the
+/// upper layer (created or modified inside the workdir), open the upper
+/// file and inject it as an fd, rewriting the path to /proc/self/fd/N so
+/// the kernel execs the COW version.
+///
+/// Without this, execve resolves the original (un-redirected) path, which
+/// for a COW-only binary lives only in upper and is invisible under the
+/// lower workdir → ENOENT. Files resolving to the lower layer are
+/// unmodified, so the kernel finds them at the original path and we leave
+/// them alone.
+pub(crate) async fn handle_cow_exec(
+    notif: &SeccompNotif,
+    cow_state: &Arc<Mutex<CowState>>,
+    processes: &Arc<ProcessIndex>,
+    notif_fd: RawFd,
+) -> NotifAction {
+    let nr = notif.data.nr as i64;
+    // execve(path, argv, envp):        args[0] = path
+    // execveat(dirfd, path, argv, ..): args[0]=dirfd, args[1]=path
+    let (dirfd, path_ptr) = if nr == libc::SYS_execveat {
+        (notif.data.args[0] as i64, notif.data.args[1])
+    } else {
+        (libc::AT_FDCWD as i64, notif.data.args[0])
+    };
+
+    let rel_path = match read_path(notif, path_ptr, notif_fd) {
+        Some(p) => p,
+        None => return NotifAction::Continue,
+    };
+
+    let virtual_cwd = if (dirfd as i32) == libc::AT_FDCWD && !Path::new(&rel_path).is_absolute() {
+        current_virtual_cwd(processes, notif.pid).await
+    } else {
+        None
+    };
+    let resolved = resolve_at_path_with_virtual(notif, dirfd, &rel_path, virtual_cwd.as_deref());
+
+    let upper_path = {
+        let st = cow_state.lock().await;
+        let cow = match st.branch.as_ref() {
+            Some(c) => c,
+            None => return NotifAction::Continue,
+        };
+        let path = map_cow_upper_path(cow, &resolved);
+        if !cow.has_changes() || !cow.matches(&path) {
+            return NotifAction::Continue;
+        }
+        match cow.handle_stat(&path) {
+            // Only redirect when the binary lives in the upper layer.
+            Some(real) if real.starts_with(cow.upper_dir()) => real,
+            // Lower-layer (unmodified) binary — kernel resolves it fine.
+            Some(_) => return NotifAction::Continue,
+            // Deleted in the COW layer (or absent) — must not exec the lower file.
+            None => return NotifAction::Errno(libc::ENOENT),
+        }
+    };
+
+    // Open the upper binary and inject the fd into the child.
+    let c_path = match std::ffi::CString::new(upper_path.to_str().unwrap_or("")) {
+        Ok(c) => c,
+        Err(_) => return NotifAction::Continue,
+    };
+    let src_fd = unsafe { libc::open(c_path.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC) };
+    if src_fd < 0 {
+        return NotifAction::Errno(libc::ENOENT);
+    }
+
+    let addfd = crate::sys::structs::SeccompNotifAddfd {
+        id: notif.id,
+        flags: 0,
+        srcfd: src_fd as u32,
+        newfd: 0,
+        newfd_flags: 0, // no O_CLOEXEC — the kernel must read it at exec time
+    };
+    let child_fd = unsafe {
+        libc::ioctl(
+            notif_fd,
+            crate::sys::structs::SECCOMP_IOCTL_NOTIF_ADDFD as libc::c_ulong,
+            &addfd as *const _,
+        )
+    };
+    unsafe { libc::close(src_fd) };
+
+    if child_fd < 0 {
+        return NotifAction::Errno(libc::EIO);
+    }
+
+    // Rewrite the path argument to /proc/self/fd/N so the kernel execs the
+    // injected fd. execve replaces the whole address space on success, so
+    // (unlike chdir) writing past the original buffer is harmless — the
+    // only memory the kernel still reads is argv/envp, which sit elsewhere.
+    let fd_path = format!("/proc/self/fd/{}\0", child_fd);
+    if write_child_mem(notif_fd, notif.id, notif.pid, path_ptr, fd_path.as_bytes()).is_err() {
+        return NotifAction::Errno(libc::EFAULT);
+    }
+
+    NotifAction::Continue
 }
 
 /// Handle readlinkat — read symlink from upper/lower, write to child buffer.

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -1204,6 +1204,29 @@ impl Sandbox {
 
         let cow_config = cow_branch.as_ref().and_then(|b| b.child_mount_config());
 
+        // Seccomp COW: create the branch before fork so the child's Landlock
+        // ruleset can include the upper layer. Binaries created inside the
+        // workdir live in the upper dir, and Landlock checks EXECUTE on the
+        // file's real path at execve time — so the upper dir must be granted
+        // read+execute (READ_ACCESS) or `./created-binary` fails with EACCES.
+        let seccomp_cow_branch = if !nested && self.workdir.is_some() && self.fs_isolation == FsIsolation::None {
+            let workdir = self.workdir.as_ref().unwrap().clone();
+            let storage = self.fs_storage.clone();
+            let max_disk = self.max_disk.map(|b| b.0).unwrap_or(0);
+            match crate::cow::seccomp::SeccompCowBranch::create(&workdir, storage.as_deref(), max_disk) {
+                Ok(branch) => {
+                    self.fs_readable.push(branch.upper_dir().to_path_buf());
+                    Some(branch)
+                }
+                Err(e) => {
+                    eprintln!("sandlock: seccomp COW branch creation failed: {}", e);
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         let (stdout_r, stderr_r) = if capture {
             let mut stdout_fds = [0i32; 2];
             let mut stderr_fds = [0i32; 2];
@@ -1418,15 +1441,7 @@ impl Sandbox {
             res_state.proc_count = 1;
 
             let mut cow_state = CowState::new();
-            if self.workdir.is_some() && self.fs_isolation == FsIsolation::None {
-                let workdir = self.workdir.as_ref().unwrap();
-                let storage = self.fs_storage.as_deref();
-                let max_disk = self.max_disk.map(|b| b.0).unwrap_or(0);
-                match crate::cow::seccomp::SeccompCowBranch::create(workdir, storage, max_disk) {
-                    Ok(branch) => { cow_state.branch = Some(branch); }
-                    Err(e) => { eprintln!("sandlock: seccomp COW branch creation failed: {}", e); }
-                }
-            }
+            cow_state.branch = seccomp_cow_branch;
 
             let mut policy_fn_state = PolicyFnState::new();
 

--- a/crates/sandlock-core/src/seccomp/dispatch.rs
+++ b/crates/sandlock-core/src/seccomp/dispatch.rs
@@ -935,6 +935,10 @@ fn register_cow_handlers(table: &mut DispatchTable, ctx: &Arc<SupervisorCtx>) {
 
     table.register(libc::SYS_chdir, cow_call!(crate::cow::dispatch::handle_cow_chdir));
     table.register(libc::SYS_getcwd, cow_call!(crate::cow::dispatch::handle_cow_getcwd));
+
+    for &nr in &[libc::SYS_execve, libc::SYS_execveat] {
+        table.register(nr, cow_call!(crate::cow::dispatch::handle_cow_exec));
+    }
 }
 
 // ============================================================

--- a/crates/sandlock-core/tests/integration/test_cow.rs
+++ b/crates/sandlock-core/tests/integration/test_cow.rs
@@ -500,3 +500,88 @@ async fn test_seccomp_cow_read_existing() {
 
     let _ = fs::remove_dir_all(&workdir);
 }
+
+/// Regression test: statx on a COW-created file must succeed.
+///
+/// statx is what `ls`, `stat`, and most modern coreutils use. The COW
+/// statx handler returned Continue when the file existed in the upper
+/// layer, so the kernel re-ran statx against the un-redirected lower path
+/// and returned ENOENT for files that live only in upper.
+#[tokio::test]
+async fn test_seccomp_cow_statx_created_file() {
+    let workdir = temp_dir("seccomp-statx");
+    let out_file = std::env::temp_dir().join(format!(
+        "sandlock-test-statx-{}", std::process::id()
+    ));
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr").fs_read("/lib").fs_read_if_exists("/lib64").fs_read("/bin").fs_read("/etc")
+        .fs_read("/proc").fs_read("/dev")
+        .fs_write(&workdir).fs_write("/tmp")
+        .workdir(&workdir)
+        .cwd(&workdir)
+        .on_exit(BranchAction::Abort)
+        .build()
+        .unwrap();
+
+    // Create a file that lives only in the COW upper layer, then statx it
+    // via the raw syscall (the path coreutils `stat`/`ls` take).
+    let script = format!(concat!(
+        "import ctypes, os, platform\n",
+        "libc = ctypes.CDLL('libc.so.6', use_errno=True)\n",
+        "libc.syscall.restype = ctypes.c_long\n",
+        "open('created.txt', 'w').write('hi')\n",
+        "buf = ctypes.create_string_buffer(256)\n",
+        "AT_FDCWD = -100\n",
+        "STATX_BASIC_STATS = 0x7ff\n",
+        "nr = 291 if platform.machine() == 'aarch64' else 332\n",
+        "ret = libc.syscall(nr, AT_FDCWD, b'created.txt', 0, STATX_BASIC_STATS, buf)\n",
+        "err = ctypes.get_errno()\n",
+        "open('{out}', 'w').write('OK' if ret == 0 else f'FAIL:errno={{err}}')\n",
+    ), out = out_file.display());
+
+    let result = policy.clone().with_name("test").run(&["python3", "-c", &script]).await.unwrap();
+    assert!(result.success(), "exit={:?}, stderr={}", result.code(), result.stderr_str().unwrap_or(""));
+    let content = fs::read_to_string(&out_file).unwrap_or_default();
+    assert_eq!(content, "OK", "statx on COW-created file should succeed, got: {}", content);
+
+    let _ = fs::remove_dir_all(&workdir);
+    let _ = fs::remove_file(&out_file);
+}
+
+/// Regression test: a binary created inside the COW workdir must
+/// be executable. execve had no COW redirect, so the kernel resolved the
+/// un-redirected lower path and returned ENOENT for binaries that live
+/// only in the upper layer.
+#[tokio::test]
+async fn test_seccomp_cow_exec_created_file() {
+    let workdir = temp_dir("seccomp-exec");
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr").fs_read("/lib").fs_read_if_exists("/lib64").fs_read("/bin").fs_read("/etc")
+        .fs_read("/proc").fs_read("/dev")
+        .fs_write(&workdir)
+        .workdir(&workdir)
+        .cwd(&workdir)
+        .on_exit(BranchAction::Abort)
+        .build()
+        .unwrap();
+
+    // Copy a real binary into the COW workdir (lands in upper), then exec it.
+    let result = policy.clone().with_name("test").run(&[
+        "sh", "-c", "cp /bin/echo m && ./m EXEC_OK",
+    ]).await.unwrap();
+
+    assert!(
+        result.success(),
+        "exec of COW-created binary should succeed, exit={:?}, stderr={}",
+        result.code(), result.stderr_str().unwrap_or("")
+    );
+    assert!(
+        result.stdout_str().unwrap_or("").contains("EXEC_OK"),
+        "exec'd binary should print EXEC_OK, stdout={:?}",
+        result.stdout_str()
+    );
+
+    let _ = fs::remove_dir_all(&workdir);
+}


### PR DESCRIPTION
## Problem

With the seccomp COW backend active (any `--workdir` run with `fs_isolation=None`), a file created inside the sandbox was visible to `open()`/`read()` and `newfstatat`, but:

- invisible to `statx` (used by `ls`, `stat`, most modern coreutils), returning ENOENT
- not executable via `execve`, returning ENOENT

This broke the create-then-use / compile-and-run workflow (e.g. `gcc` writing `a.out` then the shell stat/exec'ing it).

## Root causes

1. `handle_cow_statx` returned `Continue` when the file existed in the upper layer, so the kernel re-ran `statx` against the un-redirected lower path and saw nothing.
2. `execve`/`execveat` were not in the COW seccomp notification set, so the supervisor was never consulted and there was no COW handler at all.
3. Once a handler was added, Landlock evaluates `execve(/proc/self/fd/N)` against the target file's real path, so the COW upper dir has to be in the allowlist.
4. `handle_cow_open` hardcoded creation mode `0o666`, so a binary copied into the workdir landed in the upper layer non-executable.

## Changes

- `handle_cow_statx`: run `statx` on the resolved upper path in the supervisor and write the buffer back, mirroring the chroot statx handler. Handles AT_EMPTY_PATH.
- New `handle_cow_exec` for `execve`/`execveat`: redirect to the upper file via an injected fd (`/proc/self/fd/N`) when the target resolves into the upper layer; pass through lower-layer files; return ENOENT for files deleted in the COW layer.
- Add `execve`/`execveat` to the COW notification set so the handler is reachable.
- `handle_cow_open`: honor the child's requested O_CREAT mode instead of `0o666`.
- Create the seccomp COW branch before fork and add its upper dir to the child's Landlock allowlist (read access includes execute).

Audited `readlink` and `getdents64`: both resolve and write their results directly, so they do not have the same fall-through bug.

## Testing

Added two regression tests (statx on a COW-created file, exec of a COW-created binary) that fail before and pass after. Full suite green: 275 lib, 218 integration, 321 Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)