### PR TITLE
core: error on missing chroot path instead of silently dropping confinement

### DIFF
--- a/crates/sandlock-core/src/chroot/resolve.rs
+++ b/crates/sandlock-core/src/chroot/resolve.rs
@@ -205,6 +205,25 @@ pub fn resolve_chroot_root(
     }
 }
 
+/// Canonicalize the host source of each bind mount, preserving the virtual
+/// destination unchanged.
+///
+/// A host path that cannot be canonicalized falls back to the path as given:
+/// unlike the chroot root (which gates confinement), a mount source may be
+/// created later or resolved relative to another mount, so a missing source is
+/// not treated as fatal here.
+pub fn resolve_chroot_mounts(mounts: &[(PathBuf, PathBuf)]) -> Vec<(PathBuf, PathBuf)> {
+    mounts
+        .iter()
+        .map(|(virtual_path, host_path)| {
+            (
+                virtual_path.clone(),
+                std::fs::canonicalize(host_path).unwrap_or_else(|_| host_path.clone()),
+            )
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -239,6 +258,26 @@ mod tests {
             matches!(err, crate::error::SandboxError::ChrootNotFound { .. }),
             "expected ChrootNotFound, got: {err:?}"
         );
+    }
+
+    #[test]
+    fn resolve_chroot_mounts_canonicalizes_existing_and_falls_back_on_missing() {
+        let dir = TempDir::new().unwrap();
+        let existing = dir.path().join("src");
+        std::fs::create_dir(&existing).unwrap();
+        let missing = PathBuf::from("/nonexistent/sandlock/mount-src");
+
+        let resolved = resolve_chroot_mounts(&[
+            (PathBuf::from("/data"), existing.clone()),
+            (PathBuf::from("/cache"), missing.clone()),
+        ]);
+
+        // Virtual destinations are preserved verbatim.
+        assert_eq!(resolved[0].0, PathBuf::from("/data"));
+        assert_eq!(resolved[1].0, PathBuf::from("/cache"));
+        // Existing source is canonicalized; missing source falls back as-is.
+        assert_eq!(resolved[0].1, existing.canonicalize().unwrap());
+        assert_eq!(resolved[1].1, missing);
     }
 
     #[test]

--- a/crates/sandlock-core/src/chroot/resolve.rs
+++ b/crates/sandlock-core/src/chroot/resolve.rs
@@ -184,11 +184,62 @@ pub fn resolve_existing_in_root(chroot_root: &Path, child_path: &str) -> Option<
     }
 }
 
+/// Resolve the configured chroot root to a canonical, on-disk path.
+///
+/// `None` chroot yields `Ok(None)`. A configured chroot path that cannot be
+/// canonicalized (missing or inaccessible) is a hard error: silently dropping
+/// it would disable the seccomp-notify chroot mediation without telling the
+/// caller, leaving the workload effectively unconfined.
+pub fn resolve_chroot_root(
+    chroot: Option<&Path>,
+) -> Result<Option<PathBuf>, crate::error::SandboxError> {
+    match chroot {
+        Some(p) => match std::fs::canonicalize(p) {
+            Ok(resolved) => Ok(Some(resolved)),
+            Err(source) => Err(crate::error::SandboxError::ChrootNotFound {
+                path: p.to_path_buf(),
+                source,
+            }),
+        },
+        None => Ok(None),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::os::unix::fs::symlink;
     use tempfile::TempDir;
+
+    #[test]
+    fn resolve_chroot_root_none_is_ok_none() {
+        assert!(resolve_chroot_root(None).unwrap().is_none());
+    }
+
+    #[test]
+    fn resolve_chroot_root_existing_canonicalizes() {
+        // /tmp exists on every supported target.
+        let resolved = resolve_chroot_root(Some(Path::new("/tmp")))
+            .unwrap()
+            .expect("an existing chroot path should resolve to Some");
+        assert!(resolved.is_absolute());
+    }
+
+    #[test]
+    fn resolve_chroot_root_missing_path_errors() {
+        // A configured chroot that does not exist must error rather than
+        // silently disabling confinement. Regression: the old
+        // `canonicalize(p).ok()` swallowed this into `None`, turning off the
+        // seccomp-notify chroot mediation without telling the caller.
+        let err = resolve_chroot_root(Some(Path::new(
+            "/nonexistent/sandlock/rootfs/does-not-exist",
+        )))
+        .unwrap_err();
+        assert!(
+            matches!(err, crate::error::SandboxError::ChrootNotFound { .. }),
+            "expected ChrootNotFound, got: {err:?}"
+        );
+    }
 
     #[test]
     fn test_confine_absolute() {

--- a/crates/sandlock-core/src/error.rs
+++ b/crates/sandlock-core/src/error.rs
@@ -27,6 +27,13 @@ pub enum SandboxError {
 
     #[error("confine() only accepts Landlock filesystem policy; unsupported fields: {0}")]
     UnsupportedForConfine(String),
+
+    #[error("chroot path {path} does not exist or is inaccessible: {source}")]
+    ChrootNotFound {
+        path: std::path::PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
 }
 
 /// Errors from the sandbox process runtime (fork, confinement, child, etc.).

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -1322,9 +1322,7 @@ impl Sandbox {
                 chroot_readable: self.fs_readable.clone(),
                 chroot_writable: self.fs_writable.clone(),
                 chroot_denied: self.fs_denied.clone(),
-                chroot_mounts: self.fs_mount.iter().map(|(vp, hp)| {
-                    (vp.clone(), std::fs::canonicalize(hp).unwrap_or_else(|_| hp.clone()))
-                }).collect(),
+                chroot_mounts: crate::chroot::resolve::resolve_chroot_mounts(&self.fs_mount),
                 deterministic_dirs: self.deterministic_dirs,
                 virtual_hostname: Some(rt_name),
                 has_http_acl: !self.http_allow.is_empty() || !self.http_deny.is_empty(),

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -1111,6 +1111,11 @@ impl Sandbox {
             return Err(SandboxRuntimeError::Child("empty command".into()).into());
         }
 
+        // Resolve the chroot root eagerly, before any fork or confinement work:
+        // a configured-but-missing chroot must be a hard error, never a silent
+        // drop to "no confinement".
+        let chroot_root = crate::chroot::resolve::resolve_chroot_root(self.chroot.as_deref())?;
+
         let c_cmd: Vec<CString> = cmd
             .iter()
             .map(|s| CString::new(*s).map_err(|_| SandboxRuntimeError::Child("invalid command string".into())))
@@ -1313,7 +1318,7 @@ impl Sandbox {
                 num_cpus: self.num_cpus,
                 port_remap: self.port_remap,
                 cow_enabled: self.workdir.is_some(),
-                chroot_root: self.chroot.as_ref().and_then(|p| std::fs::canonicalize(p).ok()),
+                chroot_root: chroot_root.clone(),
                 chroot_readable: self.fs_readable.clone(),
                 chroot_writable: self.fs_writable.clone(),
                 chroot_denied: self.fs_denied.clone(),


### PR DESCRIPTION
## Problem

`Sandbox::do_create` built the runtime chroot root as:

```rust
chroot_root: self.chroot.as_ref().and_then(|p| std::fs::canonicalize(p).ok()),
```

A configured-but-missing (or inaccessible) chroot path was silently swallowed into `None` by `.ok()`. Since the seccomp-notify chroot mediation is gated on `chroot_root.is_some()` (`seccomp/dispatch.rs`, `seccomp/notif.rs`), a `None` root **disables filesystem confinement entirely**, with no error returned to the caller. Nothing upstream caught it either: `build_unchecked()` performs no chroot check and `Sandbox::validate()` is a no-op. There is no real `chroot(2)` syscall (namespace-less, Landlock-based design), so the kernel never rejects the missing directory.

Net effect: requesting `.chroot("/path/that/does/not/exist")` neither errors nor confines.

## Fix

Resolve the chroot root **eagerly, before any fork or confinement work**, and make a missing path a hard error instead of a silent drop:

- New `SandboxError::ChrootNotFound { path, source }`.
- New `chroot::resolve::resolve_chroot_root()` — `Ok(None)` when no chroot is set, `Ok(Some(canonical))` for an existing path, `Err(ChrootNotFound)` when canonicalization fails.
- `do_create` calls it via `?` up front, covering all entry points (`create`, `create_interactive`, `run`, `spawn`, …), including `build_unchecked` callers.

This is fixed in `sandlock-core` independently of any consumer.

## Refactor (second commit)

Consolidated chroot path-resolution logic out of the ~2300-line `sandbox.rs` into the existing `chroot/resolve.rs` module (next to `confine`, `to_virtual_path`, `resolve_in_root`):

- Moved `resolve_chroot_root` there.
- Extracted the bind-mount host-path canonicalization into `resolve_chroot_mounts()`.

`sandbox.rs` now contains no chroot resolution logic — only the `Sandbox`/`SandboxBuilder` field, the `.chroot()` builder, runtime wiring, and two delegating calls.

> Note: `resolve_chroot_mounts` preserves the pre-existing behavior where a missing bind-mount *source* falls back to the raw path rather than erroring (pinned by a characterization test). Tightening that is a possible follow-up.

## Tests

- TDD: `resolve_chroot_root_missing_path_errors` was written first and watched fail (`unwrap_err() on an Ok value: None`) before the fix.
- Added `resolve_chroot_root_*` (none / existing / missing) and `resolve_chroot_mounts_*` characterization tests.
- Full `sandlock-core` lib suite: **295 passed, 0 failed**. Whole workspace (core/ffi/cli) builds clean.
