### PR TITLE
python: make PEP 585/604 annotations parse on 3.8 and 3.9

### DIFF
--- a/python/src/sandlock/inputs.py
+++ b/python/src/sandlock/inputs.py
@@ -14,6 +14,8 @@ corresponding producer's stdout. Values are read lazily on
 first access and cached.
 """
 
+from __future__ import annotations
+
 import os
 
 

--- a/python/tests/_tool_helpers.py
+++ b/python/tests/_tool_helpers.py
@@ -7,6 +7,8 @@ should structure its tools.
 """
 
 
+from __future__ import annotations
+
 def _read_file_tool(path: str, *, workspace: str) -> str:
     import os
     with open(os.path.join(workspace, path)) as f:

--- a/python/tests/_worker_fixture.py
+++ b/python/tests/_worker_fixture.py
@@ -4,6 +4,8 @@
 Uses a module-level import, constant, and helper on purpose: the patterns
 the old source-re-exec path could not handle.
 """
+from __future__ import annotations
+
 import os
 
 PREFIX = "fixture:"

--- a/python/tests/test_checkpoint.py
+++ b/python/tests/test_checkpoint.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for sandlock.Checkpoint (save_fn / restore_fn / persistence)."""
 
+from __future__ import annotations
+
 import json
 import sys
 

--- a/python/tests/test_chroot_cow.py
+++ b/python/tests/test_chroot_cow.py
@@ -6,6 +6,8 @@ concurrent sandboxes with separate fs_storage directories get isolated
 upper layers.  Parametrized across all COW backends (seccomp, overlayfs).
 """
 
+from __future__ import annotations
+
 import os
 import shutil
 import threading

--- a/python/tests/test_chroot_legacy_syscalls.py
+++ b/python/tests/test_chroot_legacy_syscalls.py
@@ -8,6 +8,8 @@ them. On ARM64 the helper uses equivalent raw *at syscalls, because
 Linux ARM64 does not expose the legacy non-*at path syscall ABI.
 """
 
+from __future__ import annotations
+
 import os
 import shutil
 from pathlib import Path

--- a/python/tests/test_fs_mount.py
+++ b/python/tests/test_fs_mount.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for fs_mount: mapping virtual paths inside a chroot to host directories."""
 
+from __future__ import annotations
+
 import os
 import shutil
 import tempfile

--- a/python/tests/test_handler_smoke.py
+++ b/python/tests/test_handler_smoke.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Smoke tests for the sandlock Python handler wrapper."""
 
+from __future__ import annotations
+
 from sandlock.handler import ExceptionPolicy, Handler, NotifAction
 
 

--- a/python/tests/test_lifecycle.py
+++ b/python/tests/test_lifecycle.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the Python Sandbox lifecycle methods: spawn, create, start, wait."""
 
+from __future__ import annotations
+
 import os
 import time
 

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for sandlock.mcp — deny-by-default capability model."""
 
+from __future__ import annotations
+
 import pytest
 from types import SimpleNamespace
 

--- a/python/tests/test_mcp_integration.py
+++ b/python/tests/test_mcp_integration.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Integration tests for sandlock.mcp — per-tool sandboxed execution."""
 
+from __future__ import annotations
+
 import asyncio
 import json
 import os

--- a/python/tests/test_pipeline.py
+++ b/python/tests/test_pipeline.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for Stage, Pipeline, and Sandbox.cmd()."""
 
+from __future__ import annotations
+
 import os
 import sys
 import tempfile

--- a/python/tests/test_policy_fn.py
+++ b/python/tests/test_policy_fn.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the dynamic policy callback (policy_fn) feature."""
 
+from __future__ import annotations
+
 import os
 import sys
 import threading

--- a/python/tests/test_profile.py
+++ b/python/tests/test_profile.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for sandlock._profile (sectioned schema)."""
 
+from __future__ import annotations
+
 import textwrap
 
 import pytest

--- a/python/tests/test_sandbox.py
+++ b/python/tests/test_sandbox.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for sandlock.Sandbox (ctypes FFI bindings)."""
 
+from __future__ import annotations
+
 import json
 import os
 import socket

--- a/python/tests/test_sandbox_config.py
+++ b/python/tests/test_sandbox_config.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for sandlock.sandbox."""
 
+from __future__ import annotations
+
 import pytest
 
 from sandlock.sandbox import (


### PR DESCRIPTION
## Summary

`pyproject.toml` declares `requires-python = ">=3.8"`, but the source and tests use PEP 604 (`str | None`) and PEP 585 (`dict[str, int]`) annotations at module load time, which only parse on 3.10+ and 3.9+ respectively. Any `import sandlock` on 3.8/3.9 crashed at collection. The 3.10/3.11/3.12 CI matrix hid it.

Add `from __future__ import annotations` to every file that uses the modern syntax and isn't already shimmed (16 files: one src module, the rest tests). PEP 563 postpones annotation evaluation to runtime lookups, so the literal `str | None` and `dict[str, int]` parse fine on every supported version. Verified no runtime usage of these forms (no `isinstance(x, str | None)`, no `typing.cast`, no `typing.get_type_hints`) so the future import alone is sufficient.

## Test plan

- [x] Python 3.8: `python3 -m pytest tests/` (319 / 321 pass; the 2 failures are pre-existing: optional `mcp` extra missing, and a sub-sandbox `PYTHONPATH` quirk, both unrelated to the syntax change)
- [x] Python 3.9: same — 296 / 297 pass with the same single pre-existing failure.
- [x] Module imports cleanly on both versions: `python3.8 -c "import sandlock"` and `python3.9 -c "import sandlock"` succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)