### PR TITLE
core: fail closed on three confinement-path fail-open bugs

### DIFF
--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -336,6 +336,22 @@ fn respond_value(fd: RawFd, id: u64, val: i64) -> io::Result<()> {
     send_resp_raw(fd, &resp)
 }
 
+/// Fail-closed response used when fd injection fails.
+///
+/// Denies the syscall with `EACCES` rather than letting it continue: a
+/// `SECCOMP_USER_NOTIF_FLAG_CONTINUE` here would let the child's original
+/// syscall run unmediated against the host path, silently bypassing
+/// chroot/file confinement. (Regression guard: this must never be a CONTINUE
+/// response.)
+fn inject_failure_resp(id: u64) -> SeccompNotifResp {
+    SeccompNotifResp {
+        id,
+        val: 0,
+        error: -libc::EACCES,
+        flags: 0,
+    }
+}
+
 /// Inject a file descriptor into the child process using SECCOMP_ADDFD_FLAG_SEND.
 ///
 /// Uses the SEND flag to atomically inject the fd and respond to the syscall.
@@ -564,11 +580,12 @@ fn send_response(fd: RawFd, id: u64, action: NotifAction) -> io::Result<()> {
         NotifAction::InjectFdSend { srcfd, newfd_flags } => {
             // SECCOMP_ADDFD_FLAG_SEND atomically injects the fd and responds.
             // No separate NOTIF_SEND needed after this.
-            // Fall back to Continue if ADDFD_SEND fails (e.g., old kernel).
+            // On failure, deny (fail closed) rather than letting the original
+            // syscall continue unmediated against the host path.
             // srcfd (OwnedFd) is dropped at end of this arm, closing the fd.
             match inject_fd_and_send(fd, id, srcfd.as_raw_fd(), newfd_flags) {
                 Ok(_new_fd) => Ok(()),
-                Err(_) => respond_continue(fd, id),
+                Err(_) => send_resp_raw(fd, &inject_failure_resp(id)),
             }
         }
         NotifAction::InjectFdSendTracked { srcfd, newfd_flags, on_success } => {
@@ -577,7 +594,7 @@ fn send_response(fd: RawFd, id: u64, action: NotifAction) -> io::Result<()> {
                     (on_success.0)(new_fd);
                     Ok(())
                 }
-                Err(_) => respond_continue(fd, id),
+                Err(_) => send_resp_raw(fd, &inject_failure_resp(id)),
             }
         }
         NotifAction::ReturnValue(val) => respond_value(fd, id, val),
@@ -1301,6 +1318,22 @@ mod tests {
 
     fn gettid() -> u32 {
         (unsafe { libc::syscall(libc::SYS_gettid) }) as u32
+    }
+
+    #[test]
+    fn inject_failure_response_denies_not_continues() {
+        // When fd injection fails, the supervisor must fail closed: deny the
+        // syscall instead of letting it continue unmediated against the host
+        // path (which would silently bypass chroot/file confinement).
+        let resp = inject_failure_resp(123);
+        assert_eq!(resp.id, 123);
+        assert_eq!(
+            resp.flags & SECCOMP_USER_NOTIF_FLAG_CONTINUE,
+            0,
+            "fd-injection failure must not respond with CONTINUE"
+        );
+        assert_ne!(resp.error, 0, "fd-injection failure must be a denial");
+        assert_eq!(resp.error, -libc::EACCES);
     }
 
     #[test]

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -883,6 +883,21 @@ fn read_argv_for_event(notif: &SeccompNotif, argv_ptr: u64, notif_fd: RawFd) -> 
     if args.is_empty() { None } else { Some(args) }
 }
 
+/// Resolve a held syscall's policy_fn gate outcome into a verdict.
+///
+/// `received` is the verdict the callback sent, or `None` if the gate timed
+/// out or its channel closed before a decision arrived. A held syscall is one
+/// whose verdict matters (execve, connect, openat, ...); when no decision
+/// arrives we fail closed and deny rather than letting the syscall proceed.
+fn resolve_held_gate(
+    received: Option<crate::policy_fn::Verdict>,
+) -> Option<crate::policy_fn::Verdict> {
+    match received {
+        Some(v) => Some(v),
+        None => Some(crate::policy_fn::Verdict::Deny),
+    }
+}
+
 /// Emit a syscall event to the policy_fn callback thread (if active).
 /// Returns the callback's verdict for held syscalls.
 async fn emit_policy_event(
@@ -974,10 +989,11 @@ async fn emit_policy_event(
             event,
             gate: Some(gate_tx),
         });
-        match tokio::time::timeout(std::time::Duration::from_secs(5), gate_rx).await {
+        let received = match tokio::time::timeout(std::time::Duration::from_secs(5), gate_rx).await {
             Ok(Ok(verdict)) => Some(verdict),
-            _ => None, // timeout or channel closed — allow
-        }
+            _ => None, // timeout or channel closed
+        };
+        resolve_held_gate(received)
     } else {
         let _ = tx.send(crate::policy_fn::PolicyEvent {
             event,
@@ -1334,6 +1350,32 @@ mod tests {
         );
         assert_ne!(resp.error, 0, "fd-injection failure must be a denial");
         assert_eq!(resp.error, -libc::EACCES);
+    }
+
+    #[test]
+    fn held_gate_no_decision_denies() {
+        use crate::policy_fn::Verdict;
+        // A held syscall whose policy_fn gate times out or whose channel closes
+        // (received == None) must fail closed: deny, not allow the syscall.
+        assert!(matches!(resolve_held_gate(None), Some(Verdict::Deny)));
+    }
+
+    #[test]
+    fn held_gate_passes_through_callback_verdict() {
+        use crate::policy_fn::Verdict;
+        // A real verdict from the callback is forwarded unchanged.
+        assert!(matches!(
+            resolve_held_gate(Some(Verdict::Allow)),
+            Some(Verdict::Allow)
+        ));
+        assert!(matches!(
+            resolve_held_gate(Some(Verdict::Deny)),
+            Some(Verdict::Deny)
+        ));
+        assert!(matches!(
+            resolve_held_gate(Some(Verdict::DenyWith(13))),
+            Some(Verdict::DenyWith(13))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

2 independent fail-open bugs on the sandbox confinement path, each fixed to **fail closed**. All found while auditing for the same `.ok()`/silent-degrade pattern as the chroot fix (#79); this PR is separate from that one. Each fix is its own commit with a detailed body, developed test-first.

## 1. seccomp fd-injection silently fell back to "allow" (`seccomp/notif.rs`)

fd injection (`SECCOMP_ADDFD_FLAG_SEND`) is how chroot/file-access mediation works: the supervisor opens the path *inside* the chroot and hands the child a confined descriptor. On injection failure the supervisor responded with `SECCOMP_USER_NOTIF_FLAG_CONTINUE`, letting the child's original syscall run **unmediated against the host path** — a silent chroot/file-confinement bypass. There is no `ADDFD_SEND` capability probe, so this fired on any injection error (e.g. transient `EMFILE`), not only old kernels.

**Fix:** deny with `EACCES` on injection failure. Behavior change: on kernels lacking `ADDFD_SEND`, mediated syscalls now fail rather than running unconfined.

## 2. policy_fn gate timeout → allow (`seccomp/notif.rs`)

Held syscalls (`execve`, `execveat`, `connect`, `sendto`, `bind`, `openat`) block on the user `policy_fn` verdict with a 5s timeout. On timeout or a closed channel the supervisor returned no verdict, which the caller treats as "allow". A slow/hung/dropped policy callback silently let the held syscall through.

**Fix:** no decision now fails closed (`Verdict::Deny` -> `EPERM`), factored into `resolve_held_gate`. The legitimate no-verdict paths (no `policy_fn`; non-held fire-and-forget syscalls) are unchanged.

## Tests

Each fix developed test-first (RED watched fail, then GREEN): 6 new unit tests pinning the fail-closed disposition and the legitimate pass-through paths. Full `sandlock-core` lib suite: **301 passed, 0 failed**. Whole workspace builds clean.
