### PR TITLE
seccomp: fall back to NEW_LISTENER on kernels without WAIT_KILLABLE_RECV

### DIFF
--- a/crates/sandlock-core/src/seccomp/bpf.rs
+++ b/crates/sandlock-core/src/seccomp/bpf.rs
@@ -145,20 +145,50 @@ pub fn install_deny_filter(prog: &[SockFilter]) -> std::io::Result<()> {
 
 /// Install a cBPF seccomp filter on the calling thread with `NEW_LISTENER`.
 ///
+/// `WAIT_KILLABLE_RECV` (Linux 5.19+) is preferred for reliable notification
+/// delivery, but we fall back to `NEW_LISTENER`-only on older kernels that
+/// reject the bit with `EINVAL`. The fallback matches the pre-Rust Python
+/// implementation (`commit 50d5eb9`) and only trades a robustness flag —
+/// the security boundary (kept by `NEW_LISTENER`) is unaffected.
+///
 /// Returns the seccomp notification file descriptor.
 pub fn install_filter(prog: &[SockFilter]) -> std::io::Result<OwnedFd> {
     let fprog = SockFprog {
         len: prog.len() as u16,
         filter: prog.as_ptr(),
     };
-    let flags = SECCOMP_FILTER_FLAG_NEW_LISTENER | SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV;
-    let fd = seccomp(
-        SECCOMP_SET_MODE_FILTER,
-        flags,
-        &fprog as *const SockFprog as *const std::ffi::c_void,
+    let fd = install_with_einval_fallback(
+        SECCOMP_FILTER_FLAG_NEW_LISTENER | SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV,
+        SECCOMP_FILTER_FLAG_NEW_LISTENER,
+        |flags| {
+            seccomp(
+                SECCOMP_SET_MODE_FILTER,
+                flags,
+                &fprog as *const SockFprog as *const std::ffi::c_void,
+            )
+        },
     )?;
     // SAFETY: kernel returns a valid fd on success
     Ok(unsafe { OwnedFd::from_raw_fd(fd as i32) })
+}
+
+/// Call `install` with `preferred_flags`; on `EINVAL`, retry with `fallback_flags`.
+///
+/// Extracted as a generic helper so the EINVAL-retry control flow can be
+/// unit-tested without the real `seccomp(2)` syscall.
+pub(crate) fn install_with_einval_fallback<F>(
+    preferred_flags: u64,
+    fallback_flags: u64,
+    mut install: F,
+) -> std::io::Result<i64>
+where
+    F: FnMut(u64) -> std::io::Result<i64>,
+{
+    match install(preferred_flags) {
+        Ok(fd) => Ok(fd),
+        Err(e) if e.raw_os_error() == Some(libc::EINVAL) => install(fallback_flags),
+        Err(e) => Err(e),
+    }
 }
 
 // ============================================================
@@ -271,5 +301,70 @@ mod tests {
             Err(e) => e,
         };
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    // --------------------------------------------------------
+    // install_with_einval_fallback — regression coverage for the
+    // SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV fallback on kernels < 5.19.
+    // --------------------------------------------------------
+
+    const PREFERRED: u64 =
+        SECCOMP_FILTER_FLAG_NEW_LISTENER | SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV;
+    const FALLBACK: u64 = SECCOMP_FILTER_FLAG_NEW_LISTENER;
+
+    #[test]
+    fn fallback_succeeds_first_try_returns_fd_no_retry() {
+        let mut calls = Vec::new();
+        let fd = install_with_einval_fallback(PREFERRED, FALLBACK, |flags| {
+            calls.push(flags);
+            Ok(42)
+        })
+        .expect("should succeed");
+        assert_eq!(fd, 42);
+        assert_eq!(calls, vec![PREFERRED], "must not retry on success");
+    }
+
+    #[test]
+    fn fallback_einval_retries_with_fallback_flags() {
+        let mut calls = Vec::new();
+        let fd = install_with_einval_fallback(PREFERRED, FALLBACK, |flags| {
+            calls.push(flags);
+            if flags & SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV != 0 {
+                Err(std::io::Error::from_raw_os_error(libc::EINVAL))
+            } else {
+                Ok(99)
+            }
+        })
+        .expect("fallback must succeed");
+        assert_eq!(fd, 99);
+        assert_eq!(
+            calls,
+            vec![PREFERRED, FALLBACK],
+            "EINVAL on preferred must trigger fallback retry"
+        );
+    }
+
+    #[test]
+    fn fallback_non_einval_error_propagates_without_retry() {
+        let mut calls = 0;
+        let res = install_with_einval_fallback(PREFERRED, FALLBACK, |_| {
+            calls += 1;
+            Err(std::io::Error::from_raw_os_error(libc::EPERM))
+        });
+        let err = res.expect_err("EPERM should not retry");
+        assert_eq!(err.raw_os_error(), Some(libc::EPERM));
+        assert_eq!(calls, 1, "non-EINVAL error must not trigger retry");
+    }
+
+    #[test]
+    fn fallback_einval_on_both_returns_second_einval() {
+        let mut calls = 0;
+        let res = install_with_einval_fallback(PREFERRED, FALLBACK, |_| {
+            calls += 1;
+            Err(std::io::Error::from_raw_os_error(libc::EINVAL))
+        });
+        let err = res.expect_err("both EINVAL should return error");
+        assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
+        assert_eq!(calls, 2, "must attempt both flag sets exactly once");
     }
 }


### PR DESCRIPTION
Fixes #62.

The Python implementation (commit `50d5eb9`, "Enable SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV for reliable notifications") tried the install with `WAIT_KILLABLE_RECV` first and fell back to bare `NEW_LISTENER` on older kernels that rejected the bit with `EINVAL`. The Rust rewrite passed both flags unconditionally, so `seccomp(SET_MODE_FILTER)` returns `EINVAL` on every kernel < 5.19 — blocking sandlock on RHEL 9 (5.14) and Ubuntu 22.04 (5.15) at runtime, before Landlock is even attempted.

## Change

Restore the pre-rewrite behaviour:
- Try `NEW_LISTENER | WAIT_KILLABLE_RECV` first
- On `EINVAL` (and only `EINVAL`), retry with `NEW_LISTENER` alone
- Propagate any other error unchanged

The retry control flow is extracted into `install_with_einval_fallback` so the success-fast-path, EINVAL-retry, non-EINVAL-passthrough, and both-EINVAL terminal cases can be unit-tested without invoking the real `seccomp(2)`.

`WAIT_KILLABLE_RECV` is a robustness flag (it stops signals from aborting in-flight notifications); dropping it on older kernels does not relax the security boundary, which is what the original Python fallback already relied on.

`seccomp(SET_MODE_FILTER)` also returns `EINVAL` for a malformed BPF program (bad instruction count, bad opcode, kernel verifier rejection). In that case both attempts use the *same* `fprog`, so the second call fails with `EINVAL` too and the error is propagated — the fallback cannot silently paper over a malformed filter. The `fallback_einval_on_both_returns_second_einval` test pins this behaviour.

## Tests

- `seccomp::bpf::tests::fallback_succeeds_first_try_returns_fd_no_retry` — happy path, no retry
- `seccomp::bpf::tests::fallback_einval_retries_with_fallback_flags` — preferred-set returns `EINVAL`, fallback-set succeeds
- `seccomp::bpf::tests::fallback_non_einval_error_propagates_without_retry` — `EPERM` is not retried
- `seccomp::bpf::tests::fallback_einval_on_both_returns_second_einval` — both attempts fail, terminal error surfaces

282 lib tests pass.

## Verified on a real < 5.19 kernel

On stock Rocky Linux 9.6 (kernel `5.14.0-570.17.1.el9_6`, Landlock ABI v5):

Before this change:
```
$ sandlock run --fs-read /usr --fs-read /lib64 --fs-read /etc -- /usr/bin/true
sandlock child: seccomp install: Invalid argument (os error 22)
Error: child process error: read notif fd from child: pipe closed
exit=1
```

After this change (same binary, same kernel):
```
$ sandlock run --fs-read /usr --fs-read /lib64 --fs-read /etc -- /usr/bin/true
exit=0
```

(The Rocky 9.6 run also requires #17 / Protection opt-out to skip the two v6 IPC scopes; the seccomp install passes either way once this fix lands.)
