### PR TITLE
handler: add deferred off-loop dispatch and inject_bytes content injection (core, FFI, Python)

### DIFF
--- a/crates/sandlock-core/Cargo.toml
+++ b/crates/sandlock-core/Cargo.toml
@@ -32,5 +32,5 @@ default = []
 cli = ["dep:clap"]
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
 tempfile = "3"

--- a/crates/sandlock-core/src/procfs.rs
+++ b/crates/sandlock-core/src/procfs.rs
@@ -19,16 +19,14 @@
 //     contents, so the seccomp_unotify TOCTOU class doesn't apply.
 
 use std::collections::HashSet;
-use std::io::{Seek, SeekFrom, Write};
-use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::io::RawFd;
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
-use crate::seccomp::notif::{read_child_cstr, write_child_mem, NotifAction, NotifPolicy};
+use crate::seccomp::notif::{content_memfd, read_child_cstr, write_child_mem, NotifAction, NotifPolicy};
 use crate::seccomp::state::{NetworkState, ProcessIndex};
 use crate::sys::structs::{SeccompNotif, EACCES};
-use crate::sys::syscall;
 
 // ============================================================
 // Sensitive path detection
@@ -340,49 +338,19 @@ fn parse_proc_net_tcp_port(line: &str) -> Option<u16> {
 // memfd injection
 // ============================================================
 
-/// Create a memfd with the given content and return an InjectFd action.
+/// Create a sealed memfd of `content` and inject it as the child's openat
+/// result. The memfd is created in the supervisor, sealed read-only, and
+/// handed to the child via NOTIF_ADDFD, so the kernel never re-resolves the
+/// virtualized /proc path string after injection.
 ///
-/// The memfd is created in the supervisor process, written with content,
-/// seeked to the beginning, then injected into the child via NOTIF_ADDFD.
-/// The child sees it as the fd returned by their openat call.
-///
-/// IMPORTANT: The returned OwnedFd must stay alive until after the ioctl
-/// in send_response completes. We leak it intentionally here because the
-/// supervisor loop calls inject_fd immediately after this returns. A more
-/// robust design would store it in an arena, but leaking is acceptable for
-/// the supervisor's lifetime.
+/// On memfd allocation failure we fall through to `Continue` (let the real
+/// open proceed) rather than `Errno`, preserving this module's long-standing
+/// behavior: a failure to synthesise /proc content is not a denial.
 fn inject_memfd(content: &[u8]) -> NotifAction {
-    let memfd = match syscall::memfd_create(
-        "sandlock",
-        (libc::MFD_CLOEXEC | libc::MFD_ALLOW_SEALING) as u32,
-    ) {
-        Ok(fd) => fd,
-        Err(_) => return NotifAction::Continue, // fallback: let real open proceed
-    };
-
-    // Write content and seek to start.
-    // Borrow the raw fd for File I/O without transferring ownership.
-    let raw = memfd.as_raw_fd();
-    {
-        let mut file = unsafe { std::fs::File::from_raw_fd(raw) };
-        if file.write_all(content).is_err() || file.seek(SeekFrom::Start(0)).is_err() {
-            std::mem::forget(file);
-            return NotifAction::Continue;
-        }
-        // Forget the File so it doesn't close the fd — memfd (OwnedFd) still owns it.
-        std::mem::forget(file);
+    match content_memfd(content, true) {
+        Ok(fd) => NotifAction::InjectFdSend { srcfd: fd, newfd_flags: libc::O_CLOEXEC as u32 },
+        Err(_) => NotifAction::Continue, // fallback: let real open proceed
     }
-
-    // Lock the memfd: the child gets an injected fd to the same description
-    // (memfd_create returns RW), so without sealing they could overwrite the
-    // synthesised /proc content. Best-effort — if F_ADD_SEALS fails (very old
-    // kernel without sealing support), we still inject the fd, since the child
-    // is still bounded by everything else in the policy.
-    let seals = libc::F_SEAL_SEAL | libc::F_SEAL_WRITE | libc::F_SEAL_GROW | libc::F_SEAL_SHRINK;
-    unsafe { libc::fcntl(raw, libc::F_ADD_SEALS, seals) };
-
-    // Move the OwnedFd into InjectFdSend — send_response will close it after the ioctl.
-    NotifAction::InjectFdSend { srcfd: memfd, newfd_flags: libc::O_CLOEXEC as u32 }
 }
 
 // ============================================================

--- a/crates/sandlock-core/src/seccomp/dispatch.rs
+++ b/crates/sandlock-core/src/seccomp/dispatch.rs
@@ -1209,6 +1209,47 @@ mod handler_tests {
         );
     }
 
+    /// A handler returning `Defer` is non-`Continue`, so it must short-circuit
+    /// the chain exactly like `Errno`/`ReturnValue`: later handlers on the same
+    /// syscall do not run.  Deferral is therefore a terminal decision.
+    #[tokio::test]
+    async fn dispatch_short_circuits_on_defer() {
+        let mut table = DispatchTable::new();
+        let later_ran = Arc::new(AtomicUsize::new(0));
+
+        table.register(
+            libc::SYS_openat,
+            |_cx: &HandlerCtx| async { NotifAction::defer(async { NotifAction::ReturnValue(1) }) },
+        );
+
+        let later = Arc::clone(&later_ran);
+        table.register(
+            libc::SYS_openat,
+            move |_cx: &HandlerCtx| {
+                let later = Arc::clone(&later);
+                async move {
+                    later.fetch_add(1, Ordering::SeqCst);
+                    NotifAction::Continue
+                }
+            },
+        );
+
+        let _ctx = fake_supervisor_ctx();
+        let action = table
+            .dispatch(fake_notif(libc::SYS_openat as i32), -1)
+            .await;
+
+        assert!(
+            matches!(action, NotifAction::Defer(_)),
+            "dispatch must return the Defer produced by the first handler"
+        );
+        assert_eq!(
+            later_ran.load(Ordering::SeqCst),
+            0,
+            "Defer must short-circuit the chain like any non-Continue action"
+        );
+    }
+
     /// `validate_handler_syscalls_against_policy` must reject handlers whose
     /// syscall is in the policy's user-specified blocklist, with the same
     /// rationale as DEFAULT_BLOCKLIST: the BPF program emits notif JEQs before

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -3,9 +3,11 @@
 // sends responses.
 
 use std::collections::{HashMap, HashSet};
+use std::future::Future;
 use std::io;
 use std::net::IpAddr;
 use std::os::unix::io::{AsRawFd, OwnedFd, RawFd};
+use std::pin::Pin;
 use std::sync::Arc;
 
 use crate::error::NotifError;
@@ -42,6 +44,53 @@ impl OnInjectSuccess {
     }
 }
 
+/// A deferred decision: an owned, `'static` future that produces the real
+/// [`NotifAction`] off the supervisor's notification loop.
+///
+/// A handler returns [`NotifAction::Defer`] when computing the response is
+/// slow (a network round-trip, a blocking syscall) and must not stall the
+/// single supervisor task that gates every other trapped syscall.  The
+/// supervisor moves the future onto a worker, lets the loop proceed, and
+/// sends the response (via the still-valid `notif.id`) when the future
+/// resolves.  The future is `'static` because it outlives the borrowed
+/// `HandlerCtx` — capture what you need (`notif` is `Copy`, `notif_fd` is a
+/// `RawFd`) by value rather than borrowing `&self`.
+///
+/// The deferred future need only be `Send` (not `Sync`): the supervisor
+/// moves it onto a worker task and never shares it by reference.  Requiring
+/// `Sync` of user futures would be a leaky bound (it would reject a future
+/// capturing, say, a `Cell`), so it is not required.
+pub struct Deferred(Pin<Box<dyn Future<Output = NotifAction> + Send + 'static>>);
+
+// Safety: `NotifAction` must stay `Sync` so it can live in `Sync` contexts
+// (handler `&self` state, etc.; the `Handler` trait is `Send + Sync`), which
+// requires `Deferred: Sync`.  A `Send`-only future is not `Sync`, but the
+// boxed future is unreachable through a shared `&Deferred`: the field is
+// private, `Debug` touches only a static string, and `run(self)` consumes
+// the value (it is never callable through `&self`).  With no path to poll or
+// read the future via a shared reference, sharing `&Deferred` across threads
+// cannot race, so asserting `Sync` is sound while keeping user futures
+// `Send`-only.
+unsafe impl Sync for Deferred {}
+
+impl std::fmt::Debug for Deferred {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Deferred(<future>)")
+    }
+}
+
+impl Deferred {
+    pub fn new<F: Future<Output = NotifAction> + Send + 'static>(f: F) -> Self {
+        Self(Box::pin(f))
+    }
+
+    /// Drive the deferred future to its terminal action.  Consumes `self`
+    /// because the future is run exactly once, on a worker task.
+    pub async fn run(self) -> NotifAction {
+        self.0.await
+    }
+}
+
 /// How the supervisor should respond to a notification.
 #[derive(Debug)]
 pub enum NotifAction {
@@ -72,6 +121,30 @@ pub enum NotifAction {
     /// Kill the child process group (OOM-kill semantics).
     /// Fields: signal, process group leader pid.
     Kill { sig: i32, pgid: i32 },
+    /// Defer the response: run the carried future on a worker task and
+    /// send its terminal action later, keyed by `notif.id`.  Non-`Continue`,
+    /// so it short-circuits the handler chain — a deferring handler makes a
+    /// terminal decision.  See [`Deferred`].
+    Defer(Deferred),
+}
+
+impl NotifAction {
+    /// Construct a [`NotifAction::Defer`] from a `'static` future.  Ergonomic
+    /// shorthand for `NotifAction::Defer(Deferred::new(fut))`.
+    pub fn defer<F: Future<Output = NotifAction> + Send + 'static>(fut: F) -> Self {
+        NotifAction::Defer(Deferred::new(fut))
+    }
+}
+
+/// Collapse a deferred future's resolved action into a sendable terminal
+/// action.  A deferred future that itself resolves to `Defer` is a bug
+/// (no nested deferral); collapse it to `EIO` so the trapped child gets a
+/// definite response instead of wedging forever waiting for one.
+fn finalize_deferred(action: NotifAction) -> NotifAction {
+    match action {
+        NotifAction::Defer(_) => NotifAction::Errno(libc::EIO),
+        other => other,
+    }
 }
 
 // ============================================================
@@ -599,6 +672,13 @@ fn send_response(fd: RawFd, id: u64, action: NotifAction) -> io::Result<()> {
         }
         NotifAction::ReturnValue(val) => respond_value(fd, id, val),
         NotifAction::Hold => Ok(()), // Don't send a response.
+        NotifAction::Defer(_) => {
+            // Defer is intercepted in `handle_notification` and never reaches
+            // here on the normal path. If it ever does, fail closed with EIO
+            // rather than dropping the future and wedging the child.
+            debug_assert!(false, "Defer reached send_response; should be intercepted earlier");
+            respond_errno(fd, id, libc::EIO)
+        }
         NotifAction::Kill { sig, pgid } => {
             // Kill the entire process group, then return ENOMEM so the
             // seccomp notification is resolved (avoids a kernel warning).
@@ -1009,11 +1089,35 @@ async fn emit_policy_event(
 
 /// Process a single seccomp notification: vDSO re-patch, path denial check,
 /// dispatch, policy event emission, and response.
+/// Maximum number of deferred handler futures running concurrently. Caps
+/// the worker fan-out (and any resources those workers hold, e.g. memfds or
+/// sockets) so a burst of deferrals cannot exhaust the supervisor process.
+const DEFER_MAX_INFLIGHT: usize = 64;
+
+/// Spawn a worker task that drives a deferred handler future to its terminal
+/// action and sends the seccomp response, keyed by `id`. The `permit` is
+/// held for the worker's lifetime, releasing its `DEFER_MAX_INFLIGHT` slot on
+/// completion. A stale `id` (child exited mid-defer) makes `send_response`
+/// a no-op, matching the inline path's "child may have exited" tolerance.
+fn spawn_deferred(
+    fd: RawFd,
+    id: u64,
+    deferred: Deferred,
+    permit: tokio::sync::OwnedSemaphorePermit,
+) {
+    tokio::spawn(async move {
+        let _permit = permit; // released when the worker finishes
+        let action = finalize_deferred(deferred.run().await);
+        let _ = send_response(fd, id, action);
+    });
+}
+
 async fn handle_notification(
     notif: SeccompNotif,
     ctx: &Arc<super::ctx::SupervisorCtx>,
     dispatch_table: &super::dispatch::DispatchTable,
     fd: RawFd,
+    defer_sem: &Arc<tokio::sync::Semaphore>,
 ) {
     let policy = &ctx.policy;
 
@@ -1138,6 +1242,34 @@ async fn handle_notification(
         }
     }
 
+    // Deferred response: run the handler's future on a worker task so the
+    // single supervisor loop is not blocked waiting for slow work (a network
+    // round-trip, a blocking syscall). The trapped child stays parked in the
+    // syscall; the worker sends the real response later, keyed by notif.id.
+    //
+    // Deferral is refused on syscalls whose Continue path requires the
+    // execve argv-safety freeze or fork creation-tracking: sending the
+    // response off-loop would skip that TOCTOU-closing work. (When `action`
+    // is Defer it is not Continue, so `exec_freeze`/`creation_trace` above
+    // are already None — there is nothing to unwind here.)
+    if let NotifAction::Defer(deferred) = action {
+        if crate::freeze::requires_freeze_on_continue(nr)
+            || crate::resource::requires_process_creation_tracking(&notif, fd, policy)
+        {
+            let _ = send_response(fd, notif.id, NotifAction::Errno(libc::EPERM));
+            return;
+        }
+        match Arc::clone(defer_sem).try_acquire_owned() {
+            Ok(permit) => spawn_deferred(fd, notif.id, deferred, permit),
+            // Too many deferrals in flight: fail fast with EAGAIN rather than
+            // blocking the loop or letting unbounded workers accrete.
+            Err(_) => {
+                let _ = send_response(fd, notif.id, NotifAction::Errno(libc::EAGAIN));
+            }
+        }
+        return;
+    }
+
     // Ignore error — child may have exited between recv and response.
     let exec_continued = exec_freeze.is_some() && matches!(action, NotifAction::Continue);
     let send_result = send_response(fd, notif.id, action);
@@ -1226,6 +1358,11 @@ pub async fn supervisor(
     // still per-child pidfd readiness in `spawn_pid_watcher`.
     let gc = tokio::spawn(process_index_gc(Arc::clone(&ctx.processes)));
 
+    // Bounds the number of in-flight deferred handler futures (see
+    // `DEFER_MAX_INFLIGHT`). Shared across all notifications this supervisor
+    // processes.
+    let defer_sem = Arc::new(tokio::sync::Semaphore::new(DEFER_MAX_INFLIGHT));
+
     // Edge-triggered drain: each `readable().await` returns once per
     // epoll edge, then we drain the kernel queue via `probe_notif_fd`
     // until empty. The drain is necessary because tokio's AsyncFd is
@@ -1251,7 +1388,7 @@ pub async fn supervisor(
                         Err(e) if e.raw_os_error() == Some(libc::EINTR) => continue,
                         Err(_) => break 'outer,
                     };
-                    handle_notification(notif, &ctx, &dispatch_table, fd).await;
+                    handle_notification(notif, &ctx, &dispatch_table, fd, &defer_sem).await;
                 }
                 NotifFdState::Empty => break,
                 NotifFdState::Terminal => break 'outer,
@@ -1442,6 +1579,48 @@ mod tests {
         let _ = format!("{:?}", NotifAction::ReturnValue(42));
         let _ = format!("{:?}", NotifAction::Hold);
         let _ = format!("{:?}", NotifAction::Kill { sig: 9, pgid: 1 });
+        let _ = format!("{:?}", NotifAction::defer(async { NotifAction::Continue }));
+    }
+
+    #[tokio::test]
+    async fn deferred_future_need_not_be_sync() {
+        // A deferred future may capture Send-but-not-Sync state across an
+        // await. `Cell` is Send but never Sync; holding it across `.await`
+        // makes the future !Sync. Only `Send` is required (the supervisor
+        // moves the future to a worker, never shares it by reference).
+        use std::cell::Cell;
+        let action = NotifAction::defer(async move {
+            let counter = Cell::new(0);
+            counter.set(counter.get() + 41);
+            tokio::task::yield_now().await; // hold the !Sync Cell across await
+            NotifAction::ReturnValue(counter.get() + 1)
+        });
+        let NotifAction::Defer(d) = action else { panic!("expected Defer") };
+        assert!(matches!(d.run().await, NotifAction::ReturnValue(42)));
+    }
+
+    #[tokio::test]
+    async fn deferred_runs_to_its_terminal_action() {
+        // A Defer carries a future; running it yields the deferred decision.
+        let action = NotifAction::defer(async { NotifAction::ReturnValue(7) });
+        let NotifAction::Defer(deferred) = action else {
+            panic!("defer() must construct a NotifAction::Defer");
+        };
+        assert!(matches!(deferred.run().await, NotifAction::ReturnValue(7)));
+    }
+
+    #[test]
+    fn finalize_deferred_collapses_nested_defer_to_eio() {
+        // A deferred future that itself resolves to Defer is a bug: collapse
+        // to EIO so the trapped child is never wedged waiting for a response.
+        let nested = NotifAction::defer(async { NotifAction::Continue });
+        assert!(matches!(finalize_deferred(nested), NotifAction::Errno(e) if e == libc::EIO));
+        // Non-nested terminal actions pass through unchanged.
+        assert!(matches!(finalize_deferred(NotifAction::Continue), NotifAction::Continue));
+        assert!(matches!(
+            finalize_deferred(NotifAction::ReturnValue(3)),
+            NotifAction::ReturnValue(3)
+        ));
     }
 
     #[test]

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -1164,6 +1164,30 @@ async fn emit_policy_event(
 /// sockets) so a burst of deferrals cannot exhaust the supervisor process.
 const DEFER_MAX_INFLIGHT: usize = 64;
 
+/// Maximum time a deferred handler future may run before the supervisor gives
+/// up and fails the trapped syscall closed. Bounds the worst case so a hung
+/// future (e.g. a stalled network fetch in a token-injection handler) cannot
+/// park the child forever or permanently leak its `DEFER_MAX_INFLIGHT` slot.
+const DEFER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Drive a deferred future to its terminal action, bounded by `limit`.
+///
+/// On timeout, fail closed with `EIO` so the trapped child gets a definite
+/// response instead of parking forever; `finalize_deferred` still guards a
+/// future that resolves to a nested `Defer`.
+async fn run_deferred_within(deferred: Deferred, limit: std::time::Duration) -> NotifAction {
+    match tokio::time::timeout(limit, deferred.run()).await {
+        Ok(action) => finalize_deferred(action),
+        Err(_) => {
+            eprintln!(
+                "sandlock: deferred handler exceeded {:?}; failing syscall with EIO",
+                limit
+            );
+            NotifAction::Errno(libc::EIO)
+        }
+    }
+}
+
 /// Spawn a worker task that drives a deferred handler future to its terminal
 /// action and sends the seccomp response, keyed by `id`. The `permit` is
 /// held for the worker's lifetime, releasing its `DEFER_MAX_INFLIGHT` slot on
@@ -1177,7 +1201,7 @@ fn spawn_deferred(
 ) {
     tokio::spawn(async move {
         let _permit = permit; // released when the worker finishes
-        let action = finalize_deferred(deferred.run().await);
+        let action = run_deferred_within(deferred, DEFER_TIMEOUT).await;
         let _ = send_response(fd, id, action);
     });
 }
@@ -1677,6 +1701,27 @@ mod tests {
             panic!("defer() must construct a NotifAction::Defer");
         };
         assert!(matches!(deferred.run().await, NotifAction::ReturnValue(7)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn deferred_times_out_to_eio() {
+        // A deferred future that exceeds its limit must fail closed (EIO) so
+        // the trapped child gets a definite response instead of parking
+        // forever (and leaking its DEFER_MAX_INFLIGHT slot).
+        let slow = Deferred::new(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            NotifAction::ReturnValue(7)
+        });
+        let action = run_deferred_within(slow, std::time::Duration::from_secs(1)).await;
+        assert!(matches!(action, NotifAction::Errno(e) if e == libc::EIO));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn deferred_within_limit_passes_through() {
+        // A future that resolves within the limit returns its terminal action.
+        let fast = Deferred::new(async { NotifAction::ReturnValue(7) });
+        let action = run_deferred_within(fast, std::time::Duration::from_secs(1)).await;
+        assert!(matches!(action, NotifAction::ReturnValue(7)));
     }
 
     #[test]

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -134,6 +134,76 @@ impl NotifAction {
     pub fn defer<F: Future<Output = NotifAction> + Send + 'static>(fut: F) -> Self {
         NotifAction::Defer(Deferred::new(fut))
     }
+
+    /// Inject `content` into the child as the syscall's returned fd, backed by
+    /// a sealed (read-only, fixed-size), `O_CLOEXEC` in-memory file.
+    ///
+    /// The fd is created, populated, sealed, and owned end to end by sandlock;
+    /// the caller never sees or closes it. On allocation failure this collapses
+    /// to `Errno(EIO)`, so a handler can return it directly:
+    ///
+    /// ```ignore
+    /// return NotifAction::inject_bytes(&secret);
+    /// ```
+    ///
+    /// For a *writable* injected fd, build one with
+    /// [`content_memfd(content, false)`](content_memfd) and pass it to
+    /// [`NotifAction::InjectFdSend`] yourself.
+    pub fn inject_bytes(content: &[u8]) -> NotifAction {
+        match content_memfd(content, true) {
+            Ok(fd) => NotifAction::InjectFdSend {
+                srcfd: fd,
+                newfd_flags: libc::O_CLOEXEC as u32,
+            },
+            Err(_) => NotifAction::Errno(libc::EIO),
+        }
+    }
+}
+
+/// Create an anonymous in-memory file ("memfd") populated with `content` and
+/// rewound to offset 0, ready to inject as a syscall's returned fd via
+/// [`NotifAction::InjectFdSend`].
+///
+/// When `seal` is true the fd is sealed read-only and fixed-size
+/// (`F_SEAL_SEAL | F_SEAL_WRITE | F_SEAL_GROW | F_SEAL_SHRINK`) so the guest
+/// cannot modify or resize the content it is handed. Sealing is best-effort:
+/// on a kernel without sealing support the fd is still returned, bounded by
+/// the rest of the policy. Pass `false` only when the guest genuinely needs a
+/// writable injected fd.
+///
+/// Most callers want [`NotifAction::inject_bytes`], which wraps this in the
+/// common sealed + `O_CLOEXEC` configuration.
+pub fn content_memfd(content: &[u8], seal: bool) -> io::Result<OwnedFd> {
+    use std::io::{Seek, SeekFrom, Write};
+    use std::os::unix::io::FromRawFd;
+
+    let flags = if seal {
+        (libc::MFD_CLOEXEC | libc::MFD_ALLOW_SEALING) as u32
+    } else {
+        libc::MFD_CLOEXEC as u32
+    };
+    let memfd = crate::sys::syscall::memfd_create("sandlock-content", flags)?;
+
+    // Write the content and rewind. Borrow the raw fd for File I/O without
+    // transferring ownership: `memfd` (the OwnedFd) keeps owning it.
+    {
+        let raw = memfd.as_raw_fd();
+        let mut file = unsafe { std::fs::File::from_raw_fd(raw) };
+        let res = file
+            .write_all(content)
+            .and_then(|()| file.seek(SeekFrom::Start(0)).map(|_| ()));
+        std::mem::forget(file); // don't close `raw`; `memfd` still owns it
+        res?;
+    }
+
+    if seal {
+        // Best-effort: ignore failure on kernels lacking sealing support.
+        let seals =
+            libc::F_SEAL_SEAL | libc::F_SEAL_WRITE | libc::F_SEAL_GROW | libc::F_SEAL_SHRINK;
+        unsafe { libc::fcntl(memfd.as_raw_fd(), libc::F_ADD_SEALS, seals) };
+    }
+
+    Ok(memfd)
 }
 
 /// Collapse a deferred future's resolved action into a sendable terminal
@@ -1621,6 +1691,57 @@ mod tests {
             finalize_deferred(NotifAction::ReturnValue(3)),
             NotifAction::ReturnValue(3)
         ));
+    }
+
+    #[test]
+    fn content_memfd_roundtrips_content() {
+        use std::io::Read;
+        let fd = content_memfd(b"hello world", true).expect("content_memfd");
+        // The fd is rewound to offset 0, so a plain read returns the content.
+        let mut f = std::fs::File::from(fd);
+        let mut buf = String::new();
+        f.read_to_string(&mut buf).unwrap();
+        assert_eq!(buf, "hello world");
+    }
+
+    #[test]
+    fn content_memfd_sealed_applies_write_seal() {
+        let fd = content_memfd(b"data", true).expect("content_memfd");
+        let seals = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_GET_SEALS) };
+        assert!(seals >= 0, "F_GET_SEALS failed");
+        assert!(
+            seals & libc::F_SEAL_WRITE != 0,
+            "expected F_SEAL_WRITE on a sealed memfd, got {seals:#x}"
+        );
+    }
+
+    #[test]
+    fn content_memfd_unsealed_has_no_write_seal() {
+        let fd = content_memfd(b"data", false).expect("content_memfd");
+        let seals = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_GET_SEALS) };
+        assert!(seals >= 0, "F_GET_SEALS failed");
+        assert_eq!(
+            seals & libc::F_SEAL_WRITE,
+            0,
+            "unsealed memfd must not carry a write seal, got {seals:#x}"
+        );
+    }
+
+    #[test]
+    fn inject_bytes_produces_sealed_cloexec_injectfdsend() {
+        use std::io::Read;
+        match NotifAction::inject_bytes(b"payload") {
+            NotifAction::InjectFdSend { srcfd, newfd_flags } => {
+                assert_eq!(newfd_flags, libc::O_CLOEXEC as u32);
+                let seals = unsafe { libc::fcntl(srcfd.as_raw_fd(), libc::F_GET_SEALS) };
+                assert!(seals & libc::F_SEAL_WRITE != 0, "inject_bytes must seal");
+                let mut f = std::fs::File::from(srcfd);
+                let mut buf = String::new();
+                f.read_to_string(&mut buf).unwrap();
+                assert_eq!(buf, "payload");
+            }
+            other => panic!("expected InjectFdSend, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/sandlock-core/tests/integration/test_handlers.rs
+++ b/crates/sandlock-core/tests/integration/test_handlers.rs
@@ -667,3 +667,52 @@ async fn run_with_handlers_rejects_handler_on_default_blocklist_syscall() {
         other => panic!("expected Handler(OnDenySyscall), got {:?}", other.err()),
     }
 }
+
+/// End-to-end coverage for `NotifAction::inject_bytes`: a handler on
+/// `SYS_openat` materialises synthetic content as a sealed memfd and injects
+/// it as the guest's `openat` result. The guest `cat`s a path that does not
+/// exist on the host, yet reads back the injected bytes — proving the kernel
+/// returned the supervisor's fd rather than performing the real open.
+#[tokio::test]
+async fn inject_bytes_delivers_synthetic_content_to_guest() {
+    let policy = base_policy().build().unwrap();
+    let out = temp_out("inject-bytes-content");
+    // Sentinel path: never created on the host. `cat` opens it (intercepted),
+    // the handler injects content, and `cat` writes that to `out`.
+    let virt = "/tmp/sandlock-virtual-inject-XYZ";
+    let content = "INJECTED_SECRET_42\n";
+    let cmd = format!("cat {virt} > {}", out.display());
+
+    let handler = |cx: &HandlerCtx| {
+        // openat(2): args[1] is the path. Read it synchronously, then move only
+        // the owned path into the future (don't borrow `cx` across it). Only the
+        // sentinel injects; every other openat (libc, the output file, ...)
+        // falls through.
+        let path = sandlock_core::seccomp::notif::read_child_cstr(
+            cx.notif_fd, cx.notif.id, cx.notif.pid, cx.notif.data.args[1], 4096,
+        );
+        async move {
+            match path {
+                Some(p) if p.ends_with("sandlock-virtual-inject-XYZ") => {
+                    NotifAction::inject_bytes(b"INJECTED_SECRET_42\n")
+                }
+                _ => NotifAction::Continue,
+            }
+        }
+    };
+
+    let result = policy
+        .clone()
+        .run_with_handlers(&["sh", "-c", &cmd], [(libc::SYS_openat, handler)])
+        .await
+        .expect("sandbox spawn failed");
+
+    let contents = std::fs::read_to_string(&out).unwrap_or_default();
+    let _ = std::fs::remove_file(&out);
+
+    assert!(result.success(), "shell wrapper should exit 0");
+    assert_eq!(
+        contents, content,
+        "guest must read back exactly the injected bytes for a host-nonexistent path"
+    );
+}

--- a/crates/sandlock-ffi/include/sandlock.h
+++ b/crates/sandlock-ffi/include/sandlock.h
@@ -296,6 +296,21 @@ sandlock_handler_t *sandlock_handler_new(sandlock_handler_fn_t handler_fn,
 /** Free a handler container that has not been handed to the supervisor. */
 void sandlock_handler_free(sandlock_handler_t *h);
 
+/** Mark a handler as deferred. The supervisor then runs its callback off the
+ *  notification loop, so a slow callback (network round-trip, blocking
+ *  syscall) does not stall every other trapped syscall. Call before
+ *  registering the handler with a run.
+ *
+ *  A deferred handler makes a *terminal* decision: deferral short-circuits
+ *  the handler chain, so if it would continue and other user handlers are
+ *  registered on the same syscall, those later handlers do not run.
+ *  Builtins always run first regardless. Deferral is refused at dispatch
+ *  time for syscalls whose continue path needs the execve argv-safety freeze
+ *  (`execve`/`execveat`) or fork creation-tracking; such a call is denied
+ *  with EPERM. If more than an internal cap of deferrals are in flight at
+ *  once, further ones are failed with EAGAIN rather than queued. */
+void sandlock_handler_set_deferred(sandlock_handler_t *h, bool deferred);
+
 typedef struct sandlock_handler_registration_t {
     int64_t syscall_nr;
     sandlock_handler_t *handler; /* ownership transferred on a successful run */

--- a/crates/sandlock-ffi/include/sandlock.h
+++ b/crates/sandlock-ffi/include/sandlock.h
@@ -210,6 +210,24 @@ void sandlock_action_set_return_value(sandlock_action_out_t *out, int64_t value)
  *  setter per action. */
 void sandlock_action_set_inject_fd_send(sandlock_action_out_t *out,
                                         int32_t srcfd, uint32_t newfd_flags);
+
+/* Flags for sandlock_action_set_inject_bytes(). flags == 0 is the safe
+ * default: the injected file is sealed read-only and the child-side fd is
+ * O_CLOEXEC. */
+#define SANDLOCK_INJECT_WRITABLE   (1u << 0)  /* leave the memfd writable (do not seal) */
+#define SANDLOCK_INJECT_NO_CLOEXEC (1u << 1)  /* clear O_CLOEXEC on the child-side fd */
+
+/** Inject `len` bytes from `data` into the child as the syscall's returned
+ *  fd, backed by an in-memory file the supervisor creates. The bytes are
+ *  copied during the call, so `data` need not outlive it, and the caller
+ *  owns no fd (the supervisor creates, populates, and closes the memfd).
+ *  Use this instead of sandlock_action_set_inject_fd_send() when injecting
+ *  synthetic content (secrets, virtual files, fetched objects) rather than
+ *  an fd you already hold. On allocation failure the action becomes
+ *  Errno(EIO). `data` may be NULL when `len == 0` (injects an empty file). */
+void sandlock_action_set_inject_bytes(sandlock_action_out_t *out,
+                                      const uint8_t *data, size_t len,
+                                      uint32_t flags);
 /* NOTE: `SANDLOCK_ACTION_INJECT_FD_SEND_TRACKED` (= 5) and
  * `sandlock_action_inject_tracked_t` are reserved for a future
  * tracker-aware inject variant. No setter is exposed in this release;

--- a/crates/sandlock-ffi/src/handler/abi.rs
+++ b/crates/sandlock-ffi/src/handler/abi.rs
@@ -376,6 +376,12 @@ pub struct sandlock_handler_t {
     pub(super) ud: *mut std::ffi::c_void,
     pub(super) ud_drop: Option<sandlock_handler_ud_drop_t>,
     pub(super) on_exception: sandlock_exception_policy_t,
+    /// When true, the supervisor runs this handler's callback off the
+    /// notification loop (as a deferred future) instead of inline, so a
+    /// slow callback (network round-trip, blocking syscall) does not stall
+    /// every other trapped syscall. The container is an opaque box — C
+    /// never sees this field's layout — so adding it is not a C ABI break.
+    pub(super) deferred: bool,
 }
 
 // Safety:
@@ -448,8 +454,32 @@ pub unsafe extern "C" fn sandlock_handler_new(
         ud,
         ud_drop,
         on_exception,
+        deferred: false,
     });
     Box::into_raw(h)
+}
+
+/// Mark a handler as deferred: the supervisor will run its callback off the
+/// notification loop so a slow callback does not block other trapped
+/// syscalls. Must be called before the handler is registered with a run.
+///
+/// A deferred handler makes a *terminal* decision: deferral short-circuits
+/// the handler chain, so if a deferred handler would `Continue` and other
+/// user handlers are registered on the same syscall, those later handlers do
+/// not run. Builtins always run first regardless. Deferral is refused at
+/// dispatch time for syscalls whose Continue path needs the execve
+/// argv-safety freeze (`execve`/`execveat`) or fork creation-tracking.
+///
+/// # Safety
+/// `h` must be a non-null pointer returned by `sandlock_handler_new` that has
+/// not yet been registered with a run or freed.
+#[no_mangle]
+pub unsafe extern "C" fn sandlock_handler_set_deferred(
+    h: *mut sandlock_handler_t,
+    deferred: bool,
+) {
+    if h.is_null() { return; }
+    (*h).deferred = deferred;
 }
 
 /// Free a handler container that has *not* been registered with a

--- a/crates/sandlock-ffi/src/handler/abi.rs
+++ b/crates/sandlock-ffi/src/handler/abi.rs
@@ -2,10 +2,17 @@
 //! handler module. No Rust-side dispatch logic lives here — only the
 //! data layout and the thin `extern "C-unwind"` wrappers around it.
 
-use std::os::unix::io::RawFd;
+use std::os::unix::io::{IntoRawFd, RawFd};
 use std::slice;
 
-use sandlock_core::seccomp::notif::{read_child_cstr, read_child_mem, write_child_mem};
+use sandlock_core::seccomp::notif::{content_memfd, read_child_cstr, read_child_mem, write_child_mem};
+
+/// `flags` bit for [`sandlock_action_set_inject_bytes`]: leave the injected
+/// memfd writable (do not seal). Default (bit clear) seals it read-only.
+pub const SANDLOCK_INJECT_WRITABLE: u32 = 1 << 0;
+/// `flags` bit for [`sandlock_action_set_inject_bytes`]: do not set
+/// `O_CLOEXEC` on the child-side fd. Default (bit clear) sets `O_CLOEXEC`.
+pub const SANDLOCK_INJECT_NO_CLOEXEC: u32 = 1 << 1;
 
 /// Opaque child-memory accessor handed to a C handler callback.
 ///
@@ -287,6 +294,61 @@ pub unsafe extern "C" fn sandlock_action_set_inject_fd_send(
     (*out).payload.inject_send = sandlock_action_inject_t { srcfd, newfd_flags };
 }
 
+/// Inject `len` bytes from `data` into the child as the syscall's returned
+/// fd, backed by an in-memory file created by the supervisor. The bytes are
+/// copied immediately, so `data` need not outlive the call.
+///
+/// `flags` is a bitmask of `SANDLOCK_INJECT_*`. With `flags == 0` the memfd is
+/// sealed read-only and the child-side fd is `O_CLOEXEC` — the safe default
+/// for synthetic file content (secrets, virtual files, fetched objects). On
+/// allocation failure the action is set to `Errno(EIO)`, so the callback's
+/// one-setter contract still holds and the child gets a definite response.
+///
+/// Unlike [`sandlock_action_set_inject_fd_send`], the caller owns no fd here:
+/// the supervisor creates, populates, and (on dispatch) closes the memfd.
+///
+/// # Safety
+/// `out` follows the same constraints as `sandlock_action_set_continue`.
+/// `data` must point to at least `len` readable bytes, or be null when
+/// `len == 0`.
+#[no_mangle]
+pub unsafe extern "C" fn sandlock_action_set_inject_bytes(
+    out: *mut sandlock_action_out_t,
+    data: *const u8,
+    len: usize,
+    flags: u32,
+) {
+    if out.is_null() { return; }
+
+    let seal = flags & SANDLOCK_INJECT_WRITABLE == 0;
+    let newfd_flags = if flags & SANDLOCK_INJECT_NO_CLOEXEC == 0 {
+        libc::O_CLOEXEC as u32
+    } else {
+        0
+    };
+
+    // Copy the caller's bytes now; `data` is only valid for this call.
+    let bytes: &[u8] = if data.is_null() || len == 0 {
+        &[]
+    } else {
+        slice::from_raw_parts(data, len)
+    };
+
+    match content_memfd(bytes, seal) {
+        Ok(fd) => {
+            (*out).kind = sandlock_action_kind_t::InjectFdSend as u32;
+            (*out).payload.inject_send = sandlock_action_inject_t {
+                srcfd: fd.into_raw_fd(),
+                newfd_flags,
+            };
+        }
+        Err(_) => {
+            (*out).kind = sandlock_action_kind_t::Errno as u32;
+            (*out).payload.errno_value = libc::EIO;
+        }
+    }
+}
+
 /// Hold the syscall pending until the supervisor explicitly releases it.
 ///
 /// # Safety
@@ -521,3 +583,70 @@ pub struct sandlock_handler_registration_t {
 // `Send` to allow the input array to be borrowed inside `unsafe`
 // contexts without per-call wrapper structs.
 unsafe impl Send for sandlock_handler_registration_t {}
+
+#[cfg(test)]
+mod inject_bytes_tests {
+    use super::*;
+    use std::io::Read;
+    use std::os::unix::io::{FromRawFd, OwnedFd};
+
+    // Read an fd's full contents (from offset 0) and close it.
+    fn read_and_close(fd: RawFd) -> String {
+        let mut f = unsafe { std::fs::File::from_raw_fd(fd) };
+        let mut s = String::new();
+        f.read_to_string(&mut s).unwrap();
+        s
+    }
+
+    #[test]
+    fn inject_bytes_default_is_sealed_cloexec_injectfdsend() {
+        let mut out = sandlock_action_out_t::zeroed();
+        let data = b"secret-token";
+        unsafe { sandlock_action_set_inject_bytes(&mut out, data.as_ptr(), data.len(), 0) };
+        assert_eq!(out.kind, sandlock_action_kind_t::InjectFdSend as u32);
+        let inject = unsafe { out.payload.inject_send };
+        assert_eq!(inject.newfd_flags, libc::O_CLOEXEC as u32);
+        let seals = unsafe { libc::fcntl(inject.srcfd, libc::F_GET_SEALS) };
+        assert!(seals & libc::F_SEAL_WRITE != 0, "default flags must seal");
+        assert_eq!(read_and_close(inject.srcfd), "secret-token");
+    }
+
+    #[test]
+    fn inject_bytes_writable_flag_skips_seal() {
+        let mut out = sandlock_action_out_t::zeroed();
+        let data = b"rw";
+        unsafe {
+            sandlock_action_set_inject_bytes(
+                &mut out, data.as_ptr(), data.len(), SANDLOCK_INJECT_WRITABLE,
+            )
+        };
+        assert_eq!(out.kind, sandlock_action_kind_t::InjectFdSend as u32);
+        let inject = unsafe { out.payload.inject_send };
+        let seals = unsafe { libc::fcntl(inject.srcfd, libc::F_GET_SEALS) };
+        assert_eq!(seals & libc::F_SEAL_WRITE, 0, "WRITABLE must not seal");
+        drop(unsafe { OwnedFd::from_raw_fd(inject.srcfd) });
+    }
+
+    #[test]
+    fn inject_bytes_no_cloexec_flag_clears_newfd_flags() {
+        let mut out = sandlock_action_out_t::zeroed();
+        let data = b"x";
+        unsafe {
+            sandlock_action_set_inject_bytes(
+                &mut out, data.as_ptr(), data.len(), SANDLOCK_INJECT_NO_CLOEXEC,
+            )
+        };
+        let inject = unsafe { out.payload.inject_send };
+        assert_eq!(inject.newfd_flags, 0);
+        drop(unsafe { OwnedFd::from_raw_fd(inject.srcfd) });
+    }
+
+    #[test]
+    fn inject_bytes_null_data_injects_empty_file() {
+        let mut out = sandlock_action_out_t::zeroed();
+        unsafe { sandlock_action_set_inject_bytes(&mut out, std::ptr::null(), 0, 0) };
+        assert_eq!(out.kind, sandlock_action_kind_t::InjectFdSend as u32);
+        let inject = unsafe { out.payload.inject_send };
+        assert_eq!(read_and_close(inject.srcfd), "");
+    }
+}

--- a/crates/sandlock-ffi/src/handler/adapter.rs
+++ b/crates/sandlock-ffi/src/handler/adapter.rs
@@ -154,8 +154,15 @@ impl Handler for FfiHandler {
         let handler_fn = self.inner.handler_fn;
         let ud = UdPtr(self.inner.ud);
         let on_exception_fallback = self.exception_action(child_pgid);
+        let deferred = self.inner.deferred;
 
-        Box::pin(async move {
+        // The whole callback (including its slow work) runs on a blocking
+        // worker. When `deferred` is set we hand this future to the
+        // supervisor as `NotifAction::Defer` so it runs off the notification
+        // loop; otherwise the supervisor awaits it inline as before. The
+        // future is fully owned (`'static`) either way — nothing borrows
+        // `self`/`cx`.
+        let run = async move {
             let join = tokio::task::spawn_blocking(move || {
                 // Rust 2021 disjoint closure captures (RFC 2229) would
                 // otherwise capture `ud.0` (a bare `*mut c_void`, not
@@ -210,7 +217,15 @@ impl Handler for FfiHandler {
                     on_exception_fallback
                 }
             }
-        })
+        };
+
+        if deferred {
+            // Resolves immediately to Defer; the supervisor moves `run` onto
+            // a worker task and sends the response when it completes.
+            Box::pin(async move { NotifAction::defer(run) })
+        } else {
+            Box::pin(run)
+        }
     }
 }
 

--- a/crates/sandlock-ffi/tests/c/handler_smoke.c
+++ b/crates/sandlock-ffi/tests/c/handler_smoke.c
@@ -9,6 +9,7 @@
  * file as a starting point.
  */
 #define _GNU_SOURCE
+#include <fcntl.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -18,6 +19,60 @@
 #include <unistd.h>
 
 #include "sandlock.h"
+
+/* Exercise sandlock_action_set_inject_bytes() through the cdylib: the
+ * default flags must produce an InjectFdSend whose fd reads back the bytes
+ * and is sealed read-only; SANDLOCK_INJECT_WRITABLE must leave it unsealed.
+ * Returns 0 on success, non-zero on failure. */
+static int check_inject_bytes(void) {
+    sandlock_action_out_t out;
+    memset(&out, 0, sizeof out);
+
+    const char *payload = "hello-from-c";
+    size_t n = strlen(payload);
+    sandlock_action_set_inject_bytes(&out, (const uint8_t *)payload, n, 0);
+
+    if (out.kind != SANDLOCK_ACTION_INJECT_FD_SEND) {
+        fprintf(stderr, "inject_bytes: kind=%u, want %d\n",
+                out.kind, SANDLOCK_ACTION_INJECT_FD_SEND);
+        return 1;
+    }
+    if (out.payload.inject_send.newfd_flags != (uint32_t)O_CLOEXEC) {
+        fprintf(stderr, "inject_bytes: newfd_flags=%u, want O_CLOEXEC\n",
+                out.payload.inject_send.newfd_flags);
+        return 1;
+    }
+    int fd = out.payload.inject_send.srcfd;
+
+    int seals = fcntl(fd, F_GET_SEALS);
+    if (seals < 0 || !(seals & F_SEAL_WRITE)) {
+        fprintf(stderr, "inject_bytes: default fd not write-sealed (seals=%d)\n", seals);
+        close(fd);
+        return 1;
+    }
+
+    char buf[64] = {0};
+    ssize_t got = pread(fd, buf, sizeof buf - 1, 0);
+    close(fd);
+    if (got != (ssize_t)n || memcmp(buf, payload, n) != 0) {
+        fprintf(stderr, "inject_bytes: content mismatch (got=%zd)\n", got);
+        return 1;
+    }
+
+    /* Writable variant: same content, but no write seal. */
+    memset(&out, 0, sizeof out);
+    sandlock_action_set_inject_bytes(&out, (const uint8_t *)payload, n,
+                                     SANDLOCK_INJECT_WRITABLE);
+    int wfd = out.payload.inject_send.srcfd;
+    int wseals = fcntl(wfd, F_GET_SEALS);
+    close(wfd);
+    if (wseals >= 0 && (wseals & F_SEAL_WRITE)) {
+        fprintf(stderr, "inject_bytes: WRITABLE fd unexpectedly write-sealed\n");
+        return 1;
+    }
+
+    return 0;
+}
 
 static int force_getpid_to_777(
     void *ud,
@@ -33,6 +88,12 @@ static int force_getpid_to_777(
 }
 
 int main(void) {
+    /* Pure-C check of the content-injection setter, independent of a live
+     * sandbox run. */
+    if (check_inject_bytes() != 0) {
+        return 1;
+    }
+
     /* Build a sandbox that exposes just enough of the host for the
      * system python3 interpreter to start. Mirrors the read mounts
      * from the Rust integration test in tests/handler_smoke.rs. */

--- a/crates/sandlock-ffi/tests/handler_smoke.rs
+++ b/crates/sandlock-ffi/tests/handler_smoke.rs
@@ -369,6 +369,46 @@ async fn ffi_handler_translates_return_value() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn deferred_ffi_handler_returns_defer_that_resolves_to_callback() {
+    // A handler flagged deferred must return NotifAction::Defer (so the
+    // supervisor runs it off-loop), and driving that future must yield the
+    // same action the C callback would have produced inline.
+    let raw = unsafe {
+        sandlock_ffi::handler::sandlock_handler_new(
+            Some(return_value_42),
+            std::ptr::null_mut(),
+            None,
+            sandlock_exception_policy_t::Kill as u32,
+        )
+    };
+    unsafe { sandlock_ffi::handler::sandlock_handler_set_deferred(raw, true) };
+    let h = unsafe { FfiHandler::from_raw(raw) };
+    let cx = fake_ctx();
+    let action = h.handle(&cx).await;
+    let deferred = match action {
+        NotifAction::Defer(d) => d,
+        other => panic!("deferred handler must return Defer, got {other:?}"),
+    };
+    assert!(matches!(deferred.run().await, NotifAction::ReturnValue(42)));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn non_deferred_ffi_handler_stays_inline() {
+    // Without the flag, handle() resolves the action inline (no Defer).
+    let raw = unsafe {
+        sandlock_ffi::handler::sandlock_handler_new(
+            Some(return_value_42),
+            std::ptr::null_mut(),
+            None,
+            sandlock_exception_policy_t::Kill as u32,
+        )
+    };
+    let h = unsafe { FfiHandler::from_raw(raw) };
+    let cx = fake_ctx();
+    assert!(matches!(h.handle(&cx).await, NotifAction::ReturnValue(42)));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn ffi_handler_applies_exception_policy_on_failure() {
     let raw = unsafe {
         sandlock_ffi::handler::sandlock_handler_new(

--- a/docs/extension-handlers.md
+++ b/docs/extension-handlers.md
@@ -377,6 +377,7 @@ The contract is exercised at two layers:
 | `InjectFd { srcfd, targetfd }` | Inject `srcfd` into the guest at slot `targetfd`, then continue. |
 | `InjectFdSendTracked { srcfd, newfd_flags, on_success }` | Inject `srcfd`; `on_success` callback runs synchronously when the kernel returns the slot, so downstream tracking cannot race with the guest seeing the new fd. |
 | `Kill { sig, pgid }` | Send `sig` to the guest's process group. |
+| `Defer(Deferred)` | Run the carried future off the supervisor loop; its terminal action is sent later, keyed by `notif.id`. Non-`Continue`, so it ends the chain. See [Deferred handlers](#deferred-handlers). |
 
 ### Continue-site safety
 
@@ -391,12 +392,80 @@ handler-owned state on `&self`: a `tokio::sync::Mutex<T>` or `RwLock<T>` field o
 must not be held across an `.await` point. If the guard is alive when control returns to the
 supervisor loop, the next notification that needs the same lock parks, the response for the
 current notification is not sent, and the child stays trapped in the syscall. Acquire, mutate,
-drop — `await` only after the guard is out of scope.
+drop, and `await` only after the guard is out of scope. For work that is genuinely slow (a network
+round-trip, a blocking syscall) rather than a short critical section, do not block the loop at
+all: return [`NotifAction::Defer`](#deferred-handlers) and let the supervisor run it off-loop.
 
 See [issue #27][i27] for the underlying supervisor-loop contract that this convention extends to
 user handlers.
 
 [i27]: https://github.com/multikernel/sandlock/issues/27
+
+### Deferred handlers
+
+Continue-site safety exists because the supervisor processes notifications sequentially: a handler
+that blocks (a network round-trip, a blocking syscall, a slow lock) stalls every other trapped
+syscall until it returns. `NotifAction::Defer` is the escape hatch. A handler that returns `Defer`
+hands the supervisor an owned, `'static` future; the supervisor moves it onto a worker task, lets
+the notification loop proceed immediately, and sends the response (keyed by `notif.id`) when the
+future resolves. The trapped child stays parked in the syscall until then, so `notif.id` stays
+valid and the child-memory helpers keep working inside the deferred future.
+
+```rust
+use std::future::Future;
+use std::pin::Pin;
+use sandlock_core::{Handler, HandlerCtx};
+use sandlock_core::seccomp::notif::{read_child_cstr, NotifAction};
+
+fn handle<'a>(
+    &'a self,
+    cx: &'a HandlerCtx,
+) -> Pin<Box<dyn Future<Output = NotifAction> + Send + 'a>> {
+    // Copy out what the deferred future needs: `notif` is `Copy`, `notif_fd`
+    // is a `RawFd`, and `Arc` state is cloned. Never borrow `&self`/`cx`:
+    // the deferred future is `'static` and outlives this call.
+    let (fd, id, pid) = (cx.notif_fd, cx.notif.id, cx.notif.pid);
+    let key = read_child_cstr(fd, id, pid, cx.notif.data.args[1], 4096);
+    let backend = self.backend.clone();
+    Box::pin(async move {
+        let Some(key) = key else { return NotifAction::Continue };
+        NotifAction::defer(async move {
+            // Runs on a worker, off the supervisor loop. The child is still
+            // parked, so child-memory helpers and `id` are valid here.
+            match backend.get(&key).await {
+                Ok(_data) => NotifAction::ReturnValue(0), // e.g. inject a memfd of `_data`
+                Err(_) => NotifAction::Errno(libc::EIO),
+            }
+        })
+    })
+}
+```
+
+The deferred future must be `Send + 'static`: `Send` so the supervisor can move it onto a worker,
+and `'static` so it can outlive the borrowed `HandlerCtx`. It does **not** need to be `Sync` (the
+supervisor moves it, never shares it by reference). Capture owned data only: copy `notif` (it is
+`Copy`), clone an `Arc` for shared state, and never borrow `&self`/`cx`.
+
+Contract:
+
+- **Terminal decision.** `Defer` is non-`Continue`, so it short-circuits the handler chain exactly
+  like `Errno`/`ReturnValue`: later handlers on the same syscall do not run. A deferring handler
+  decides the outcome.
+- **No deferral on freeze/fork syscalls.** Deferral is refused (with `EPERM`) on
+  `execve`/`execveat` and fork-creating syscalls, because moving the response off-loop would skip
+  the argv-safety freeze (see [issue #27][i27]) and process creation-tracking that those paths
+  require before `Continue`.
+- **Bounded fan-out.** At most `DEFER_MAX_INFLIGHT` deferred futures run concurrently; beyond that,
+  further deferrals fail fast with `EAGAIN` rather than queuing. The cap also bounds the resources
+  workers hold (memfds, sockets).
+- **No nesting.** A deferred future that itself resolves to `Defer` is a bug; the supervisor
+  collapses it to `EIO` so the child is never left wedged.
+- **Stale id.** If the child exits mid-defer, the eventual `send_response` is a no-op and the
+  child-memory helpers fail safe (they are `id_valid`-bracketed), matching the inline path's
+  "child may have exited" tolerance.
+
+Do not defer trivial fast handlers: the worker hop adds latency. Defer only when the work would
+otherwise block the loop.
 
 ## Security boundary
 
@@ -505,6 +574,11 @@ than collecting them after exit) needs interceptors on `openat(O_CREAT)`, `write
 translate filesystem operations into multipart-upload calls. Those interceptors must live inside
 the same supervisor task as sandlock's builtins — `SECCOMP_FILTER_FLAG_NEW_LISTENER` allows only
 one listener per process.
+
+Because the multipart-upload calls are slow network operations, return
+[`NotifAction::Defer`](#deferred-handlers) from those handlers so the uploads run off the
+notification loop. Otherwise each upload blocks the single supervisor task and stalls every other
+trapped syscall for the duration of the round-trip.
 
 Wrap each handler in `Box<dyn Handler>` so the iterator's `H` parameter is uniform across
 heterogeneous handler types:

--- a/docs/extension-handlers.md
+++ b/docs/extension-handlers.md
@@ -256,6 +256,60 @@ fn handle<'a>(
 }
 ```
 
+### Injecting synthetic content (`inject_bytes`)
+
+When a handler hands the guest synthetic file content (a secret, a generated config, a fetched
+object) as the result of an `open`/`openat`, use
+[`NotifAction::inject_bytes`](../crates/sandlock-core/src/seccomp/notif.rs) instead of building a
+`memfd` by hand. It creates an in-memory file populated with the bytes, rewinds it, seals it
+read-only, and returns an `InjectFdSend` action carrying that fd:
+
+```rust
+use sandlock_core::seccomp::notif::NotifAction;
+
+// Inside a handler: serve the bytes as the openat result fd.
+return NotifAction::inject_bytes(b"INJECTED CONTENT\n");
+```
+
+`inject_bytes` owns the fd end to end: the supervisor creates, populates, seals, and (on dispatch)
+closes it, so the caller never touches a raw fd and there is no "when do I close this" question. On
+an allocation failure it collapses to `Errno(EIO)`, which is why it returns a `NotifAction`
+directly rather than a `Result`.
+
+The two defaults both suit the dominant case (synthetic, often sensitive, read-only content):
+
+- **Sealed read-only.** The fd carries `F_SEAL_SEAL | F_SEAL_WRITE | F_SEAL_GROW | F_SEAL_SHRINK`,
+  so the guest cannot modify or resize the content it is handed.
+- **`O_CLOEXEC` on the child-side fd**, so the content does not leak into programs the guest later
+  `execve`s (see the note below).
+
+When you are impersonating a real file and want byte-for-byte the semantics the guest asked for (a
+writable fd, or the guest's own `O_CLOEXEC` choice), drop to the lower-level primitive
+[`content_memfd(content, seal)`](../crates/sandlock-core/src/seccomp/notif.rs), which returns an
+`OwnedFd` you pass to `NotifAction::InjectFdSend { srcfd, newfd_flags }` yourself:
+
+```rust
+use sandlock_core::seccomp::notif::{content_memfd, NotifAction};
+
+// Writable injected fd, mirroring the guest's own O_CLOEXEC request.
+let fd = match content_memfd(&bytes, /* seal */ false) {
+    Ok(fd) => fd,
+    Err(_) => return NotifAction::Errno(libc::EIO),
+};
+let cloexec = (cx.notif.data.args[2] as i32 & libc::O_CLOEXEC) != 0; // openat flags
+NotifAction::InjectFdSend {
+    srcfd: fd,
+    newfd_flags: if cloexec { libc::O_CLOEXEC as u32 } else { 0 },
+}
+```
+
+> **Why `O_CLOEXEC` by default.** `newfd_flags` sets the close-on-exec bit on the *child-side* fd
+> (distinct from the supervisor's own `MFD_CLOEXEC` copy of the memfd). Without it, a subprocess
+> the guest `execve`s inherits an open fd to the injected content and can read it without ever
+> opening the file. For secret injection that is a silent leak, so `inject_bytes` closes the fd
+> across `exec`; handlers that virtualize a real file and need to honor the guest's request opt out
+> via `content_memfd` (or, over the C ABI, the documented flags).
+
 ### State patterns
 
 Common confusion: when a handler holds mutable state, what kind of synchronisation is needed?
@@ -379,6 +433,11 @@ The contract is exercised at two layers:
 | `Kill { sig, pgid }` | Send `sig` to the guest's process group. |
 | `Defer(Deferred)` | Run the carried future off the supervisor loop; its terminal action is sent later, keyed by `notif.id`. Non-`Continue`, so it ends the chain. See [Deferred handlers](#deferred-handlers). |
 
+`InjectFd`/`InjectFdSend`/`InjectFdSendTracked` carry a file descriptor. To synthesise *content*
+(rather than inject an fd you already hold), construct the action with
+[`NotifAction::inject_bytes`](#injecting-synthetic-content-inject_bytes); it builds the sealed
+`memfd` and produces an `InjectFdSend` for you.
+
 ### Continue-site safety
 
 Today's supervisor processes notifications sequentially in a single tokio task, so the response
@@ -485,8 +544,8 @@ User handlers can:
   syscall must have returned `Continue` for the user handler to see it.
 - Fake results (`ReturnValue`, `Errno`) — but only after the builtins for the same syscall
   returned `Continue`, so they cannot subvert confinement.
-- Inject fds (`InjectFd`/`InjectFdSendTracked`) — useful for materialising virtual file content
-  via `memfd` without ever touching the host filesystem.
+- Inject fds (`inject_bytes`, `InjectFd`, `InjectFdSendTracked`) to materialise virtual file
+  content via `memfd` without ever touching the host filesystem.
 
 ### BPF coverage
 
@@ -603,11 +662,17 @@ against the configured policy.
 
 ### Synthetic file content via `InjectFdSendTracked`
 
+For the common read-only case,
+[`NotifAction::inject_bytes`](#injecting-synthetic-content-inject_bytes) is the one-liner: it
+builds the sealed `memfd` and returns the inject action for you. Reach for `InjectFdSendTracked`
+only when you must know the exact fd number the kernel assigned in the child (for example to key
+per-fd bookkeeping); its `on_success` callback delivers that number without racing the guest.
+
 A read-only virtual file (e.g. `/etc/hostname`, an in-memory configuration generated per-call)
 can be exposed by intercepting `openat` and injecting a sealed `memfd` containing the content.
 The kernel returns the new fd slot to the guest, the handler's `on_success` callback runs
 synchronously to register the fd in the handler's bookkeeping, and the guest reads the content
-via the `memfd` — no host filesystem touched.
+via the `memfd` (no host filesystem touched).
 
 ### Deterministic audit trail for compliance
 
@@ -721,6 +786,36 @@ break. Consequently the caller MUST ensure their `ud` pointer is
 thread-safe: either immutable, or guarded by their own synchronization
 primitives (atomics, mutex, etc.). Rust offers no synchronization for
 an opaque `void*`; the responsibility is on the C side.
+
+### Injecting content (`sandlock_action_set_inject_bytes`)
+
+The C counterpart of
+[`NotifAction::inject_bytes`](#injecting-synthetic-content-inject_bytes) is:
+
+```c
+void sandlock_action_set_inject_bytes(sandlock_action_out_t *out,
+                                      const uint8_t *data, size_t len,
+                                      uint32_t flags);
+```
+
+The supervisor copies `data` during the call (so it need not outlive the
+call), builds the backing in-memory file, and owns the resulting fd.
+Unlike `sandlock_action_set_inject_fd_send`, the caller passes no fd and
+frees nothing. On an allocation failure the action becomes `Errno(EIO)`,
+so the one-setter callback contract still holds.
+
+`flags` is a bitmask whose zero value is the safe default (sealed
+read-only, child-side fd `O_CLOEXEC`), matching `inject_bytes`:
+
+| `flags` | effect |
+|---|---|
+| `0` | sealed read-only, `O_CLOEXEC` (recommended) |
+| `SANDLOCK_INJECT_WRITABLE` | leave the memfd writable (do not seal) |
+| `SANDLOCK_INJECT_NO_CLOEXEC` | clear `O_CLOEXEC` on the child-side fd |
+
+`data` may be `NULL` when `len == 0`, which injects an empty file. The
+pure-C check in `crates/sandlock-ffi/tests/c/handler_smoke.c` exercises
+both the sealed default and the `SANDLOCK_INJECT_WRITABLE` variant.
 
 ### Minimal example
 

--- a/docs/python-handlers.md
+++ b/docs/python-handlers.md
@@ -22,8 +22,11 @@ sb.run_with_handlers(
 ## Core types
 
 - `Handler` — base class. Subclass and override `handle(ctx) -> NotifAction`.
-  Set the class attribute `on_exception` (default `ExceptionPolicy.KILL`) to
-  choose what the supervisor does when the handler errors.
+  Define `handle` as `async def` to run it off the supervisor loop so it can
+  `await` slow work without stalling other trapped syscalls; see
+  [Deferred handlers](#deferred-handlers). Set the class attribute
+  `on_exception` (default `ExceptionPolicy.KILL`) to choose what the
+  supervisor does when the handler errors.
 - `HandlerCtx` — frozen dataclass with the notification fields (`id`, `pid`,
   `flags`, `syscall_nr`, `arch`, `instruction_pointer`, `args`) plus
   child-memory accessors.
@@ -238,7 +241,10 @@ syscall list rather than against an empty dispatch table.
   `handle()` to be fast (sub-millisecond) and to protect any mutable
   handler state with your own synchronization. High-frequency
   interception (e.g. per-`SYS_openat` audit on a busy workload) will
-  serialize on the GIL and can stall the supervisor.
+  serialize on the GIL and can stall the supervisor. For a `handle()`
+  that must do slow work (a network call, a blocking read), define it as
+  `async def` so it runs off the loop instead; see
+  [Deferred handlers](#deferred-handlers).
 
 - **Interpreter finalization.** If `Py_FinalizeEx` runs while the
   sandbox is still alive (e.g. the main thread exits with handlers
@@ -257,6 +263,60 @@ syscall list rather than against an empty dispatch table.
   `Sandbox.run_with_handlers` from a thread that already runs a Tokio
   runtime — the FFI will panic, and the panic surfaces as a Python
   exception. Pure-Python use (the common case) is unaffected.
+
+## Deferred handlers
+
+By default `handle()` runs synchronously inside the supervisor's
+notification loop, so a slow callback stalls every other trapped syscall
+until it returns. Define `handle` as `async def` to run it off that loop
+instead: the coroutine is driven to completion on a worker thread, so it
+can `await` slow work without blocking the supervisor. That is the only
+change; you do not set any flag.
+
+```python
+class FetchHandler(Handler):
+    def __init__(self, backend):
+        self.backend = backend
+
+    async def handle(self, ctx):
+        key = ctx.read_path()              # read the path before the slow work
+        if key is None:
+            return NotifAction.continue_()
+        data = await self.backend.get(key)  # slow network GET, awaited off-loop
+        fd = os.memfd_create("obj", os.MFD_CLOEXEC)
+        os.write(fd, data)
+        os.lseek(fd, 0, os.SEEK_SET)
+        return NotifAction.inject_fd_send(fd)
+```
+
+Why it helps Python specifically: the coroutine runs on a worker thread,
+and CPython releases the GIL while it `await`s I/O, so multiple async
+handlers doing network work genuinely overlap while the supervisor loop
+stays free. It does not parallelize CPU-bound Python work (the GIL still
+serializes that); for that, push the hot path into a C extension that
+releases the GIL.
+
+`ctx` and its child-memory accessors (`read_cstr`, `read`, `write`) stay
+valid for the whole coroutine, so you can read paths and write results
+across `await` points.
+
+Contract (enforced by the supervisor):
+
+- **Terminal decision.** Deferral short-circuits the handler chain, so if
+  an async handler returns `continue_()` and other handlers are registered
+  on the same syscall, those later handlers do not run. Built-ins always
+  run first regardless.
+- **Refused on `execve`/`execveat` and fork-creating syscalls.** The
+  response cannot be moved off-loop there without skipping argv-safety
+  work, so such a call is denied with `EPERM`.
+- **Bounded.** Beyond an internal in-flight cap, further deferrals fail
+  fast with `EAGAIN` rather than queuing.
+
+Make `handle` async only when it must do slow work. For fast handlers
+(audit counters, path checks) a synchronous `handle` runs inline at lower
+latency. See
+[`extension-handlers.md`](extension-handlers.md#deferred-handlers) for the
+underlying Rust/C contract.
 
 ## Ownership rules
 

--- a/docs/python-handlers.md
+++ b/docs/python-handlers.md
@@ -32,7 +32,9 @@ sb.run_with_handlers(
   child-memory accessors.
 - `NotifAction` — frozen value-object. Construct via factory classmethods:
   `continue_()`, `errno(value)`, `returns(value)`, `hold()`,
-  `kill(sig, pgid)`, `inject_fd_send(srcfd, newfd_flags)`.
+  `kill(sig, pgid)`, `inject_fd_send(srcfd, newfd_flags)`,
+  `inject_bytes(data, *, seal=True, cloexec=True)` (see
+  [Inject synthetic content](#inject-synthetic-content)).
 - `ExceptionPolicy` — IntEnum: `KILL` (default), `DENY_EPERM`, `CONTINUE`,
   `DENY_EIO`.
 
@@ -186,6 +188,32 @@ class FakePid(Handler):
 sb.run_with_handlers(cmd, [("getpid", FakePid())])
 ```
 
+### Inject synthetic content
+
+`NotifAction.inject_bytes(data)` serves `data` to the guest as the fd returned
+by its `open`/`openat`, backed by an in-memory file. Use it instead of
+hand-rolling `os.memfd_create` + `os.write` + `os.lseek`: it builds the memfd,
+rewinds it, seals it read-only, and transfers fd ownership to the supervisor
+(the caller must NOT close it).
+
+```python
+from sandlock.handler import Handler, NotifAction, ExceptionPolicy
+
+class HostnameFile(Handler):
+    on_exception = ExceptionPolicy.KILL
+
+    def handle(self, ctx):
+        if ctx.read_path() == "/etc/hostname":
+            return NotifAction.inject_bytes(b"sandbox\n")
+        return NotifAction.continue_()
+```
+
+By default the fd is sealed read-only (the guest cannot modify or resize it)
+and `O_CLOEXEC` (the content does not leak into programs the guest later
+`exec`s). Pass `seal=False` for a writable fd, or `cloexec=False` to mirror a
+guest that opened the file without `O_CLOEXEC`. A rare allocation failure
+raises `OSError`, which the handler's `on_exception` policy then governs.
+
 ### Kill the child from a handler
 
 ```python
@@ -283,10 +311,9 @@ class FetchHandler(Handler):
         if key is None:
             return NotifAction.continue_()
         data = await self.backend.get(key)  # slow network GET, awaited off-loop
-        fd = os.memfd_create("obj", os.MFD_CLOEXEC)
-        os.write(fd, data)
-        os.lseek(fd, 0, os.SEEK_SET)
-        return NotifAction.inject_fd_send(fd)
+        # inject_bytes builds the sealed memfd and transfers fd ownership to
+        # the supervisor (see "Inject synthetic content" above).
+        return NotifAction.inject_bytes(data)
 ```
 
 Why it helps Python specifically: the coroutine runs on a worker thread,

--- a/python/examples/s3_handlers.py
+++ b/python/examples/s3_handlers.py
@@ -41,10 +41,11 @@ Caveats (this example is deliberately minimal):
 
   * Directory listings (getdents64) are not served, so ls /s3 is empty.
   * open fetches the whole object body (no range reads).
-  * A real (network) backend's head/get runs inside the supervisor
-    dispatch path while holding the GIL, so it blocks the supervisor.
-    Prefetch out of band for anything beyond a demo. FakeS3 is in-memory
-    and instant, so this does not apply here.
+  * The handlers are async (`async def handle`), so a real (network)
+    backend's head/get runs on a worker thread off the supervisor loop
+    rather than blocking it (CPython releases the GIL during socket I/O,
+    so concurrent fetches overlap). FakeS3 is in-memory and instant, so
+    being async is a no-op here but is what makes a real backend viable.
   * _pack_stat uses the x86_64 struct stat layout. statx is
     architecture-independent by design, so _pack_statx is portable.
 """
@@ -166,10 +167,14 @@ class Namespace:
             return None
         return path[len(PREFIX):]
 
-    def head(self, key: str) -> ObjectMeta:
+    # head()/get() are async: the handlers `await` them, which is what runs
+    # the handler off the supervisor loop. FakeS3's backend is synchronous
+    # and instant, so we call it directly; a real client (boto3's async
+    # variant, an aiohttp S3 client) would `await` its network call here.
+    async def head(self, key: str) -> ObjectMeta:
         return self._backend.head(key)
 
-    def get(self, key: str) -> bytes:
+    async def get(self, key: str) -> bytes:
         with self._lock:
             if key in self._body_cache:
                 return self._body_cache[key]
@@ -250,7 +255,16 @@ def _pack_statx(meta: ObjectMeta) -> bytes:
 class _NamespaceHandler(Handler):
     """Base: holds the shared Namespace. handle() maps its own errors to
     errno, so the KILL default never fires; DENY_EIO is a last-resort
-    backstop."""
+    backstop.
+
+    handle() is an `async def`, which runs it off the supervisor's
+    notification loop. A real backend's head()/get() is a network
+    round-trip; run inline it would block the single supervisor task (and
+    hold the GIL) for its full duration, stalling every other trapped
+    syscall. As an async handler it runs on a worker and `await`s the
+    fetch, so the loop stays free and concurrent fetches overlap. FakeS3
+    is instant so this changes nothing here, but it is what makes a real
+    backend viable beyond a demo."""
 
     on_exception = ExceptionPolicy.DENY_EIO
 
@@ -261,7 +275,7 @@ class _NamespaceHandler(Handler):
 class OpenatHandler(_NamespaceHandler):
     """openat(dirfd, pathname, flags, mode): inject a memfd of the object."""
 
-    def handle(self, ctx: HandlerCtx) -> NotifAction:
+    async def handle(self, ctx: HandlerCtx) -> NotifAction:
         key = self._ns.key_for(ctx.read_path())  # openat path arg inferred
         if key is None:
             return NotifAction.continue_()        # not ours: kernel handles it
@@ -271,7 +285,7 @@ class OpenatHandler(_NamespaceHandler):
             return NotifAction.errno(errno.EROFS)  # read-only, no writes
 
         try:
-            data = self._ns.get(key)               # S3 GetObject
+            data = await self._ns.get(key)         # S3 GetObject (off-loop)
         except Exception as e:
             return NotifAction.errno(_errno_for(e))
 
@@ -291,12 +305,12 @@ class OpenatHandler(_NamespaceHandler):
 class NewfstatatHandler(_NamespaceHandler):
     """newfstatat(dirfd, pathname, statbuf, flags): write a struct stat."""
 
-    def handle(self, ctx: HandlerCtx) -> NotifAction:
+    async def handle(self, ctx: HandlerCtx) -> NotifAction:
         key = self._ns.key_for(ctx.read_path(arg=1))
         if key is None:
             return NotifAction.continue_()
         try:
-            meta = self._ns.head(key)              # S3 HeadObject
+            meta = await self._ns.head(key)        # S3 HeadObject (off-loop)
         except Exception as e:
             return NotifAction.errno(_errno_for(e))
         if not ctx.write(ctx.args[2], _pack_stat(meta)):  # args[2] = statbuf
@@ -307,12 +321,12 @@ class NewfstatatHandler(_NamespaceHandler):
 class StatxHandler(_NamespaceHandler):
     """statx(dirfd, pathname, flags, mask, statxbuf): write a struct statx."""
 
-    def handle(self, ctx: HandlerCtx) -> NotifAction:
+    async def handle(self, ctx: HandlerCtx) -> NotifAction:
         key = self._ns.key_for(ctx.read_path(arg=1))
         if key is None:
             return NotifAction.continue_()
         try:
-            meta = self._ns.head(key)              # S3 HeadObject
+            meta = await self._ns.head(key)        # S3 HeadObject (off-loop)
         except Exception as e:
             return NotifAction.errno(_errno_for(e))
         if not ctx.write(ctx.args[4], _pack_statx(meta)):  # args[4] = statxbuf

--- a/python/examples/s3_handlers.py
+++ b/python/examples/s3_handlers.py
@@ -289,17 +289,12 @@ class OpenatHandler(_NamespaceHandler):
         except Exception as e:
             return NotifAction.errno(_errno_for(e))
 
-        fd = os.memfd_create(f"s3:{key}", os.MFD_CLOEXEC)
+        # inject_bytes builds the (sealed, read-only) memfd, rewinds it, and
+        # transfers fd ownership to the supervisor — no manual memfd dance.
         try:
-            os.write(fd, data)
-            os.lseek(fd, 0, os.SEEK_SET)  # ADDFD shares the offset, so rewind
+            return NotifAction.inject_bytes(data, cloexec=bool(flags & os.O_CLOEXEC))
         except OSError:
-            os.close(fd)
             return NotifAction.errno(errno.EIO)
-
-        # Ownership of fd transfers to the supervisor, so do NOT close it here.
-        newfd_flags = os.O_CLOEXEC if (flags & os.O_CLOEXEC) else 0
-        return NotifAction.inject_fd_send(fd, newfd_flags)
 
 
 class NewfstatatHandler(_NamespaceHandler):

--- a/python/src/sandlock/_handler_ffi.py
+++ b/python/src/sandlock/_handler_ffi.py
@@ -31,7 +31,9 @@ registry entry.
 
 from __future__ import annotations
 
+import asyncio
 import ctypes
+import inspect
 import threading
 from typing import Dict
 
@@ -125,6 +127,15 @@ def _trampoline_impl(ud, notif_ptr, mem_ptr, out_ptr) -> int:
     try:
         try:
             action = handler.handle(ctx)
+            if inspect.iscoroutine(action):
+                # `async def handle`: drive the coroutine to completion on
+                # this worker thread. Async handlers are always deferred (see
+                # sandbox._is_deferred_handler), so this runs off the
+                # supervisor loop and `await` does not stall other syscalls.
+                # The mem handle stays valid until the finally below, so
+                # child-memory access inside the coroutine works; awaits
+                # release the GIL, so concurrent async handlers overlap.
+                action = asyncio.run(action)
         except BaseException:
             # Any exception → defer to the configured on_exception policy.
             return -1

--- a/python/src/sandlock/_sdk.py
+++ b/python/src/sandlock/_sdk.py
@@ -480,6 +480,9 @@ _lib.sandlock_handler_new.argtypes = [
 _lib.sandlock_handler_free.restype = None
 _lib.sandlock_handler_free.argtypes = [_c_handler_p]
 
+_lib.sandlock_handler_set_deferred.restype = None
+_lib.sandlock_handler_set_deferred.argtypes = [_c_handler_p, ctypes.c_bool]
+
 _lib.sandlock_run_with_handlers.restype = _c_result_p
 _lib.sandlock_run_with_handlers.argtypes = [
     _c_policy_p, ctypes.c_char_p,

--- a/python/src/sandlock/handler.py
+++ b/python/src/sandlock/handler.py
@@ -136,12 +136,30 @@ class Handler:
     inside the supervisor's dispatch path while holding the GIL; a
     handler that blocks (a long sleep, a blocking I/O call, an infinite
     loop) stalls the supervisor and can wedge the entire run.
+
+    Deferral: define ``handle`` as ``async def`` to run it off the
+    supervisor's notification loop, so a slow handler (a network round-trip,
+    a blocking call) does not stall every other trapped syscall. The
+    coroutine is driven to completion on a worker thread, and for I/O-bound
+    work multiple async handlers overlap (the GIL is released during
+    blocking I/O). Trade-offs: an async handler makes a *terminal*
+    decision: deferral short-circuits the handler chain, so if it returns
+    ``continue_()`` and other handlers are registered on the same syscall,
+    those later handlers do not run. Deferral is refused for
+    ``execve``/``execveat`` and fork-creating syscalls (the response cannot
+    be moved off-loop without skipping argv-safety work); such a call is
+    denied with EPERM.
     """
 
     on_exception: ExceptionPolicy = ExceptionPolicy.KILL
 
     def handle(self, ctx: HandlerCtx) -> NotifAction:
         """Override in a subclass to inspect ``ctx`` and return a NotifAction.
+
+        May be defined as ``async def`` to run off the supervisor loop: its
+        coroutine is driven to completion on a worker thread, so it may
+        ``await`` slow work (network I/O, etc.) without stalling other
+        trapped syscalls, and concurrent async handlers overlap during I/O.
 
         Raising an exception triggers the configured ``on_exception``
         policy. Returning a non-NotifAction value is treated as an

--- a/python/src/sandlock/handler.py
+++ b/python/src/sandlock/handler.py
@@ -99,6 +99,53 @@ class NotifAction:
             newfd_flags=newfd_flags,
         )
 
+    @classmethod
+    def inject_bytes(
+        cls,
+        data: bytes,
+        *,
+        seal: bool = True,
+        cloexec: bool = True,
+    ) -> NotifAction:
+        """Inject ``data`` into the child as the syscall's returned fd.
+
+        Builds an in-memory file (``memfd``) populated with ``data`` and
+        rewound to offset 0, then returns an inject-fd action for it. Use
+        this for synthetic file content (secrets, virtual files, fetched
+        objects) instead of hand-rolling ``os.memfd_create``.
+
+        By default the fd is sealed read-only/fixed-size so the guest cannot
+        modify or resize the content (pass ``seal=False`` for a writable fd),
+        and the child-side fd is ``O_CLOEXEC`` (pass ``cloexec=False`` to
+        clear it).
+
+        Like :meth:`inject_fd_send`, ownership of the created fd transfers to
+        the supervisor on dispatch; the caller must NOT close it. A rare
+        allocation failure raises :class:`OSError`, which the handler's
+        ``on_exception`` policy then governs.
+        """
+        import fcntl
+        import os
+
+        mfd_flags = os.MFD_CLOEXEC
+        if seal:
+            mfd_flags |= os.MFD_ALLOW_SEALING
+        fd = os.memfd_create("sandlock-content", mfd_flags)
+        try:
+            os.write(fd, data)
+            os.lseek(fd, 0, os.SEEK_SET)
+            if seal:
+                fcntl.fcntl(
+                    fd,
+                    fcntl.F_ADD_SEALS,
+                    fcntl.F_SEAL_SEAL | fcntl.F_SEAL_WRITE
+                    | fcntl.F_SEAL_GROW | fcntl.F_SEAL_SHRINK,
+                )
+        except OSError:
+            os.close(fd)  # not yet handed off, so we still own it
+            raise
+        return cls.inject_fd_send(fd, newfd_flags=os.O_CLOEXEC if cloexec else 0)
+
 
 class ExceptionPolicy(enum.IntEnum):
     """Maps to sandlock_exception_policy_t in the C ABI.

--- a/python/src/sandlock/sandbox.py
+++ b/python/src/sandlock/sandbox.py
@@ -8,6 +8,7 @@ time; runtime state (``_native``, ``_handle``) is initialized lazily.
 
 from __future__ import annotations
 
+import inspect
 import re
 from dataclasses import dataclass, field
 from enum import Enum
@@ -602,6 +603,10 @@ class Sandbox:
                         "sandlock_handler_new returned NULL for syscall "
                         f"{syscall_nr}"
                     )
+                # An async `handle` runs off the supervisor loop. Flag the
+                # container before it is handed to the run.
+                if _is_deferred_handler(handler):
+                    _lib.sandlock_handler_set_deferred(container, True)
                 regs[i].syscall_nr = int(syscall_nr)
                 regs[i].handler = container
                 # Ownership now lives in regs[i]; clear the pending ref so
@@ -1035,6 +1040,16 @@ def _encode(s: str) -> bytes:
     if b'\x00' in result:
         raise ValueError(f"NUL byte in string argument: {result!r}")
     return result
+
+
+def _is_deferred_handler(handler) -> bool:
+    """Whether a handler runs off the supervisor loop.
+
+    True when its ``handle`` is an ``async def`` (a coroutine function): the
+    coroutine is driven to completion on a worker thread, which would block
+    the supervisor loop if run inline, so it must be deferred.
+    """
+    return inspect.iscoroutinefunction(getattr(handler, "handle", None))
 
 
 def _resolve_syscall(key) -> int:

--- a/python/tests/test_handler_smoke.py
+++ b/python/tests/test_handler_smoke.py
@@ -688,6 +688,121 @@ def test_run_with_handlers_rejects_non_handler():
 
 
 # ----------------------------------------------------------------
+# Deferred (off-loop) handler dispatch.
+# ----------------------------------------------------------------
+
+
+def test_is_deferred_handler_detects_async():
+    """Registration treats a handler as deferred iff its `handle` is an
+    `async def`. A synchronous handler runs inline. This pins the helper."""
+    from sandlock.sandbox import _is_deferred_handler
+
+    class Sync(Handler):
+        def handle(self, ctx):
+            return NotifAction.continue_()
+
+    class Async(Handler):
+        async def handle(self, ctx):
+            return NotifAction.continue_()
+
+    assert _is_deferred_handler(Sync()) is False
+    assert _is_deferred_handler(Async()) is True
+
+
+def test_async_handle_delivers_errno_e2e(tmp_dir):
+    """An `async def handle` that awaits and then returns errno(EACCES) must
+    make the child's openat fail with EACCES (exit 7). Proves the trampoline
+    drives the coroutine to completion: if it did not, `handle()` would return
+    a coroutine (not a NotifAction), the handler would be treated as failed,
+    and the KILL policy would terminate the child instead (no exit 7)."""
+    if not os.path.exists(_SYSTEM_PYTHON):
+        pytest.skip(f"{_SYSTEM_PYTHON} not available")
+
+    import asyncio  # noqa: F401  (used inside the handler)
+    import errno as _errno
+
+    probe = tmp_dir / "async-errno-probe.txt"
+    probe.write_text("payload\n")
+    probe_path = str(probe)
+
+    class _AsyncDeny(Handler):
+        on_exception = ExceptionPolicy.KILL
+
+        async def handle(self, ctx):
+            import asyncio
+            await asyncio.sleep(0)  # actually suspend on the event loop
+            path = ctx.read_cstr(ctx.args[1], max_len=4096)
+            if path == probe_path:
+                return NotifAction.errno(_errno.EACCES)
+            return NotifAction.continue_()
+
+    sb = sandlock.Sandbox(fs_readable=[*_PYTHON_READABLE, str(tmp_dir)])
+    script = (
+        "import os, sys\n"
+        "try:\n"
+        "    os.open(%r, os.O_RDONLY)\n"
+        "    sys.exit(0)\n"
+        "except OSError as e:\n"
+        "    sys.exit(7 if e.errno == %d else 8)\n" % (probe_path, _errno.EACCES)
+    )
+    result = sb.run_with_handlers(
+        cmd=[_SYSTEM_PYTHON, "-c", script],
+        handlers=[("openat", _AsyncDeny())],
+    )
+    assert not result.success, result
+    assert result.exit_code == 7, (result.exit_code, result.stderr)
+
+
+def test_async_handle_short_circuits_chain_e2e(tmp_dir):
+    """An `async def handle` is auto-deferred, hence terminal: when it
+    continues, a later handler on the same syscall must NOT run. First
+    handler is async and always continues; second denies the probe. The
+    child opening successfully proves the async handler auto-deferred (a
+    non-deferred async handler driven inline would Continue, letting the
+    second handler deny -> child fails)."""
+    if not os.path.exists(_SYSTEM_PYTHON):
+        pytest.skip(f"{_SYSTEM_PYTHON} not available")
+
+    import errno as _errno
+
+    probe = tmp_dir / "async-chain-probe.txt"
+    probe.write_text("payload\n")
+    probe_path = str(probe)
+
+    class _AsyncContinue(Handler):
+        on_exception = ExceptionPolicy.CONTINUE
+
+        async def handle(self, ctx):
+            import asyncio
+            await asyncio.sleep(0)
+            return NotifAction.continue_()
+
+    class _DenyProbe(Handler):
+        on_exception = ExceptionPolicy.KILL
+
+        def handle(self, ctx):
+            path = ctx.read_cstr(ctx.args[1], max_len=4096)
+            if path == probe_path:
+                return NotifAction.errno(_errno.EACCES)
+            return NotifAction.continue_()
+
+    sb = sandlock.Sandbox(fs_readable=[*_PYTHON_READABLE, str(tmp_dir)])
+    script = (
+        "import os, sys\n"
+        "fd = os.open(%r, os.O_RDONLY)\n"
+        "os.close(fd)\n" % probe_path
+    )
+    result = sb.run_with_handlers(
+        cmd=[_SYSTEM_PYTHON, "-c", script],
+        handlers=[("openat", _AsyncContinue()), ("openat", _DenyProbe())],
+    )
+    assert result.success, (
+        "async handler must auto-defer (terminal), so the deny handler never "
+        f"runs; got {result}"
+    )
+
+
+# ----------------------------------------------------------------
 # Handler-registry hygiene. run_with_handlers inserts each Handler
 # into a process-global registry keyed by integer id; the C ABI's
 # ud_drop removes the entry when the supervisor frees the container.

--- a/python/tests/test_handler_smoke.py
+++ b/python/tests/test_handler_smoke.py
@@ -49,6 +49,46 @@ def test_inject_fd_send_rejects_negative_srcfd():
         NotifAction.inject_fd_send(-1)
 
 
+def test_inject_bytes_returns_injectfdsend_with_readable_content():
+    import os
+    a = NotifAction.inject_bytes(b"hello-bytes")
+    assert a.kind == 4  # SANDLOCK_ACTION_INJECT_FD_SEND
+    assert a.newfd_flags == os.O_CLOEXEC
+    try:
+        assert os.pread(a.srcfd, 64, 0) == b"hello-bytes"
+    finally:
+        os.close(a.srcfd)  # not dispatched in this test, so we close it
+
+
+def test_inject_bytes_seals_read_only_by_default():
+    import os, fcntl
+    a = NotifAction.inject_bytes(b"x")
+    try:
+        seals = fcntl.fcntl(a.srcfd, fcntl.F_GET_SEALS)
+        assert seals & fcntl.F_SEAL_WRITE
+    finally:
+        os.close(a.srcfd)
+
+
+def test_inject_bytes_writable_skips_seal():
+    import os, fcntl
+    a = NotifAction.inject_bytes(b"x", seal=False)
+    try:
+        seals = fcntl.fcntl(a.srcfd, fcntl.F_GET_SEALS)
+        assert not (seals & fcntl.F_SEAL_WRITE)
+    finally:
+        os.close(a.srcfd)
+
+
+def test_inject_bytes_no_cloexec_clears_newfd_flags():
+    import os
+    a = NotifAction.inject_bytes(b"x", cloexec=False)
+    try:
+        assert a.newfd_flags == 0
+    finally:
+        os.close(a.srcfd)
+
+
 def test_notif_action_is_frozen():
     import dataclasses
     a = NotifAction.continue_()


### PR DESCRIPTION
## Summary

Adds `NotifAction::Defer` so a handler doing slow work (a network round-trip, a blocking syscall) runs off the single supervisor loop instead of stalling every other trapped syscall. The trapped child stays parked; the response is sent later, keyed by `notif.id`, while the loop keeps processing other notifications.

This branch also adds `NotifAction::inject_bytes`, a content-injection helper that pairs naturally with `Defer`: a deferred handler can fetch content off-loop and hand it to the guest as a sealed in-memory file without hand-rolling a `memfd`. See [Content injection](#content-injection-inject_bytes) below.

## Layers

**Core (sandlock-core)**
- `NotifAction::Defer(Deferred)`: a per-call return value carrying an owned `'static` future. `handle_notification` spawns a worker that drives it and responds by `notif.id`, bounded by a semaphore (`EAGAIN` on saturation).
- Refused with `EPERM` on `execve`/`execveat` and fork-creating syscalls (deferring would skip the argv-safety freeze and process creation-tracking). A nested `Defer` collapses to `EIO`. `Defer` is non-`Continue`, so it short-circuits the handler chain.
- Deferred futures need only `Send + 'static`; `NotifAction` stays `Sync` (so it can live in handler `&self` state) via a sound `unsafe impl Sync for Deferred` (the boxed future is unreachable through a shared `&Deferred`).

**FFI (sandlock-ffi)**
- `sandlock_handler_set_deferred()` plus a flag on the opaque `sandlock_handler_t` (no C ABI break). This is the deferral API for C callers, which have no `async`.

**Python**
- `async def handle` is the deferral opt-in: auto-detected at registration (`inspect.iscoroutinefunction`), its coroutine driven to completion on a worker thread (`asyncio.run`). Concurrent async handlers overlap as the GIL releases during I/O. A synchronous `handle` runs inline.

## Content injection (`inject_bytes`)

Injecting synthetic content (secrets, virtual files, fetched objects) as an `open`/`openat` result previously meant hand-rolling a `memfd` in every handler: create, write, rewind, seal, then juggle fd ownership. That dance was duplicated, and `python/examples/s3_handlers.py` shipped without sealing, leaving injected content guest-writable.

**Core**
- `content_memfd(content, seal) -> OwnedFd` builds, populates, and rewinds an in-memory file (optionally sealed read-only).
- `NotifAction::inject_bytes(content)` wraps it as a sealed, `O_CLOEXEC` `InjectFdSend` and collapses allocation failure to `Errno(EIO)`. `procfs::inject_memfd` now delegates to the primitive.

**FFI**
- `sandlock_action_set_inject_bytes(out, data, len, flags)` copies the bytes, builds the memfd, and reuses the `InjectFdSend` payload (no new action kind). `flags == 0` is the safe default (sealed + `O_CLOEXEC`); `SANDLOCK_INJECT_WRITABLE` / `SANDLOCK_INJECT_NO_CLOEXEC` opt out.

**Python**
- `NotifAction.inject_bytes(data, *, seal=True, cloexec=True)` builds the memfd in-process and routes through `inject_fd_send`; `s3_handlers.py` is refactored onto it, fixing the missing seal.

Defaults favor the dominant case (synthetic, sensitive, read-only content): sealed so the guest cannot modify or resize it, and `O_CLOEXEC` so it does not leak across the guest's `execve` into descendant processes. Both are overridable for the transparent-virtual-file case via `content_memfd` / the C flags / the Python keywords.

## Tests

- Rust: core lib 301, core integration 222 (incl. live Landlock+seccomp handler tests, and a new test where the guest reads back injected bytes for a host-nonexistent path), FFI 49 lib + C smoke + 4 handler-integration, including a pure-C `inject_bytes` check through the cdylib. All green.
- Python: 328, including discriminating e2e tests (async errno delivery, async chain short-circuit), the detection helper, and 5 new `inject_bytes` unit tests.

## Docs / example

- `docs/extension-handlers.md` and `docs/python-handlers.md` updated for both `Defer` and `inject_bytes`.
- `python/examples/s3_handlers.py` converted to `async def handle` and refactored onto `inject_bytes`; verified end to end (object read via injected memfd, `os.stat` via synthesized `struct stat`/`statx`, missing key to ENOENT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
