### PR TITLE
landlock: fix disable() of FS protections; reject disable(FsRefer)

### DIFF
--- a/crates/sandlock-cli/src/main.rs
+++ b/crates/sandlock-cli/src/main.rs
@@ -128,7 +128,9 @@ struct RunArgs {
     allow_degraded: Vec<String>,
 
     /// Disable the named protection entirely (no rule emitted, no error on missing ABI).
-    /// Repeatable. Accepts the same values as --allow-degraded.
+    /// Repeatable. Accepts the same values as --allow-degraded, except fs-refer:
+    /// the kernel denies REFER by default even when unhandled, so disabling it
+    /// only tightens the sandbox and is rejected.
     #[arg(long = "disable", value_name = "PROTECTION")]
     disable: Vec<String>,
 

--- a/crates/sandlock-core/src/landlock.rs
+++ b/crates/sandlock-core/src/landlock.rs
@@ -420,7 +420,15 @@ fn confine_inner(policy: &Sandbox, handle_net: bool) -> Result<(), SandlockError
     // The PT_INTERP patching in handle_chroot_exec ensures the kernel loads
     // the image's ELF interpreter via an injected fd, not a host path.
     let chroot_root = policy.chroot.as_deref();
-    let fs_write_mask = write_access(abi);
+    // Intersect the per-path write mask with the resolved handled set so
+    // every installed rule is a subset of `handled_access_fs` by
+    // construction. `compute_fs_mask` drops the REFER/TRUNCATE/IOCTL_DEV
+    // bit for any FS protection that is Disabled or Degraded; without this
+    // intersection the writable-path rule would still request the dropped
+    // bit and `landlock_add_rule` would reject it with EINVAL. (The file
+    // path inside `add_path_rule` further narrows this with `& ACCESS_FILE`,
+    // which preserves the subset property.)
+    let fs_write_mask = write_access(abi) & handled_access_fs;
     for path in &policy.fs_writable {
         let host;
         let rule_path = if let Some(root) = chroot_root {

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -1967,6 +1967,14 @@ impl SandboxBuilder {
     /// it. Intended for workloads that legitimately need the capability
     /// the protection blocks (e.g. signalling a sibling process when
     /// `SignalScope` would normally prevent it).
+    ///
+    /// `Protection::FsRefer` cannot be disabled: Landlock denies REFER
+    /// (cross-directory rename/link) by default in every ruleset even when
+    /// it is not handled, so disabling it only tightens the sandbox rather
+    /// than loosening it. `build()` (and `build_unchecked()`) return
+    /// `SandboxError::Invalid` if `disable(Protection::FsRefer)` was called.
+    /// Use [`allow_degraded`](Self::allow_degraded) if you want REFER
+    /// enforced only where the kernel supports it.
     pub fn disable(mut self, protection: Protection) -> Self {
         self.protection_policy.set(protection, ProtectionState::Disabled);
         self
@@ -2227,6 +2235,25 @@ impl SandboxBuilder {
     /// construct sandboxes violating cross-section invariants.
     pub fn build_unchecked(self) -> Result<Sandbox, SandboxError> {
         validate_syscall_names(&self.extra_deny_syscalls)?;
+
+        // Reject disable(FsRefer): the kernel denies REFER (cross-directory
+        // rename/link) by default in every ruleset even when REFER is not
+        // handled. Controlled cross-directory rename within writable areas
+        // works precisely *because* REFER is handled and granted on writable
+        // paths (the Strict and Degradable states do this). Disabling REFER
+        // un-handles it, which can only make rename stricter, never looser,
+        // so it cannot do what disable() promises and is a footgun. Degrading
+        // (allow_degraded) REFER is still meaningful and remains allowed.
+        if self.protection_policy.state(Protection::FsRefer) == ProtectionState::Disabled {
+            return Err(SandboxError::Invalid(
+                "disable(Protection::FsRefer) is not permitted: Landlock denies \
+                 REFER (cross-directory rename/link) by default even when it is \
+                 not handled, so disabling it only tightens the sandbox, never \
+                 loosens it. Remove the disable() call (use allow_degraded() if \
+                 you wanted REFER enforced only where the kernel supports it)."
+                    .into(),
+            ));
+        }
 
         // Validate: max_cpu must be 1-100
         if let Some(cpu) = self.max_cpu {

--- a/crates/sandlock-core/tests/integration/test_protection.rs
+++ b/crates/sandlock-core/tests/integration/test_protection.rs
@@ -353,3 +353,110 @@ fn protection_policy_survives_bincode_round_trip() {
          not reset to strict_all() on load"
     );
 }
+
+// ----------------------------------------------------------------------
+// Regression: disable() of an FS protection must not cause confine to
+// fail with EINVAL when the sandbox has a writable path.
+//
+// `compute_fs_mask` drops the disabled bit (REFER/TRUNCATE/IOCTL_DEV)
+// from `handled_access_fs`, but the per-path write mask is derived from
+// `write_access(abi)` alone. If the two are not intersected, the
+// writable-path rule still requests the dropped bit, which is no longer
+// a subset of the ruleset's handled accesses, and `landlock_add_rule`
+// rejects it with EINVAL, breaking every real sandbox (one that has at
+// least one writable path) under `disable(FsRefer/FsTruncate/FsIoctlDev)`.
+//
+// This must run a real `confine_filesystem` against the host kernel, so
+// it forks: confinement is irreversible. NO_NEW_PRIVS is set in the
+// child so `restrict_self` succeeds; the child then exits 0 only if
+// every `add_path_rule` (including the writable-path rule) was accepted.
+// ----------------------------------------------------------------------
+
+/// Run `confine_filesystem(sandbox)` in a forked child and return true
+/// iff it succeeds end-to-end (child exits 0). Exit codes: 0 = Ok,
+/// 1 = confine_filesystem returned Err (the EINVAL bug), 2 = NO_NEW_PRIVS
+/// prctl failed (harness problem, not the code under test).
+fn confine_filesystem_succeeds_in_child(sandbox: &sandlock_core::Sandbox) -> i32 {
+    let pid = unsafe { libc::fork() };
+    assert!(pid >= 0, "fork failed");
+    if pid == 0 {
+        if unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) } != 0 {
+            unsafe { libc::_exit(2) };
+        }
+        let code = match sandlock_core::landlock::confine_filesystem(sandbox) {
+            Ok(()) => 0,
+            Err(_) => 1,
+        };
+        unsafe { libc::_exit(code) };
+    }
+    let mut status: i32 = 0;
+    unsafe { libc::waitpid(pid, &mut status, 0) };
+    assert!(libc::WIFEXITED(status), "child did not exit normally");
+    libc::WEXITSTATUS(status)
+}
+
+#[test]
+fn disable_fs_protection_with_writable_path_does_not_einval() {
+    // Needs a real v6+ host: the default policy keeps the v6 scope
+    // protections Strict, so confine_filesystem would otherwise abort
+    // with ProtectionUnavailable before reaching the FS rules.
+    if sandlock_core::landlock_abi_version().unwrap_or(0) < 6 {
+        eprintln!("Skipping: Landlock ABI v6 required");
+        return;
+    }
+
+    // A writable path is the trigger: without one, no write rule is
+    // installed and the handled-vs-rule inconsistency never surfaces.
+    // (FsRefer is excluded: disabling it is rejected at build time; see
+    // `disable_fsrefer_is_rejected_at_build` below.)
+    for p in [Protection::FsTruncate, Protection::FsIoctlDev] {
+        let sandbox = sandlock_core::Sandbox::builder()
+            .disable(p)
+            .fs_write("/tmp")
+            .build()
+            .expect("build sandbox");
+
+        assert_eq!(
+            confine_filesystem_succeeds_in_child(&sandbox),
+            0,
+            "disable({:?}) + fs_write(\"/tmp\") must confine cleanly, \
+             not fail with EINVAL when installing the writable-path rule",
+            p
+        );
+    }
+}
+
+// ----------------------------------------------------------------------
+// disable(FsRefer) is a footgun: Landlock denies REFER by default even
+// when unhandled, so disabling it can only tighten the sandbox, never
+// loosen it (contrary to what `disable()` promises). It is rejected at
+// build time. `allow_degraded(FsRefer)` stays meaningful and is allowed.
+// ----------------------------------------------------------------------
+
+#[test]
+fn disable_fsrefer_is_rejected_at_build() {
+    let err = sandlock_core::Sandbox::builder()
+        .disable(Protection::FsRefer)
+        .build()
+        .expect_err("disable(FsRefer) must be rejected at build");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("FsRefer"),
+        "rejection message should name FsRefer, got: {msg}"
+    );
+
+    // The unchecked path must reject it too.
+    assert!(
+        sandlock_core::Sandbox::builder()
+            .disable(Protection::FsRefer)
+            .build_unchecked()
+            .is_err(),
+        "build_unchecked must also reject disable(FsRefer)"
+    );
+
+    // allow_degraded(FsRefer) is still meaningful and must build cleanly.
+    sandlock_core::Sandbox::builder()
+        .allow_degraded(Protection::FsRefer)
+        .build()
+        .expect("allow_degraded(FsRefer) must remain allowed");
+}


### PR DESCRIPTION
Follow-up to the protection opt-out work merged in #71, addressing the blocking review comment about `disable()` of FS protections (https://github.com/multikernel/sandlock/pull/71#issuecomment-4607455519).

## 1. Blocking bug: `disable()` of an FS protection fails with EINVAL when the sandbox has a writable path

`compute_fs_mask` removes the disabled bit (REFER / TRUNCATE / IOCTL_DEV) from `handled_access_fs`, but the per-path write mask was derived from `write_access(abi)` alone. So with `disable(FsTruncate)` (or `FsIoctlDev`, or the now-rejected `FsRefer`) plus any writable path, the writable-path rule still requested the dropped bit, it was no longer a subset of the ruleset's handled accesses, and `landlock_add_rule(2)` rejected it with EINVAL. That broke nearly every real sandbox (any with a writable path). The net path was already gated this way via `net_tcp_active`; the FS path did not get the matching treatment.

Fix (`landlock.rs`): intersect the per-path write mask with the resolved handled set, so every installed rule is a subset by construction.

```rust
let fs_write_mask = write_access(abi) & handled_access_fs;
```

This covers both the directory rule (`access`) and the file rule (`access & ACCESS_FILE`).

Regression test: a forked `confine_filesystem` against the real host kernel with `disable(FsTruncate)` / `disable(FsIoctlDev)` plus `fs_write("/tmp")`, asserting clean confinement. It fails (EINVAL) before the fix and passes after. The existing `mask_contract_tests` could not catch this class because they exercise `compute_fs_mask` in isolation and never install a path rule.

## 2. `disable(FsRefer)` is rejected at build

Per `landlock(7)`, REFER is denied by default by every ruleset even when it is not handled. Controlled cross-directory rename within writable areas works precisely because REFER is handled and granted on writable paths. Disabling REFER un-handles it, which can only make the sandbox stricter, never looser, so it cannot do what `disable()` promises and is a footgun.

`build()` and `build_unchecked()` now return `SandboxError::Invalid` for `disable(Protection::FsRefer)`, surfaced uniformly through the Rust, C ABI, and Python bindings. `allow_degraded(FsRefer)` stays meaningful and is unchanged. The `disable()` rustdoc and the `--disable` CLI help carry the caveat.

## Validation

Full workspace green on a v7 host: 334 core lib + 242 core integration + 70 FFI/CLI, plus 12 Python protection tests. New tests: `disable_fs_protection_with_writable_path_does_not_einval` and `disable_fsrefer_is_rejected_at_build`.
