### PR TITLE
ffi: add user data to policy callback

### DIFF
--- a/crates/sandlock-ffi/cbindgen.toml
+++ b/crates/sandlock-ffi/cbindgen.toml
@@ -52,7 +52,11 @@ parse_deps = false
 # Force-emit the two action/exception enums: they are referenced from Rust only
 # via `... as u32` casts, never as a typed field or parameter, so cbindgen would
 # otherwise drop them as unreferenced even though their constants are public ABI.
-include = ["sandlock_action_kind_t", "sandlock_exception_policy_t"]
+include = [
+    "sandlock_action_kind_t",
+    "sandlock_exception_policy_t",
+    "sandlock_policy_ud_drop_t",
+]
 exclude = [
     "SandboxBuilder",
     "Sandbox",

--- a/crates/sandlock-ffi/include/sandlock.h
+++ b/crates/sandlock-ffi/include/sandlock.h
@@ -162,7 +162,9 @@ typedef struct {
  * Return value: 0 = allow, -1 = deny (EPERM), -2 = audit (allow + flag),
  * positive = deny with that errno (e.g. 13 = EACCES).
  */
-typedef int32_t (*sandlock_policy_fn_t)(const sandlock_event_t *event, sandlock_ctx_t *ctx);
+typedef int32_t (*sandlock_policy_fn_t)(const sandlock_event_t *event,
+                                        sandlock_ctx_t *ctx,
+                                        void *user_data);
 
 /**
  * C callback types for fork init and work functions.
@@ -259,6 +261,15 @@ typedef struct {
   int64_t syscall_nr;
   sandlock_handler_t *handler;
 } sandlock_handler_registration_t;
+
+/**
+ * C destructor type for policy_fn user data.
+ *
+ * Called when the native policy callback is dropped. This may be later than a
+ * single run when the policy has been cloned; it fires once for the final
+ * callback reference.
+ */
+typedef void (*sandlock_policy_ud_drop_t)(void *user_data);
 
 #ifdef __cplusplus
 extern "C" {
@@ -955,10 +966,16 @@ void sandlock_gather_free(sandlock_gather_t *g);
  *
  * # Safety
  * `b` must be a valid builder pointer. `cb` must be a valid function pointer
- * that remains valid for the lifetime of the sandbox.
+ * that remains valid for the lifetime of the sandbox callback.
+ * `user_data` is opaque to Rust and is passed back to every callback
+ * invocation. It must remain valid and be safe to access from the policy-fn
+ * worker thread until `user_data_drop` is invoked. `user_data_drop = None` is
+ * legal when no cleanup is needed; if provided, it must not unwind.
  */
 sandlock_builder_t *sandlock_sandbox_builder_policy_fn(sandlock_builder_t *b,
-                                                       sandlock_policy_fn_t cb);
+                                                       sandlock_policy_fn_t cb,
+                                                       void *user_data,
+                                                       void (*user_data_drop)(void *user_data));
 
 /**
  * Restrict network to the given IPs. Permanent — cannot grant back.

--- a/crates/sandlock-ffi/src/handler/abi.rs
+++ b/crates/sandlock-ffi/src/handler/abi.rs
@@ -5,7 +5,9 @@
 use std::os::unix::io::{IntoRawFd, RawFd};
 use std::slice;
 
-use sandlock_core::seccomp::notif::{content_memfd, read_child_cstr, read_child_mem, write_child_mem};
+use sandlock_core::seccomp::notif::{
+    content_memfd, read_child_cstr, read_child_mem, write_child_mem,
+};
 
 /// `flags` bit for [`sandlock_action_set_inject_bytes`]: leave the injected
 /// memfd writable (do not seal). Default (bit clear) seals it read-only.
@@ -29,7 +31,11 @@ pub struct sandlock_mem_handle_t {
 
 impl sandlock_mem_handle_t {
     pub(super) fn new(notif_fd: RawFd, notif_id: u64, pid: u32) -> Self {
-        Self { notif_fd, notif_id, pid }
+        Self {
+            notif_fd,
+            notif_id,
+            pid,
+        }
     }
 }
 
@@ -237,7 +243,9 @@ impl sandlock_action_out_t {
 /// no-op).
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_action_set_continue(out: *mut sandlock_action_out_t) {
-    if out.is_null() { return; }
+    if out.is_null() {
+        return;
+    }
     (*out).kind = sandlock_action_kind_t::Continue as u32;
 }
 
@@ -250,7 +258,9 @@ pub unsafe extern "C" fn sandlock_action_set_errno(
     out: *mut sandlock_action_out_t,
     errno_value: i32,
 ) {
-    if out.is_null() { return; }
+    if out.is_null() {
+        return;
+    }
     (*out).kind = sandlock_action_kind_t::Errno as u32;
     (*out).payload.errno_value = errno_value;
 }
@@ -264,7 +274,9 @@ pub unsafe extern "C" fn sandlock_action_set_return_value(
     out: *mut sandlock_action_out_t,
     value: i64,
 ) {
-    if out.is_null() { return; }
+    if out.is_null() {
+        return;
+    }
     (*out).kind = sandlock_action_kind_t::ReturnValue as u32;
     (*out).payload.return_value = value;
 }
@@ -289,7 +301,9 @@ pub unsafe extern "C" fn sandlock_action_set_inject_fd_send(
     srcfd: RawFd,
     newfd_flags: u32,
 ) {
-    if out.is_null() { return; }
+    if out.is_null() {
+        return;
+    }
     (*out).kind = sandlock_action_kind_t::InjectFdSend as u32;
     (*out).payload.inject_send = sandlock_action_inject_t { srcfd, newfd_flags };
 }
@@ -318,7 +332,9 @@ pub unsafe extern "C" fn sandlock_action_set_inject_bytes(
     len: usize,
     flags: u32,
 ) {
-    if out.is_null() { return; }
+    if out.is_null() {
+        return;
+    }
 
     let seal = flags & SANDLOCK_INJECT_WRITABLE == 0;
     let newfd_flags = if flags & SANDLOCK_INJECT_NO_CLOEXEC == 0 {
@@ -355,7 +371,9 @@ pub unsafe extern "C" fn sandlock_action_set_inject_bytes(
 /// Same constraints as `sandlock_action_set_continue`.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_action_set_hold(out: *mut sandlock_action_out_t) {
-    if out.is_null() { return; }
+    if out.is_null() {
+        return;
+    }
     (*out).kind = sandlock_action_kind_t::Hold as u32;
 }
 
@@ -372,7 +390,9 @@ pub unsafe extern "C" fn sandlock_action_set_kill(
     sig: i32,
     pgid: i32,
 ) {
-    if out.is_null() { return; }
+    if out.is_null() {
+        return;
+    }
     (*out).kind = sandlock_action_kind_t::Kill as u32;
     (*out).payload.kill = sandlock_action_kill_t { sig, pgid };
 }
@@ -550,11 +570,10 @@ pub unsafe extern "C" fn sandlock_handler_new(
 /// `h` must be a non-null pointer returned by `sandlock_handler_new` that has
 /// not yet been registered with a run or freed.
 #[no_mangle]
-pub unsafe extern "C" fn sandlock_handler_set_deferred(
-    h: *mut sandlock_handler_t,
-    deferred: bool,
-) {
-    if h.is_null() { return; }
+pub unsafe extern "C" fn sandlock_handler_set_deferred(h: *mut sandlock_handler_t, deferred: bool) {
+    if h.is_null() {
+        return;
+    }
     (*h).deferred = deferred;
 }
 
@@ -575,7 +594,9 @@ pub unsafe extern "C" fn sandlock_handler_set_deferred(
 /// supervisor and has not already been freed.
 #[no_mangle]
 pub unsafe extern "C-unwind" fn sandlock_handler_free(h: *mut sandlock_handler_t) {
-    if h.is_null() { return; }
+    if h.is_null() {
+        return;
+    }
     drop(Box::from_raw(h));
 }
 
@@ -631,7 +652,10 @@ mod inject_bytes_tests {
         let data = b"rw";
         unsafe {
             sandlock_action_set_inject_bytes(
-                &mut out, data.as_ptr(), data.len(), SANDLOCK_INJECT_WRITABLE,
+                &mut out,
+                data.as_ptr(),
+                data.len(),
+                SANDLOCK_INJECT_WRITABLE,
             )
         };
         assert_eq!(out.kind, sandlock_action_kind_t::InjectFdSend as u32);
@@ -647,7 +671,10 @@ mod inject_bytes_tests {
         let data = b"x";
         unsafe {
             sandlock_action_set_inject_bytes(
-                &mut out, data.as_ptr(), data.len(), SANDLOCK_INJECT_NO_CLOEXEC,
+                &mut out,
+                data.as_ptr(),
+                data.len(),
+                SANDLOCK_INJECT_NO_CLOEXEC,
             )
         };
         let inject = unsafe { out.payload.inject_send };

--- a/crates/sandlock-ffi/src/handler/adapter.rs
+++ b/crates/sandlock-ffi/src/handler/adapter.rs
@@ -12,8 +12,8 @@ use sandlock_core::seccomp::dispatch::{Handler, HandlerCtx};
 use sandlock_core::seccomp::notif::NotifAction;
 
 use super::abi::{
-    sandlock_action_kind_t, sandlock_action_out_t, sandlock_exception_policy_t,
-    sandlock_handler_t, sandlock_mem_handle_t,
+    sandlock_action_kind_t, sandlock_action_out_t, sandlock_exception_policy_t, sandlock_handler_t,
+    sandlock_mem_handle_t,
 };
 
 /// Sentinel for "we cannot safely resolve a process-group id for the
@@ -57,7 +57,9 @@ impl FfiHandler {
     /// supervisor owns the container.
     pub unsafe fn from_raw(raw: *mut sandlock_handler_t) -> Self {
         assert!(!raw.is_null(), "FfiHandler::from_raw on null pointer");
-        Self { inner: Box::from_raw(raw) }
+        Self {
+            inner: Box::from_raw(raw),
+        }
     }
 
     fn exception_action(&self, child_pgid: i32) -> NotifAction {
@@ -73,7 +75,10 @@ impl FfiHandler {
                     // failed syscall.
                     NotifAction::Errno(libc::EPERM)
                 } else {
-                    NotifAction::Kill { sig: libc::SIGKILL, pgid: child_pgid }
+                    NotifAction::Kill {
+                        sig: libc::SIGKILL,
+                        pgid: child_pgid,
+                    }
                 }
             }
             sandlock_exception_policy_t::DenyEperm => NotifAction::Errno(libc::EPERM),
@@ -175,13 +180,14 @@ impl Handler for FfiHandler {
                 let mut mem = sandlock_mem_handle_t::new(notif_fd, notif_id, pid);
                 let mut out = sandlock_action_out_t::zeroed();
                 let rc = match handler_fn {
-                    Some(f) => std::panic::catch_unwind(std::panic::AssertUnwindSafe(
-                        || f(ud_raw, &notif_snap, &mut mem, &mut out),
-                    )),
+                    Some(f) => std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        f(ud_raw, &notif_snap, &mut mem, &mut out)
+                    })),
                     None => Ok(-1),
                 };
                 (rc, out)
-            }).await;
+            })
+            .await;
 
             let (rc_or_panic, out) = match join {
                 Ok(pair) => pair,
@@ -321,7 +327,10 @@ fn translate_action(out: &sandlock_action_out_t, child_pgid: i32) -> Option<Noti
                     if child_pgid == UNSAFE_PGID {
                         return None;
                     }
-                    NotifAction::Kill { sig: out.payload.kill.sig, pgid: child_pgid }
+                    NotifAction::Kill {
+                        sig: out.payload.kill.sig,
+                        pgid: child_pgid,
+                    }
                 } else {
                     // Caller passed an explicit pgid. Defence in depth:
                     // refuse if it matches the supervisor's own group
@@ -334,7 +343,10 @@ fn translate_action(out: &sandlock_action_out_t, child_pgid: i32) -> Option<Noti
                     if user_pgid == supervisor_pgid {
                         return None;
                     }
-                    NotifAction::Kill { sig: out.payload.kill.sig, pgid: user_pgid }
+                    NotifAction::Kill {
+                        sig: out.payload.kill.sig,
+                        pgid: user_pgid,
+                    }
                 }
             }
             K::InjectFdSend => NotifAction::InjectFdSend {

--- a/crates/sandlock-ffi/src/handler/run.rs
+++ b/crates/sandlock-ffi/src/handler/run.rs
@@ -26,10 +26,7 @@ const MAX_ARGV: u32 = 4096;
 /// for the registration array.
 const MAX_REGISTRATIONS: usize = 4096;
 
-fn argv_from_c(
-    argv: *const *const std::os::raw::c_char,
-    argc: u32,
-) -> Option<Vec<String>> {
+fn argv_from_c(argv: *const *const std::os::raw::c_char, argc: u32) -> Option<Vec<String>> {
     if argv.is_null() {
         return None;
     }
@@ -119,13 +116,15 @@ fn block_on_run(
     // `crate::runtime` for why this is `current_thread`. This path is
     // reached from `extern "C-unwind"` entry points, so user callback
     // panics are intentionally allowed to propagate.
-    crate::runtime::with_runtime_unwind(|rt| rt.block_on(async move {
-        if interactive {
-            sb.run_interactive_with_handlers(&cmd_refs, handlers).await
-        } else {
-            sb.run_with_handlers(&cmd_refs, handlers).await
-        }
-    }))
+    crate::runtime::with_runtime_unwind(|rt| {
+        rt.block_on(async move {
+            if interactive {
+                sb.run_interactive_with_handlers(&cmd_refs, handlers).await
+            } else {
+                sb.run_with_handlers(&cmd_refs, handlers).await
+            }
+        })
+    })
 }
 
 /// Run the policy with C handlers. Returns NULL on failure.
@@ -159,7 +158,15 @@ pub unsafe extern "C-unwind" fn sandlock_run_with_handlers(
     registrations: *const sandlock_handler_registration_t,
     nregistrations: usize,
 ) -> *mut crate::sandlock_result_t {
-    run_with_handlers_inner(policy, name, argv, argc, registrations, nregistrations, false)
+    run_with_handlers_inner(
+        policy,
+        name,
+        argv,
+        argc,
+        registrations,
+        nregistrations,
+        false,
+    )
 }
 
 /// Interactive-stdio variant of `sandlock_run_with_handlers`.
@@ -180,7 +187,15 @@ pub unsafe extern "C-unwind" fn sandlock_run_interactive_with_handlers(
     registrations: *const sandlock_handler_registration_t,
     nregistrations: usize,
 ) -> *mut crate::sandlock_result_t {
-    run_with_handlers_inner(policy, name, argv, argc, registrations, nregistrations, true)
+    run_with_handlers_inner(
+        policy,
+        name,
+        argv,
+        argc,
+        registrations,
+        nregistrations,
+        true,
+    )
 }
 
 /// Drops every non-null handler pointer in the registration array.
@@ -202,10 +217,7 @@ pub unsafe extern "C-unwind" fn sandlock_run_interactive_with_handlers(
 /// `sandlock_handler_registration_t` slots whose `handler` pointer is
 /// either null or comes from `sandlock_handler_new` and has not been
 /// freed by anyone else.
-unsafe fn release_registrations(
-    regs: *const sandlock_handler_registration_t,
-    nregs: usize,
-) {
+unsafe fn release_registrations(regs: *const sandlock_handler_registration_t, nregs: usize) {
     if regs.is_null() || nregs == 0 {
         return;
     }

--- a/crates/sandlock-ffi/src/lib.rs
+++ b/crates/sandlock-ffi/src/lib.rs
@@ -4,13 +4,13 @@
 //! using opaque handle patterns.  Each `*mut` / `*const` pointer returned by
 //! these functions must be freed with its corresponding `_free` function.
 
-use std::ffi::{c_char, c_int, c_uint, CStr, CString};
+use std::ffi::{c_char, c_int, c_uint, c_void, CStr, CString};
 use std::ptr;
 use std::time::Duration;
 
 use sandlock_core::pipeline::Stage;
 use sandlock_core::sandbox::{BranchAction, ByteSize, SandboxBuilder};
-use sandlock_core::{Protection, Sandbox, RunResult};
+use sandlock_core::{Protection, RunResult, Sandbox};
 
 pub mod handler;
 pub mod notif_repr;
@@ -74,7 +74,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_fs_read(
     b: *mut SandboxBuilder,
     path: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || path.is_null() { return b; }
+    if b.is_null() || path.is_null() {
+        return b;
+    }
     let path = CStr::from_ptr(path).to_str().unwrap_or("");
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.fs_read(path)))
@@ -87,7 +89,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_fs_write(
     b: *mut SandboxBuilder,
     path: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || path.is_null() { return b; }
+    if b.is_null() || path.is_null() {
+        return b;
+    }
     let path = CStr::from_ptr(path).to_str().unwrap_or("");
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.fs_write(path)))
@@ -100,7 +104,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_fs_deny(
     b: *mut SandboxBuilder,
     path: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || path.is_null() { return b; }
+    if b.is_null() || path.is_null() {
+        return b;
+    }
     let path = CStr::from_ptr(path).to_str().unwrap_or("");
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.fs_deny(path)))
@@ -113,7 +119,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_fs_storage(
     b: *mut SandboxBuilder,
     path: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || path.is_null() { return b; }
+    if b.is_null() || path.is_null() {
+        return b;
+    }
     let path = CStr::from_ptr(path).to_str().unwrap_or("");
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.fs_storage(path)))
@@ -123,9 +131,13 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_fs_storage(
 /// `b` must be a valid pointer. `devices` must point to `len` u32 values (or be null when len == 0).
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_gpu_devices(
-    b: *mut SandboxBuilder, devices: *const u32, len: u32,
+    b: *mut SandboxBuilder,
+    devices: *const u32,
+    len: u32,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || (len > 0 && devices.is_null()) { return b; }
+    if b.is_null() || (len > 0 && devices.is_null()) {
+        return b;
+    }
     let slice = if len > 0 {
         std::slice::from_raw_parts(devices, len as usize)
     } else {
@@ -142,7 +154,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_workdir(
     b: *mut SandboxBuilder,
     path: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || path.is_null() { return b; }
+    if b.is_null() || path.is_null() {
+        return b;
+    }
     let path = CStr::from_ptr(path).to_str().unwrap_or("");
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.workdir(path)))
@@ -155,7 +169,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_cwd(
     b: *mut SandboxBuilder,
     path: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || path.is_null() { return b; }
+    if b.is_null() || path.is_null() {
+        return b;
+    }
     let path = CStr::from_ptr(path).to_str().unwrap_or("");
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.cwd(path)))
@@ -168,7 +184,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_chroot(
     b: *mut SandboxBuilder,
     path: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || path.is_null() { return b; }
+    if b.is_null() || path.is_null() {
+        return b;
+    }
     let path = CStr::from_ptr(path).to_str().unwrap_or("");
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.chroot(path)))
@@ -184,7 +202,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_fs_mount(
     virtual_path: *const c_char,
     host_path: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || virtual_path.is_null() || host_path.is_null() { return b; }
+    if b.is_null() || virtual_path.is_null() || host_path.is_null() {
+        return b;
+    }
     let vp = CStr::from_ptr(virtual_path).to_str().unwrap_or("");
     let hp = CStr::from_ptr(host_path).to_str().unwrap_or("");
     let builder = *Box::from_raw(b);
@@ -201,7 +221,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_on_exit(
     b: *mut SandboxBuilder,
     action: u8,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     let action = match action {
         1 => BranchAction::Abort,
@@ -221,7 +243,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_on_error(
     b: *mut SandboxBuilder,
     action: u8,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     let action = match action {
         1 => BranchAction::Abort,
@@ -239,9 +263,12 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_on_error(
 /// `b` must be a valid builder pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_max_memory(
-    b: *mut SandboxBuilder, bytes: u64,
+    b: *mut SandboxBuilder,
+    bytes: u64,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.max_memory(ByteSize(bytes))))
 }
@@ -250,9 +277,12 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_max_memory(
 /// `b` must be a valid builder pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_max_disk(
-    b: *mut SandboxBuilder, bytes: u64,
+    b: *mut SandboxBuilder,
+    bytes: u64,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.max_disk(ByteSize(bytes))))
 }
@@ -261,9 +291,12 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_max_disk(
 /// `b` must be a valid builder pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_max_processes(
-    b: *mut SandboxBuilder, n: u32,
+    b: *mut SandboxBuilder,
+    n: u32,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.max_processes(n)))
 }
@@ -272,9 +305,12 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_max_processes(
 /// `b` must be a valid builder pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_max_cpu(
-    b: *mut SandboxBuilder, pct: u8,
+    b: *mut SandboxBuilder,
+    pct: u8,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.max_cpu(pct)))
 }
@@ -283,9 +319,12 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_max_cpu(
 /// `b` must be a valid builder pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_num_cpus(
-    b: *mut SandboxBuilder, n: u32,
+    b: *mut SandboxBuilder,
+    n: u32,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.num_cpus(n)))
 }
@@ -294,9 +333,13 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_num_cpus(
 /// `b` must be a valid builder pointer.  `cores` must point to `len` u32 values.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_cpu_cores(
-    b: *mut SandboxBuilder, cores: *const u32, len: u32,
+    b: *mut SandboxBuilder,
+    cores: *const u32,
+    len: u32,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || (len > 0 && cores.is_null()) { return b; }
+    if b.is_null() || (len > 0 && cores.is_null()) {
+        return b;
+    }
     let slice = if len > 0 {
         std::slice::from_raw_parts(cores, len as usize)
     } else {
@@ -318,9 +361,12 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_cpu_cores(
 /// `b` and `spec` must be valid pointers.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_net_allow(
-    b: *mut SandboxBuilder, spec: *const c_char,
+    b: *mut SandboxBuilder,
+    spec: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || spec.is_null() { return b; }
+    if b.is_null() || spec.is_null() {
+        return b;
+    }
     let spec = CStr::from_ptr(spec).to_str().unwrap_or("");
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.net_allow(spec)))
@@ -330,9 +376,12 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_net_allow(
 /// `b` and `spec` must be valid pointers.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_net_deny(
-    b: *mut SandboxBuilder, spec: *const c_char,
+    b: *mut SandboxBuilder,
+    spec: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || spec.is_null() { return b; }
+    if b.is_null() || spec.is_null() {
+        return b;
+    }
     let spec = CStr::from_ptr(spec).to_str().unwrap_or("");
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.net_deny(spec)))
@@ -342,9 +391,12 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_net_deny(
 /// `b` must be a valid builder pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_net_allow_bind_port(
-    b: *mut SandboxBuilder, port: u16,
+    b: *mut SandboxBuilder,
+    port: u16,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.net_allow_bind_port(port)))
 }
@@ -353,9 +405,12 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_net_allow_bind_port(
 /// `b` must be a valid builder pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_net_deny_bind_port(
-    b: *mut SandboxBuilder, port: u16,
+    b: *mut SandboxBuilder,
+    port: u16,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.net_deny_bind_port(port)))
 }
@@ -364,9 +419,12 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_net_deny_bind_port(
 /// `b` must be a valid builder pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_port_remap(
-    b: *mut SandboxBuilder, v: bool,
+    b: *mut SandboxBuilder,
+    v: bool,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.port_remap(v)))
 }
@@ -381,9 +439,12 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_port_remap(
 /// `b` must be a valid builder pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_uid(
-    b: *mut SandboxBuilder, id: u32,
+    b: *mut SandboxBuilder,
+    id: u32,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.uid(id)))
 }
@@ -399,7 +460,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_http_allow(
     b: *mut SandboxBuilder,
     rule: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || rule.is_null() { return b; }
+    if b.is_null() || rule.is_null() {
+        return b;
+    }
     let rule = CStr::from_ptr(rule).to_str().unwrap_or("");
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.http_allow(rule)))
@@ -412,7 +475,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_http_deny(
     b: *mut SandboxBuilder,
     rule: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || rule.is_null() { return b; }
+    if b.is_null() || rule.is_null() {
+        return b;
+    }
     let rule = CStr::from_ptr(rule).to_str().unwrap_or("");
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.http_deny(rule)))
@@ -425,7 +490,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_http_port(
     b: *mut SandboxBuilder,
     port: u16,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.http_port(port)))
 }
@@ -437,7 +504,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_http_ca(
     b: *mut SandboxBuilder,
     path: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || path.is_null() { return b; }
+    if b.is_null() || path.is_null() {
+        return b;
+    }
     let path = CStr::from_ptr(path).to_str().unwrap_or("");
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.http_ca(path)))
@@ -450,7 +519,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_http_key(
     b: *mut SandboxBuilder,
     path: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || path.is_null() { return b; }
+    if b.is_null() || path.is_null() {
+        return b;
+    }
     let path = CStr::from_ptr(path).to_str().unwrap_or("");
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.http_key(path)))
@@ -463,7 +534,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_http_inject_ca(
     b: *mut SandboxBuilder,
     path: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || path.is_null() { return b; }
+    if b.is_null() || path.is_null() {
+        return b;
+    }
     let path = CStr::from_ptr(path).to_str().unwrap_or("");
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.http_inject_ca(path)))
@@ -476,7 +549,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_http_ca_out(
     b: *mut SandboxBuilder,
     path: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || path.is_null() { return b; }
+    if b.is_null() || path.is_null() {
+        return b;
+    }
     let path = CStr::from_ptr(path).to_str().unwrap_or("");
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.http_ca_out(path)))
@@ -490,9 +565,12 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_http_ca_out(
 /// `b` must be a valid builder pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_random_seed(
-    b: *mut SandboxBuilder, seed: u64,
+    b: *mut SandboxBuilder,
+    seed: u64,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.random_seed(seed)))
 }
@@ -501,9 +579,12 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_random_seed(
 /// `b` must be a valid builder pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_clean_env(
-    b: *mut SandboxBuilder, v: bool,
+    b: *mut SandboxBuilder,
+    v: bool,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.clean_env(v)))
 }
@@ -512,9 +593,13 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_clean_env(
 /// `b`, `key`, and `value` must be valid pointers.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_env_var(
-    b: *mut SandboxBuilder, key: *const c_char, value: *const c_char,
+    b: *mut SandboxBuilder,
+    key: *const c_char,
+    value: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || key.is_null() || value.is_null() { return b; }
+    if b.is_null() || key.is_null() || value.is_null() {
+        return b;
+    }
     let key = CStr::from_ptr(key).to_str().unwrap_or("");
     let value = CStr::from_ptr(value).to_str().unwrap_or("");
     let builder = *Box::from_raw(b);
@@ -525,9 +610,12 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_env_var(
 /// `b` must be a valid builder pointer. `epoch_secs` is seconds since UNIX epoch.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_time_start(
-    b: *mut SandboxBuilder, epoch_secs: u64,
+    b: *mut SandboxBuilder,
+    epoch_secs: u64,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     let t = std::time::UNIX_EPOCH + Duration::from_secs(epoch_secs);
     Box::into_raw(Box::new(builder.time_start(t)))
@@ -537,12 +625,19 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_time_start(
 /// `b` must be a valid builder pointer. `names` is a comma-separated NUL-terminated string.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_extra_deny_syscalls(
-    b: *mut SandboxBuilder, names: *const c_char,
+    b: *mut SandboxBuilder,
+    names: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || names.is_null() { return b; }
+    if b.is_null() || names.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     let s = CStr::from_ptr(names).to_str().unwrap_or("");
-    let calls: Vec<String> = s.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
+    let calls: Vec<String> = s
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
     Box::into_raw(Box::new(builder.extra_deny_syscalls(calls)))
 }
 
@@ -550,12 +645,19 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_extra_deny_syscalls(
 /// `b` must be a valid builder pointer. `names` is a comma-separated NUL-terminated string.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_extra_allow_syscalls(
-    b: *mut SandboxBuilder, names: *const c_char,
+    b: *mut SandboxBuilder,
+    names: *const c_char,
 ) -> *mut SandboxBuilder {
-    if b.is_null() || names.is_null() { return b; }
+    if b.is_null() || names.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     let s = CStr::from_ptr(names).to_str().unwrap_or("");
-    let names: Vec<String> = s.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
+    let names: Vec<String> = s
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
     Box::into_raw(Box::new(builder.extra_allow_syscalls(names)))
 }
 
@@ -592,9 +694,12 @@ pub unsafe extern "C" fn sandlock_syscall_nr(name: *const c_char) -> i64 {
 /// `b` must be a valid builder pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_max_open_files(
-    b: *mut SandboxBuilder, n: c_uint,
+    b: *mut SandboxBuilder,
+    n: c_uint,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.max_open_files(n)))
 }
@@ -603,9 +708,12 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_max_open_files(
 /// `b` must be a valid builder pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_no_randomize_memory(
-    b: *mut SandboxBuilder, v: bool,
+    b: *mut SandboxBuilder,
+    v: bool,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.no_randomize_memory(v)))
 }
@@ -614,9 +722,12 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_no_randomize_memory(
 /// `b` must be a valid builder pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_no_huge_pages(
-    b: *mut SandboxBuilder, v: bool,
+    b: *mut SandboxBuilder,
+    v: bool,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.no_huge_pages(v)))
 }
@@ -625,9 +736,12 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_no_huge_pages(
 /// `b` must be a valid builder pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_no_coredump(
-    b: *mut SandboxBuilder, v: bool,
+    b: *mut SandboxBuilder,
+    v: bool,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.no_coredump(v)))
 }
@@ -636,9 +750,12 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_no_coredump(
 /// `b` must be a valid builder pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_deterministic_dirs(
-    b: *mut SandboxBuilder, v: bool,
+    b: *mut SandboxBuilder,
+    v: bool,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
     Box::into_raw(Box::new(builder.deterministic_dirs(v)))
 }
@@ -712,7 +829,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_allow_degraded(
     b: *mut SandboxBuilder,
     protection: u32,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let p = match try_protection_from_raw(protection) {
         Some(p) => p,
         None => return b,
@@ -739,7 +858,9 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_disable(
     b: *mut SandboxBuilder,
     protection: u32,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let p = match try_protection_from_raw(protection) {
         Some(p) => p,
         None => return b,
@@ -765,26 +886,36 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_disable(
 /// storage for one `*mut c_char`.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_build(
-    b: *mut SandboxBuilder, err: *mut c_int, err_msg: *mut *mut c_char,
+    b: *mut SandboxBuilder,
+    err: *mut c_int,
+    err_msg: *mut *mut c_char,
 ) -> *mut sandlock_sandbox_t {
-    if !err_msg.is_null() { *err_msg = ptr::null_mut(); }
+    if !err_msg.is_null() {
+        *err_msg = ptr::null_mut();
+    }
     if b.is_null() {
         // Null-builder is a programmer error in the binding layer,
         // not a policy-validation failure. We surface the err code
         // but deliberately leave err_msg null — there is no
         // user-actionable message and inventing one here would
         // require a hard-coded literal living in the wrong layer.
-        if !err.is_null() { *err = -1; }
+        if !err.is_null() {
+            *err = -1;
+        }
         return ptr::null_mut();
     }
     let builder = *Box::from_raw(b);
     match builder.build() {
         Ok(policy) => {
-            if !err.is_null() { *err = 0; }
+            if !err.is_null() {
+                *err = 0;
+            }
             Box::into_raw(Box::new(sandlock_sandbox_t { _private: policy }))
         }
         Err(e) => {
-            if !err.is_null() { *err = -1; }
+            if !err.is_null() {
+                *err = -1;
+            }
             if !err_msg.is_null() {
                 // CString::new fails only on embedded NULs; thiserror
                 // Display impls don't produce NULs in this codebase,
@@ -803,7 +934,9 @@ pub unsafe extern "C" fn sandlock_sandbox_build(
 /// `p` must be null or a valid pointer from `sandlock_sandbox_build`.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_free(p: *mut sandlock_sandbox_t) {
-    if !p.is_null() { drop(Box::from_raw(p)); }
+    if !p.is_null() {
+        drop(Box::from_raw(p));
+    }
 }
 
 // ----------------------------------------------------------------
@@ -816,10 +949,10 @@ pub unsafe extern "C" fn sandlock_sandbox_free(p: *mut sandlock_sandbox_t) {
 /// # Safety
 /// `policy` must be a valid policy pointer.
 #[no_mangle]
-pub unsafe extern "C" fn sandlock_confine(
-    policy: *const sandlock_sandbox_t,
-) -> c_int {
-    if policy.is_null() { return -1; }
+pub unsafe extern "C" fn sandlock_confine(policy: *const sandlock_sandbox_t) -> c_int {
+    if policy.is_null() {
+        return -1;
+    }
     let policy = &(*policy)._private;
     let confinement = match sandlock_core::sandbox::Confinement::try_from(policy) {
         Ok(c) => c,
@@ -848,7 +981,9 @@ pub unsafe extern "C" fn sandlock_run(
     argv: *const *const c_char,
     argc: c_uint,
 ) -> *mut sandlock_result_t {
-    if policy.is_null() || argv.is_null() { return ptr::null_mut(); }
+    if policy.is_null() || argv.is_null() {
+        return ptr::null_mut();
+    }
     let policy = &(*policy)._private;
     let name = match optional_name(name) {
         Ok(name) => name,
@@ -897,7 +1032,9 @@ unsafe fn sandlock_create_with_runtime(
     argc: c_uint,
     build_rt: fn() -> Option<tokio::runtime::Runtime>,
 ) -> *mut sandlock_handle_t {
-    if policy.is_null() || argv.is_null() { return ptr::null_mut(); }
+    if policy.is_null() || argv.is_null() {
+        return ptr::null_mut();
+    }
     let policy = &(*policy)._private;
     let name = match optional_name(name) {
         Ok(name) => name,
@@ -920,7 +1057,10 @@ unsafe fn sandlock_create_with_runtime(
         return ptr::null_mut();
     }
 
-    Box::into_raw(Box::new(sandlock_handle_t { sandbox: sb, runtime: rt }))
+    Box::into_raw(Box::new(sandlock_handle_t {
+        sandbox: sb,
+        runtime: rt,
+    }))
 }
 
 #[no_mangle]
@@ -961,9 +1101,13 @@ pub unsafe extern "C" fn sandlock_create_for_run(
 /// `h` must be a valid handle from `sandlock_create`.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_start(h: *mut sandlock_handle_t) -> c_int {
-    if h.is_null() { return -1; }
+    if h.is_null() {
+        return -1;
+    }
     let h = &mut *h;
-    if h.sandbox.start().is_err() { return -1; }
+    if h.sandbox.start().is_err() {
+        return -1;
+    }
     0
 }
 
@@ -973,7 +1117,9 @@ pub unsafe extern "C" fn sandlock_start(h: *mut sandlock_handle_t) -> c_int {
 /// `h` must be a valid handle from `sandlock_create`.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_handle_pid(h: *const sandlock_handle_t) -> i32 {
-    if h.is_null() { return 0; }
+    if h.is_null() {
+        return 0;
+    }
     (*h).sandbox.pid().unwrap_or(0)
 }
 
@@ -983,7 +1129,9 @@ pub unsafe extern "C" fn sandlock_handle_pid(h: *const sandlock_handle_t) -> i32
 /// `h` must be a valid handle from `sandlock_create`.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_handle_wait(h: *mut sandlock_handle_t) -> *mut sandlock_result_t {
-    if h.is_null() { return ptr::null_mut(); }
+    if h.is_null() {
+        return ptr::null_mut();
+    }
     let h = &mut *h;
     match block_on_runtime(&h.runtime, h.sandbox.wait()) {
         Some(Ok(result)) => Box::into_raw(Box::new(sandlock_result_t { _private: result })),
@@ -1002,7 +1150,9 @@ pub unsafe extern "C" fn sandlock_handle_wait_timeout(
     h: *mut sandlock_handle_t,
     timeout_ms: u64,
 ) -> *mut sandlock_result_t {
-    if h.is_null() { return ptr::null_mut(); }
+    if h.is_null() {
+        return ptr::null_mut();
+    }
     let h = &mut *h;
 
     if timeout_ms == 0 {
@@ -1035,16 +1185,18 @@ pub unsafe extern "C" fn sandlock_handle_wait_timeout(
 /// # Safety
 /// `h` must be a valid handle from `sandlock_create`.
 #[no_mangle]
-pub unsafe extern "C" fn sandlock_handle_port_mappings(
-    h: *const sandlock_handle_t,
-) -> *mut c_char {
-    if h.is_null() { return ptr::null_mut(); }
+pub unsafe extern "C" fn sandlock_handle_port_mappings(h: *const sandlock_handle_t) -> *mut c_char {
+    if h.is_null() {
+        return ptr::null_mut();
+    }
     let h = &*h;
     let map = match block_on_runtime(&h.runtime, h.sandbox.port_mappings()) {
         Some(map) => map,
         None => return ptr::null_mut(),
     };
-    if map.is_empty() { return ptr::null_mut(); }
+    if map.is_empty() {
+        return ptr::null_mut();
+    }
     let json = serde_json::to_string(&map).unwrap_or_default();
     match CString::new(json) {
         Ok(cs) => cs.into_raw(),
@@ -1077,7 +1229,9 @@ pub unsafe extern "C" fn sandlock_run_interactive(
     argv: *const *const c_char,
     argc: c_uint,
 ) -> c_int {
-    if policy.is_null() || argv.is_null() { return -1; }
+    if policy.is_null() || argv.is_null() {
+        return -1;
+    }
     let policy = &(*policy)._private;
     let name = match optional_name(name) {
         Ok(name) => name,
@@ -1104,7 +1258,9 @@ pub unsafe extern "C" fn sandlock_run_interactive(
 /// `r` must be null or a valid result pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_result_exit_code(r: *const sandlock_result_t) -> c_int {
-    if r.is_null() { return -1; }
+    if r.is_null() {
+        return -1;
+    }
     (*r)._private.code().unwrap_or(-1)
 }
 
@@ -1112,7 +1268,9 @@ pub unsafe extern "C" fn sandlock_result_exit_code(r: *const sandlock_result_t) 
 /// `r` must be null or a valid result pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_result_success(r: *const sandlock_result_t) -> bool {
-    if r.is_null() { return false; }
+    if r.is_null() {
+        return false;
+    }
     (*r)._private.success()
 }
 
@@ -1123,7 +1281,9 @@ pub unsafe extern "C" fn sandlock_result_success(r: *const sandlock_result_t) ->
 /// `r` must be null or a valid result pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_result_stdout(r: *const sandlock_result_t) -> *mut c_char {
-    if r.is_null() { return ptr::null_mut(); }
+    if r.is_null() {
+        return ptr::null_mut();
+    }
     match (*r)._private.stdout.as_ref() {
         Some(bytes) => {
             let s = String::from_utf8_lossy(bytes);
@@ -1142,7 +1302,9 @@ pub unsafe extern "C" fn sandlock_result_stdout(r: *const sandlock_result_t) -> 
 /// `r` must be null or a valid result pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_result_stderr(r: *const sandlock_result_t) -> *mut c_char {
-    if r.is_null() { return ptr::null_mut(); }
+    if r.is_null() {
+        return ptr::null_mut();
+    }
     match (*r)._private.stderr.as_ref() {
         Some(bytes) => {
             let s = String::from_utf8_lossy(bytes);
@@ -1162,12 +1324,21 @@ pub unsafe extern "C" fn sandlock_result_stderr(r: *const sandlock_result_t) -> 
 /// `r` must be a valid result pointer. `len` must be a valid pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_result_stdout_bytes(
-    r: *const sandlock_result_t, len: *mut usize,
+    r: *const sandlock_result_t,
+    len: *mut usize,
 ) -> *const u8 {
-    if r.is_null() || len.is_null() { return ptr::null(); }
+    if r.is_null() || len.is_null() {
+        return ptr::null();
+    }
     match (*r)._private.stdout.as_ref() {
-        Some(bytes) => { *len = bytes.len(); bytes.as_ptr() }
-        None => { *len = 0; ptr::null() }
+        Some(bytes) => {
+            *len = bytes.len();
+            bytes.as_ptr()
+        }
+        None => {
+            *len = 0;
+            ptr::null()
+        }
     }
 }
 
@@ -1177,12 +1348,21 @@ pub unsafe extern "C" fn sandlock_result_stdout_bytes(
 /// `r` must be a valid result pointer. `len` must be a valid pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_result_stderr_bytes(
-    r: *const sandlock_result_t, len: *mut usize,
+    r: *const sandlock_result_t,
+    len: *mut usize,
 ) -> *const u8 {
-    if r.is_null() || len.is_null() { return ptr::null(); }
+    if r.is_null() || len.is_null() {
+        return ptr::null();
+    }
     match (*r)._private.stderr.as_ref() {
-        Some(bytes) => { *len = bytes.len(); bytes.as_ptr() }
-        None => { *len = 0; ptr::null() }
+        Some(bytes) => {
+            *len = bytes.len();
+            bytes.as_ptr()
+        }
+        None => {
+            *len = 0;
+            ptr::null()
+        }
     }
 }
 
@@ -1190,7 +1370,9 @@ pub unsafe extern "C" fn sandlock_result_stderr_bytes(
 /// `r` must be null or a valid pointer from `sandlock_run`.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_result_free(r: *mut sandlock_result_t) {
-    if !r.is_null() { drop(Box::from_raw(r)); }
+    if !r.is_null() {
+        drop(Box::from_raw(r));
+    }
 }
 
 /// Free a string returned by `sandlock_result_stdout` or `sandlock_result_stderr`.
@@ -1199,7 +1381,9 @@ pub unsafe extern "C" fn sandlock_result_free(r: *mut sandlock_result_t) {
 /// `s` must be null or a pointer from a `sandlock_result_std*` function.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_string_free(s: *mut c_char) {
-    if !s.is_null() { drop(CString::from_raw(s)); }
+    if !s.is_null() {
+        drop(CString::from_raw(s));
+    }
 }
 
 // ----------------------------------------------------------------
@@ -1225,7 +1409,9 @@ pub unsafe extern "C" fn sandlock_dry_run(
     argv: *const *const c_char,
     argc: c_uint,
 ) -> *mut sandlock_dry_run_result_t {
-    if policy.is_null() || argv.is_null() { return ptr::null_mut(); }
+    if policy.is_null() || argv.is_null() {
+        return ptr::null_mut();
+    }
     let policy = &(*policy)._private;
     let name = match optional_name(name) {
         Ok(name) => name,
@@ -1249,8 +1435,12 @@ pub unsafe extern "C" fn sandlock_dry_run(
 /// # Safety
 /// `r` must be a valid dry-run result pointer.
 #[no_mangle]
-pub unsafe extern "C" fn sandlock_dry_run_result_exit_code(r: *const sandlock_dry_run_result_t) -> c_int {
-    if r.is_null() { return -1; }
+pub unsafe extern "C" fn sandlock_dry_run_result_exit_code(
+    r: *const sandlock_dry_run_result_t,
+) -> c_int {
+    if r.is_null() {
+        return -1;
+    }
     (*r)._private.run_result.code().unwrap_or(-1) as c_int
 }
 
@@ -1259,8 +1449,12 @@ pub unsafe extern "C" fn sandlock_dry_run_result_exit_code(r: *const sandlock_dr
 /// # Safety
 /// `r` must be a valid dry-run result pointer.
 #[no_mangle]
-pub unsafe extern "C" fn sandlock_dry_run_result_success(r: *const sandlock_dry_run_result_t) -> bool {
-    if r.is_null() { return false; }
+pub unsafe extern "C" fn sandlock_dry_run_result_success(
+    r: *const sandlock_dry_run_result_t,
+) -> bool {
+    if r.is_null() {
+        return false;
+    }
     (*r)._private.run_result.success()
 }
 
@@ -1270,12 +1464,24 @@ pub unsafe extern "C" fn sandlock_dry_run_result_success(r: *const sandlock_dry_
 /// `r` must be a valid dry-run result pointer. `len` must be a valid pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_dry_run_result_stdout_bytes(
-    r: *const sandlock_dry_run_result_t, len: *mut usize,
+    r: *const sandlock_dry_run_result_t,
+    len: *mut usize,
 ) -> *const u8 {
-    if r.is_null() { if !len.is_null() { *len = 0; } return ptr::null(); }
+    if r.is_null() {
+        if !len.is_null() {
+            *len = 0;
+        }
+        return ptr::null();
+    }
     match &(*r)._private.run_result.stdout {
-        Some(v) => { *len = v.len(); v.as_ptr() }
-        None => { *len = 0; ptr::null() }
+        Some(v) => {
+            *len = v.len();
+            v.as_ptr()
+        }
+        None => {
+            *len = 0;
+            ptr::null()
+        }
     }
 }
 
@@ -1285,12 +1491,24 @@ pub unsafe extern "C" fn sandlock_dry_run_result_stdout_bytes(
 /// `r` must be a valid dry-run result pointer. `len` must be a valid pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_dry_run_result_stderr_bytes(
-    r: *const sandlock_dry_run_result_t, len: *mut usize,
+    r: *const sandlock_dry_run_result_t,
+    len: *mut usize,
 ) -> *const u8 {
-    if r.is_null() { if !len.is_null() { *len = 0; } return ptr::null(); }
+    if r.is_null() {
+        if !len.is_null() {
+            *len = 0;
+        }
+        return ptr::null();
+    }
     match &(*r)._private.run_result.stderr {
-        Some(v) => { *len = v.len(); v.as_ptr() }
-        None => { *len = 0; ptr::null() }
+        Some(v) => {
+            *len = v.len();
+            v.as_ptr()
+        }
+        None => {
+            *len = 0;
+            ptr::null()
+        }
     }
 }
 
@@ -1299,8 +1517,12 @@ pub unsafe extern "C" fn sandlock_dry_run_result_stderr_bytes(
 /// # Safety
 /// `r` must be a valid dry-run result pointer.
 #[no_mangle]
-pub unsafe extern "C" fn sandlock_dry_run_result_changes_len(r: *const sandlock_dry_run_result_t) -> usize {
-    if r.is_null() { return 0; }
+pub unsafe extern "C" fn sandlock_dry_run_result_changes_len(
+    r: *const sandlock_dry_run_result_t,
+) -> usize {
+    if r.is_null() {
+        return 0;
+    }
     (*r)._private.changes.len()
 }
 
@@ -1310,11 +1532,16 @@ pub unsafe extern "C" fn sandlock_dry_run_result_changes_len(r: *const sandlock_
 /// `r` must be a valid dry-run result pointer. `i` must be < changes_len.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_dry_run_result_change_kind(
-    r: *const sandlock_dry_run_result_t, i: usize,
+    r: *const sandlock_dry_run_result_t,
+    i: usize,
 ) -> c_char {
-    if r.is_null() { return 0; }
+    if r.is_null() {
+        return 0;
+    }
     let changes = &(*r)._private.changes;
-    if i >= changes.len() { return 0; }
+    if i >= changes.len() {
+        return 0;
+    }
     use sandlock_core::ChangeKind;
     match changes[i].kind {
         ChangeKind::Added => b'A' as c_char,
@@ -1329,11 +1556,16 @@ pub unsafe extern "C" fn sandlock_dry_run_result_change_kind(
 /// `r` must be a valid dry-run result pointer. `i` must be < changes_len.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_dry_run_result_change_path(
-    r: *const sandlock_dry_run_result_t, i: usize,
+    r: *const sandlock_dry_run_result_t,
+    i: usize,
 ) -> *mut c_char {
-    if r.is_null() { return ptr::null_mut(); }
+    if r.is_null() {
+        return ptr::null_mut();
+    }
     let changes = &(*r)._private.changes;
-    if i >= changes.len() { return ptr::null_mut(); }
+    if i >= changes.len() {
+        return ptr::null_mut();
+    }
     let path = changes[i].path.to_string_lossy();
     match CString::new(path.as_bytes()) {
         Ok(cs) => cs.into_raw(),
@@ -1347,7 +1579,9 @@ pub unsafe extern "C" fn sandlock_dry_run_result_change_path(
 /// `r` must be null or a valid dry-run result pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_dry_run_result_free(r: *mut sandlock_dry_run_result_t) {
-    if !r.is_null() { drop(Box::from_raw(r)); }
+    if !r.is_null() {
+        drop(Box::from_raw(r));
+    }
 }
 
 // ----------------------------------------------------------------
@@ -1372,7 +1606,9 @@ pub unsafe extern "C" fn sandlock_pipeline_add_stage(
     argv: *const *const c_char,
     argc: c_uint,
 ) {
-    if pipe.is_null() || policy.is_null() || argv.is_null() { return; }
+    if pipe.is_null() || policy.is_null() || argv.is_null() {
+        return;
+    }
     let policy = (*policy)._private.clone();
     let args = read_argv(argv, argc);
     (*pipe).stages.push((policy, args));
@@ -1388,15 +1624,23 @@ pub unsafe extern "C" fn sandlock_pipeline_run(
     pipe: *mut sandlock_pipeline_t,
     timeout_ms: u64,
 ) -> *mut sandlock_result_t {
-    if pipe.is_null() { return ptr::null_mut(); }
+    if pipe.is_null() {
+        return ptr::null_mut();
+    }
     let pipe = *Box::from_raw(pipe);
 
-    if pipe.stages.len() < 2 { return ptr::null_mut(); }
+    if pipe.stages.len() < 2 {
+        return ptr::null_mut();
+    }
 
-    let mut stages: Vec<Stage> = pipe.stages.into_iter().map(|(policy, args)| {
-        let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-        Stage::new(&policy, &arg_refs)
-    }).collect();
+    let mut stages: Vec<Stage> = pipe
+        .stages
+        .into_iter()
+        .map(|(policy, args)| {
+            let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+            Stage::new(&policy, &arg_refs)
+        })
+        .collect();
 
     // Build pipeline using BitOr
     let first = stages.remove(0);
@@ -1424,7 +1668,9 @@ pub unsafe extern "C" fn sandlock_pipeline_run(
 /// `pipe` must be null or a valid pipeline pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_pipeline_free(pipe: *mut sandlock_pipeline_t) {
-    if !pipe.is_null() { drop(Box::from_raw(pipe)); }
+    if !pipe.is_null() {
+        drop(Box::from_raw(pipe));
+    }
 }
 
 // ----------------------------------------------------------------
@@ -1458,7 +1704,9 @@ pub unsafe extern "C" fn sandlock_gather_add_source(
     argv: *const *const c_char,
     argc: c_uint,
 ) {
-    if g.is_null() || name.is_null() || policy.is_null() || argv.is_null() { return; }
+    if g.is_null() || name.is_null() || policy.is_null() || argv.is_null() {
+        return;
+    }
     let name = CStr::from_ptr(name).to_str().unwrap_or("").to_string();
     let policy = (*policy)._private.clone();
     let args = read_argv(argv, argc);
@@ -1476,7 +1724,9 @@ pub unsafe extern "C" fn sandlock_gather_set_consumer(
     argv: *const *const c_char,
     argc: c_uint,
 ) {
-    if g.is_null() || policy.is_null() || argv.is_null() { return; }
+    if g.is_null() || policy.is_null() || argv.is_null() {
+        return;
+    }
     let policy = (*policy)._private.clone();
     let args = read_argv(argv, argc);
     (*g).consumer = Some((policy, args));
@@ -1491,7 +1741,9 @@ pub unsafe extern "C" fn sandlock_gather_run(
     g: *mut sandlock_gather_t,
     timeout_ms: u64,
 ) -> *mut sandlock_result_t {
-    if g.is_null() { return ptr::null_mut(); }
+    if g.is_null() {
+        return ptr::null_mut();
+    }
     let g = *Box::from_raw(g);
 
     let (consumer_policy, consumer_args) = match g.consumer {
@@ -1525,7 +1777,9 @@ pub unsafe extern "C" fn sandlock_gather_run(
 /// `g` must be null or a valid gather pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_gather_free(g: *mut sandlock_gather_t) {
-    if !g.is_null() { drop(Box::from_raw(g)); }
+    if !g.is_null() {
+        drop(Box::from_raw(g));
+    }
 }
 
 // ----------------------------------------------------------------
@@ -1543,8 +1797,8 @@ pub struct sandlock_event_t {
     /// Category: 0=File, 1=Network, 2=Process, 3=Memory
     pub category: u8,
     pub pid: u32,
-    pub parent_pid: u32, // 0 if unknown
-    pub host: *const c_char,   // NULL if not applicable
+    pub parent_pid: u32,     // 0 if unknown
+    pub host: *const c_char, // NULL if not applicable
     pub port: u16,
     pub denied: bool,
     pub argv: *const *const c_char, // NULL-terminated array, or NULL
@@ -1564,30 +1818,86 @@ pub struct sandlock_ctx_t {
 pub type sandlock_policy_fn_t = unsafe extern "C" fn(
     event: *const sandlock_event_t,
     ctx: *mut sandlock_ctx_t,
+    user_data: *mut c_void,
 ) -> i32;
+
+/// C destructor type for policy_fn user data.
+///
+/// Called when the native policy callback is dropped. This may be later than a
+/// single run when the policy has been cloned; it fires once for the final
+/// callback reference.
+#[allow(non_camel_case_types)]
+pub type sandlock_policy_ud_drop_t = unsafe extern "C" fn(user_data: *mut c_void);
+
+struct PolicyCallbackState {
+    cb: sandlock_policy_fn_t,
+    user_data: *mut c_void,
+    user_data_drop: Option<sandlock_policy_ud_drop_t>,
+}
+
+// SAFETY: `user_data` is opaque to Rust. The FFI caller promises it remains
+// valid for the callback lifetime and is safe to access from sandlock's
+// policy-fn worker thread. The function pointers are immutable.
+unsafe impl Send for PolicyCallbackState {}
+unsafe impl Sync for PolicyCallbackState {}
+
+impl PolicyCallbackState {
+    unsafe fn call(&self, event: *const sandlock_event_t, ctx: *mut sandlock_ctx_t) -> i32 {
+        (self.cb)(event, ctx, self.user_data)
+    }
+}
+
+impl Drop for PolicyCallbackState {
+    fn drop(&mut self) {
+        if let Some(drop_fn) = self.user_data_drop {
+            unsafe { drop_fn(self.user_data) };
+        }
+    }
+}
 
 /// Set a policy callback on the builder.
 ///
 /// # Safety
 /// `b` must be a valid builder pointer. `cb` must be a valid function pointer
-/// that remains valid for the lifetime of the sandbox.
+/// that remains valid for the lifetime of the sandbox callback.
+/// `user_data` is opaque to Rust and is passed back to every callback
+/// invocation. It must remain valid and be safe to access from the policy-fn
+/// worker thread until `user_data_drop` is invoked. `user_data_drop = None` is
+/// legal when no cleanup is needed; if provided, it must not unwind.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_builder_policy_fn(
     b: *mut SandboxBuilder,
     cb: sandlock_policy_fn_t,
+    user_data: *mut c_void,
+    user_data_drop: Option<unsafe extern "C" fn(user_data: *mut c_void)>,
 ) -> *mut SandboxBuilder {
-    if b.is_null() { return b; }
+    if b.is_null() {
+        return b;
+    }
     let builder = *Box::from_raw(b);
+    let state = PolicyCallbackState {
+        cb,
+        user_data,
+        user_data_drop,
+    };
 
     // Wrap the C callback in a Rust closure
     let cb_fn = move |event: sandlock_core::policy_fn::SyscallEvent,
                       ctx: &mut sandlock_core::policy_fn::PolicyContext| {
         let syscall_c = CString::new(event.syscall.as_str()).unwrap_or_default();
-        let host_c = event.host.map(|ip| CString::new(ip.to_string()).unwrap_or_default());
+        let host_c = event
+            .host
+            .map(|ip| CString::new(ip.to_string()).unwrap_or_default());
 
         // Convert argv to C string array. CStrings live until end of closure.
-        let argv_c: Vec<CString> = event.argv.as_ref()
-            .map(|args| args.iter().filter_map(|s| CString::new(s.as_str()).ok()).collect())
+        let argv_c: Vec<CString> = event
+            .argv
+            .as_ref()
+            .map(|args| {
+                args.iter()
+                    .filter_map(|s| CString::new(s.as_str()).ok())
+                    .collect()
+            })
             .unwrap_or_default();
         let argv_ptrs: Vec<*const c_char> = argv_c.iter().map(|c| c.as_ptr()).collect();
         let argc = argv_ptrs.len() as u32;
@@ -1607,15 +1917,17 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_policy_fn(
             host: host_c.as_ref().map_or(ptr::null(), |c| c.as_ptr()),
             port: event.port.unwrap_or(0),
             denied: event.denied,
-            argv: if argv_ptrs.is_empty() { ptr::null() } else { argv_ptrs.as_ptr() },
+            argv: if argv_ptrs.is_empty() {
+                ptr::null()
+            } else {
+                argv_ptrs.as_ptr()
+            },
             argc,
         };
 
-        let mut c_ctx = sandlock_ctx_t {
-            ctx: ctx as *mut _,
-        };
+        let mut c_ctx = sandlock_ctx_t { ctx: ctx as *mut _ };
 
-        let ret = unsafe { cb(&c_event, &mut c_ctx) };
+        let ret = unsafe { state.call(&c_event, &mut c_ctx) };
         match ret {
             0 => sandlock_core::policy_fn::Verdict::Allow,
             -1 => sandlock_core::policy_fn::Verdict::Deny,
@@ -1639,7 +1951,9 @@ pub unsafe extern "C" fn sandlock_ctx_restrict_network(
     ips: *const *const c_char,
     count: u32,
 ) {
-    if ctx.is_null() { return; }
+    if ctx.is_null() {
+        return;
+    }
     let ctx = &mut *(*ctx).ctx;
     let parsed: Vec<std::net::IpAddr> = (0..count as usize)
         .filter_map(|i| {
@@ -1660,7 +1974,9 @@ pub unsafe extern "C" fn sandlock_ctx_grant_network(
     ips: *const *const c_char,
     count: u32,
 ) {
-    if ctx.is_null() { return; }
+    if ctx.is_null() {
+        return;
+    }
     let ctx = &mut *(*ctx).ctx;
     let parsed: Vec<std::net::IpAddr> = (0..count as usize)
         .filter_map(|i| {
@@ -1676,10 +1992,10 @@ pub unsafe extern "C" fn sandlock_ctx_grant_network(
 /// # Safety
 /// `ctx` must be a valid context pointer.
 #[no_mangle]
-pub unsafe extern "C" fn sandlock_ctx_restrict_max_memory(
-    ctx: *mut sandlock_ctx_t, bytes: u64,
-) {
-    if ctx.is_null() { return; }
+pub unsafe extern "C" fn sandlock_ctx_restrict_max_memory(ctx: *mut sandlock_ctx_t, bytes: u64) {
+    if ctx.is_null() {
+        return;
+    }
     let ctx = &mut *(*ctx).ctx;
     ctx.restrict_max_memory(bytes);
 }
@@ -1689,10 +2005,10 @@ pub unsafe extern "C" fn sandlock_ctx_restrict_max_memory(
 /// # Safety
 /// `ctx` must be a valid context pointer.
 #[no_mangle]
-pub unsafe extern "C" fn sandlock_ctx_restrict_max_processes(
-    ctx: *mut sandlock_ctx_t, n: u32,
-) {
-    if ctx.is_null() { return; }
+pub unsafe extern "C" fn sandlock_ctx_restrict_max_processes(ctx: *mut sandlock_ctx_t, n: u32) {
+    if ctx.is_null() {
+        return;
+    }
     let ctx = &mut *(*ctx).ctx;
     ctx.restrict_max_processes(n);
 }
@@ -1708,7 +2024,9 @@ pub unsafe extern "C" fn sandlock_ctx_restrict_pid_network(
     ips: *const *const c_char,
     count: u32,
 ) {
-    if ctx.is_null() { return; }
+    if ctx.is_null() {
+        return;
+    }
     let ctx = &mut *(*ctx).ctx;
     let parsed: Vec<std::net::IpAddr> = (0..count as usize)
         .filter_map(|i| {
@@ -1724,10 +2042,10 @@ pub unsafe extern "C" fn sandlock_ctx_restrict_pid_network(
 /// # Safety
 /// `ctx` must be a valid context pointer. `path` must be a valid C string.
 #[no_mangle]
-pub unsafe extern "C" fn sandlock_ctx_deny_path(
-    ctx: *mut sandlock_ctx_t, path: *const c_char,
-) {
-    if ctx.is_null() || path.is_null() { return; }
+pub unsafe extern "C" fn sandlock_ctx_deny_path(ctx: *mut sandlock_ctx_t, path: *const c_char) {
+    if ctx.is_null() || path.is_null() {
+        return;
+    }
     let ctx = &*(*ctx).ctx;
     let path = CStr::from_ptr(path).to_str().unwrap_or("");
     ctx.deny_path(path);
@@ -1738,10 +2056,10 @@ pub unsafe extern "C" fn sandlock_ctx_deny_path(
 /// # Safety
 /// `ctx` must be a valid context pointer. `path` must be a valid C string.
 #[no_mangle]
-pub unsafe extern "C" fn sandlock_ctx_allow_path(
-    ctx: *mut sandlock_ctx_t, path: *const c_char,
-) {
-    if ctx.is_null() || path.is_null() { return; }
+pub unsafe extern "C" fn sandlock_ctx_allow_path(ctx: *mut sandlock_ctx_t, path: *const c_char) {
+    if ctx.is_null() || path.is_null() {
+        return;
+    }
     let ctx = &*(*ctx).ctx;
     let path = CStr::from_ptr(path).to_str().unwrap_or("");
     ctx.allow_path(path);
@@ -1770,15 +2088,17 @@ pub unsafe extern "C" fn sandlock_new_with_fns(
     init_fn: sandlock_init_fn_t,
     work_fn: sandlock_work_fn_t,
 ) -> *mut Sandbox {
-    if policy.is_null() { return ptr::null_mut(); }
+    if policy.is_null() {
+        return ptr::null_mut();
+    }
     let policy = &(*policy)._private;
     let name = match optional_name(name) {
         Ok(name) => name,
         Err(_) => return ptr::null_mut(),
     };
 
-    let init = move || { unsafe { init_fn() } };
-    let work = move |id: u32| { unsafe { work_fn(id) } };
+    let init = move || unsafe { init_fn() };
+    let work = move |id: u32| unsafe { work_fn(id) };
 
     let sb = match name {
         Some(ref n) => policy.clone().with_name(n.clone()),
@@ -1799,11 +2119,10 @@ pub struct sandlock_fork_result_t {
 /// # Safety
 /// `sb` must be a valid sandbox pointer from `sandlock_new_with_fns`.
 #[no_mangle]
-pub unsafe extern "C" fn sandlock_fork(
-    sb: *mut Sandbox,
-    n: u32,
-) -> *mut sandlock_fork_result_t {
-    if sb.is_null() { return ptr::null_mut(); }
+pub unsafe extern "C" fn sandlock_fork(sb: *mut Sandbox, n: u32) -> *mut sandlock_fork_result_t {
+    if sb.is_null() {
+        return ptr::null_mut();
+    }
     let sb = &mut *sb;
 
     match with_runtime(|rt| rt.block_on(sb.fork(n))) {
@@ -1815,15 +2134,25 @@ pub unsafe extern "C" fn sandlock_fork(
 /// Get the number of clones.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_fork_result_count(r: *const sandlock_fork_result_t) -> u32 {
-    if r.is_null() { return 0; }
+    if r.is_null() {
+        return 0;
+    }
     (*r).clones.len() as u32
 }
 
 /// Get a clone's PID.
 #[no_mangle]
-pub unsafe extern "C" fn sandlock_fork_result_pid(r: *const sandlock_fork_result_t, index: u32) -> i32 {
-    if r.is_null() { return 0; }
-    (&(*r).clones).get(index as usize).and_then(|c| c.pid()).unwrap_or(0)
+pub unsafe extern "C" fn sandlock_fork_result_pid(
+    r: *const sandlock_fork_result_t,
+    index: u32,
+) -> i32 {
+    if r.is_null() {
+        return 0;
+    }
+    (&(*r).clones)
+        .get(index as usize)
+        .and_then(|c| c.pid())
+        .unwrap_or(0)
 }
 
 /// Reduce: read all clone stdout pipes, feed to reducer stdin, return result.
@@ -1866,7 +2195,9 @@ pub unsafe extern "C" fn sandlock_reduce(
 /// Free a fork result without reducing.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_fork_result_free(r: *mut sandlock_fork_result_t) {
-    if !r.is_null() { drop(Box::from_raw(r)); }
+    if !r.is_null() {
+        drop(Box::from_raw(r));
+    }
 }
 
 /// Wait for the sandbox template to exit. Returns exit code.
@@ -1875,7 +2206,9 @@ pub unsafe extern "C" fn sandlock_fork_result_free(r: *mut sandlock_fork_result_
 /// `sb` must be a valid sandbox pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_wait(sb: *mut Sandbox) -> c_int {
-    if sb.is_null() { return -1; }
+    if sb.is_null() {
+        return -1;
+    }
     let sb = &mut *sb;
 
     match with_runtime(|rt| rt.block_on(sb.wait())) {
@@ -1890,7 +2223,9 @@ pub unsafe extern "C" fn sandlock_wait(sb: *mut Sandbox) -> c_int {
 /// `sb` must be null or a valid Sandbox pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_sandbox_fns_free(sb: *mut Sandbox) {
-    if !sb.is_null() { drop(Box::from_raw(sb)); }
+    if !sb.is_null() {
+        drop(Box::from_raw(sb));
+    }
 }
 
 // ----------------------------------------------------------------
@@ -1913,7 +2248,9 @@ pub struct sandlock_checkpoint_t {
 pub unsafe extern "C" fn sandlock_handle_checkpoint(
     h: *mut sandlock_handle_t,
 ) -> *mut sandlock_checkpoint_t {
-    if h.is_null() { return ptr::null_mut(); }
+    if h.is_null() {
+        return ptr::null_mut();
+    }
     let h = &mut *h;
     match block_on_runtime(&h.runtime, h.sandbox.checkpoint()) {
         Some(Ok(cp)) => Box::into_raw(Box::new(sandlock_checkpoint_t { _private: cp })),
@@ -1931,7 +2268,9 @@ pub unsafe extern "C" fn sandlock_checkpoint_save(
     cp: *const sandlock_checkpoint_t,
     dir: *const c_char,
 ) -> c_int {
-    if cp.is_null() || dir.is_null() { return -1; }
+    if cp.is_null() || dir.is_null() {
+        return -1;
+    }
     let dir = CStr::from_ptr(dir).to_str().unwrap_or("");
     match (*cp)._private.save(std::path::Path::new(dir)) {
         Ok(()) => 0,
@@ -1948,7 +2287,9 @@ pub unsafe extern "C" fn sandlock_checkpoint_save(
 pub unsafe extern "C" fn sandlock_checkpoint_load(
     dir: *const c_char,
 ) -> *mut sandlock_checkpoint_t {
-    if dir.is_null() { return ptr::null_mut(); }
+    if dir.is_null() {
+        return ptr::null_mut();
+    }
     let dir = CStr::from_ptr(dir).to_str().unwrap_or("");
     match sandlock_core::Checkpoint::load(std::path::Path::new(dir)) {
         Ok(cp) => Box::into_raw(Box::new(sandlock_checkpoint_t { _private: cp })),
@@ -1965,7 +2306,9 @@ pub unsafe extern "C" fn sandlock_checkpoint_set_name(
     cp: *mut sandlock_checkpoint_t,
     name: *const c_char,
 ) {
-    if cp.is_null() || name.is_null() { return; }
+    if cp.is_null() || name.is_null() {
+        return;
+    }
     (*cp)._private.name = CStr::from_ptr(name).to_str().unwrap_or("").to_string();
 }
 
@@ -1974,10 +2317,10 @@ pub unsafe extern "C" fn sandlock_checkpoint_set_name(
 /// # Safety
 /// `cp` must be a valid checkpoint pointer.
 #[no_mangle]
-pub unsafe extern "C" fn sandlock_checkpoint_name(
-    cp: *const sandlock_checkpoint_t,
-) -> *mut c_char {
-    if cp.is_null() { return ptr::null_mut(); }
+pub unsafe extern "C" fn sandlock_checkpoint_name(cp: *const sandlock_checkpoint_t) -> *mut c_char {
+    if cp.is_null() {
+        return ptr::null_mut();
+    }
     match CString::new((*cp)._private.name.as_str()) {
         Ok(cs) => cs.into_raw(),
         Err(_) => ptr::null_mut(),
@@ -1994,7 +2337,9 @@ pub unsafe extern "C" fn sandlock_checkpoint_set_app_state(
     data: *const u8,
     len: usize,
 ) {
-    if cp.is_null() { return; }
+    if cp.is_null() {
+        return;
+    }
     if data.is_null() || len == 0 {
         (*cp)._private.app_state = None;
     } else {
@@ -2012,10 +2357,18 @@ pub unsafe extern "C" fn sandlock_checkpoint_app_state(
     cp: *const sandlock_checkpoint_t,
     len: *mut usize,
 ) -> *const u8 {
-    if cp.is_null() || len.is_null() { return ptr::null(); }
+    if cp.is_null() || len.is_null() {
+        return ptr::null();
+    }
     match (*cp)._private.app_state.as_ref() {
-        Some(data) => { *len = data.len(); data.as_ptr() }
-        None => { *len = 0; ptr::null() }
+        Some(data) => {
+            *len = data.len();
+            data.as_ptr()
+        }
+        None => {
+            *len = 0;
+            ptr::null()
+        }
     }
 }
 
@@ -2025,7 +2378,9 @@ pub unsafe extern "C" fn sandlock_checkpoint_app_state(
 /// `cp` must be null or a valid checkpoint pointer.
 #[no_mangle]
 pub unsafe extern "C" fn sandlock_checkpoint_free(cp: *mut sandlock_checkpoint_t) {
-    if !cp.is_null() { drop(Box::from_raw(cp)); }
+    if !cp.is_null() {
+        drop(Box::from_raw(cp));
+    }
 }
 
 // ----------------------------------------------------------------
@@ -2063,7 +2418,10 @@ unsafe fn optional_name(name: *const c_char) -> Result<Option<String>, std::str:
 unsafe fn read_argv(argv: *const *const c_char, argc: c_uint) -> Vec<String> {
     let mut args = Vec::new();
     for i in 0..argc as usize {
-        let arg = CStr::from_ptr(*argv.add(i)).to_str().unwrap_or("").to_string();
+        let arg = CStr::from_ptr(*argv.add(i))
+            .to_str()
+            .unwrap_or("")
+            .to_string();
         args.push(arg);
     }
     args

--- a/crates/sandlock-ffi/tests/c/handler_smoke.c
+++ b/crates/sandlock-ffi/tests/c/handler_smoke.c
@@ -87,22 +87,87 @@ static int force_getpid_to_777(
     return 0;
 }
 
-int main(void) {
-    /* Pure-C check of the content-injection setter, independent of a live
-     * sandbox run. */
-    if (check_inject_bytes() != 0) {
+struct policy_ud {
+    int magic;
+    int drops;
+};
+
+static int policy_fn_record_ud(
+    const sandlock_event_t *event,
+    sandlock_ctx_t *ctx,
+    void *ud
+) {
+    (void)ctx;
+    struct policy_ud *state = (struct policy_ud *)ud;
+    if (state == NULL || state->magic != 0x5150) {
         return 1;
     }
+    (void)event;
+    return 0;
+}
 
-    /* Build a sandbox that exposes just enough of the host for the
-     * system python3 interpreter to start. Mirrors the read mounts
-     * from the Rust integration test in tests/handler_smoke.rs. */
+static void policy_fn_drop_ud(void *ud) {
+    struct policy_ud *state = (struct policy_ud *)ud;
+    if (state != NULL && state->magic == 0x5150) {
+        state->drops++;
+    }
+}
+
+static int check_policy_fn_user_data_drop(void) {
+    struct policy_ud state = {
+        .magic = 0x5150,
+        .drops = 0,
+    };
+
     sandlock_builder_t *b = sandlock_sandbox_builder_new();
     b = sandlock_sandbox_builder_fs_read(b, "/usr");
     b = sandlock_sandbox_builder_fs_read(b, "/bin");
     b = sandlock_sandbox_builder_fs_read(b, "/lib");
     b = sandlock_sandbox_builder_fs_read(b, "/lib64");
     b = sandlock_sandbox_builder_fs_read(b, "/etc");
+    b = sandlock_sandbox_builder_fs_read(b, "/proc");
+    b = sandlock_sandbox_builder_fs_read(b, "/dev");
+    b = sandlock_sandbox_builder_fs_write(b, "/tmp");
+    b = sandlock_sandbox_builder_policy_fn(
+        b, policy_fn_record_ud, &state, policy_fn_drop_ud);
+
+    int err = 0;
+    sandlock_sandbox_t *p = sandlock_sandbox_build(b, &err, NULL);
+    if (p == NULL) {
+        fprintf(stderr, "policy_fn: sandbox build failed: err=%d\n", err);
+        return 1;
+    }
+
+    sandlock_sandbox_free(p);
+
+    if (state.drops != 1) {
+        fprintf(stderr, "policy_fn: user_data drop count=%d, want 1\n", state.drops);
+        return 1;
+    }
+    return 0;
+}
+
+int main(void) {
+    /* Pure-C check of the content-injection setter, independent of a live
+     * sandbox run. */
+    if (check_inject_bytes() != 0) {
+        return 1;
+    }
+    if (check_policy_fn_user_data_drop() != 0) {
+        return 1;
+    }
+
+    /* Build a sandbox that exposes just enough of the host for the
+     * system python3 interpreter to start. Mirrors the read mounts used by
+     * the live handler/proc runtime tests. */
+    sandlock_builder_t *b = sandlock_sandbox_builder_new();
+    b = sandlock_sandbox_builder_fs_read(b, "/usr");
+    b = sandlock_sandbox_builder_fs_read(b, "/bin");
+    b = sandlock_sandbox_builder_fs_read(b, "/lib");
+    b = sandlock_sandbox_builder_fs_read(b, "/lib64");
+    b = sandlock_sandbox_builder_fs_read(b, "/etc");
+    b = sandlock_sandbox_builder_fs_read(b, "/proc");
+    b = sandlock_sandbox_builder_fs_read(b, "/dev");
     b = sandlock_sandbox_builder_fs_write(b, "/tmp");
 
     int err = 0;

--- a/crates/sandlock-ffi/tests/c_smoke.rs
+++ b/crates/sandlock-ffi/tests/c_smoke.rs
@@ -7,8 +7,12 @@ fn c_smoke_compiles_and_runs() {
 
     let out_dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR"));
     let bin = out_dir.join("handler_smoke");
-    let profile = if cfg!(debug_assertions) { "debug" } else { "release" };
-    let cdylib_dir = std::env::var_os("CARGO_TARGET_DIR")
+    let profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    let target_dir = std::env::var_os("CARGO_TARGET_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|| {
             PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -17,8 +21,19 @@ fn c_smoke_compiles_and_runs() {
                 .parent()
                 .unwrap()
                 .join("target")
-        })
-        .join(profile);
+        });
+    let profile_dir = target_dir.join(profile);
+    let cdylib_dir = [
+        profile_dir.clone(),
+        profile_dir.join("deps"),
+        target_dir.join("release"),
+        target_dir.join("release").join("deps"),
+    ]
+    .into_iter()
+    .find(|dir| {
+        dir.join("libsandlock_ffi.so").exists() || dir.join("libsandlock_ffi.dylib").exists()
+    })
+    .expect("libsandlock_ffi cdylib should exist in target output");
 
     let rpath_arg = format!("-Wl,-rpath,{}", cdylib_dir.to_str().unwrap());
 

--- a/crates/sandlock-ffi/tests/handler_smoke.rs
+++ b/crates/sandlock-ffi/tests/handler_smoke.rs
@@ -35,9 +35,7 @@ fn notif_data_from_seccomp_notif_copies_all_fields() {
     assert_eq!(snap.args, [1, 2, 3, 4, 5, 6]);
 }
 
-use sandlock_ffi::handler::{
-    sandlock_mem_read, sandlock_mem_read_cstr, sandlock_mem_write,
-};
+use sandlock_ffi::handler::{sandlock_mem_read, sandlock_mem_read_cstr, sandlock_mem_write};
 
 #[test]
 fn mem_accessors_reject_null_arguments() {
@@ -89,8 +87,11 @@ fn action_setters_record_kind_and_payload() {
     a.payload.none = SENTINEL;
     unsafe { sandlock_action_set_continue(&mut a) };
     assert_eq!(a.kind, sandlock_action_kind_t::Continue as u32);
-    assert_eq!(unsafe { a.payload.none }, SENTINEL,
-               "set_continue must be tag-only and leave payload untouched");
+    assert_eq!(
+        unsafe { a.payload.none },
+        SENTINEL,
+        "set_continue must be tag-only and leave payload untouched"
+    );
 
     unsafe { sandlock_action_set_errno(&mut a, 13) };
     assert_eq!(a.kind, sandlock_action_kind_t::Errno as u32);
@@ -103,8 +104,11 @@ fn action_setters_record_kind_and_payload() {
     a.payload.none = SENTINEL;
     unsafe { sandlock_action_set_hold(&mut a) };
     assert_eq!(a.kind, sandlock_action_kind_t::Hold as u32);
-    assert_eq!(unsafe { a.payload.none }, SENTINEL,
-               "set_hold must be tag-only and leave payload untouched");
+    assert_eq!(
+        unsafe { a.payload.none },
+        SENTINEL,
+        "set_hold must be tag-only and leave payload untouched"
+    );
 
     unsafe { sandlock_action_set_kill(&mut a, libc::SIGKILL, 4321) };
     assert_eq!(a.kind, sandlock_action_kind_t::Kill as u32);
@@ -116,13 +120,19 @@ fn action_setters_record_kind_and_payload() {
 fn action_out_layout_is_stable() {
     // Size + align are gross guards; pin down field offsets so a
     // field reorder that preserves size still gets caught.
-    use std::mem::{align_of, size_of, MaybeUninit};
     use sandlock_ffi::handler::sandlock_action_out_t;
+    use std::mem::{align_of, size_of, MaybeUninit};
 
-    assert_eq!(size_of::<sandlock_action_out_t>(), 24,
-               "size drift breaks the C ABI layout");
-    assert_eq!(align_of::<sandlock_action_out_t>(), 8,
-               "align drift breaks the C ABI layout");
+    assert_eq!(
+        size_of::<sandlock_action_out_t>(),
+        24,
+        "size drift breaks the C ABI layout"
+    );
+    assert_eq!(
+        align_of::<sandlock_action_out_t>(),
+        8,
+        "align drift breaks the C ABI layout"
+    );
 
     // Hand-roll offset_of through MaybeUninit — works on stable Rust
     // without an extra crate. The C header has kind at offset 0 and
@@ -130,15 +140,19 @@ fn action_out_layout_is_stable() {
     let mut probe = MaybeUninit::<sandlock_action_out_t>::uninit();
     let base = probe.as_mut_ptr() as usize;
     let kind_offset = unsafe { std::ptr::addr_of_mut!((*probe.as_mut_ptr()).kind) as usize - base };
-    let payload_offset = unsafe { std::ptr::addr_of_mut!((*probe.as_mut_ptr()).payload) as usize - base };
+    let payload_offset =
+        unsafe { std::ptr::addr_of_mut!((*probe.as_mut_ptr()).payload) as usize - base };
     assert_eq!(kind_offset, 0, "kind must be at offset 0");
-    assert_eq!(payload_offset, 8, "payload must be at offset 8 (kind+4 bytes padding)");
+    assert_eq!(
+        payload_offset, 8,
+        "payload must be at offset 8 (kind+4 bytes padding)"
+    );
 }
 
 #[test]
 fn notif_data_field_offsets_are_stable() {
-    use std::mem::MaybeUninit;
     use sandlock_ffi::notif_repr::sandlock_notif_data_t;
+    use std::mem::MaybeUninit;
 
     let probe = MaybeUninit::<sandlock_notif_data_t>::uninit();
     let base = probe.as_ptr() as usize;
@@ -173,7 +187,9 @@ fn notif_data_field_offsets_are_stable() {
         "arch must be at offset 20",
     );
     assert_eq!(
-        unsafe { std::ptr::addr_of!((*probe.as_ptr()).instruction_pointer) as *const u8 as usize - base },
+        unsafe {
+            std::ptr::addr_of!((*probe.as_ptr()).instruction_pointer) as *const u8 as usize - base
+        },
         24,
         "instruction_pointer must be at offset 24",
     );
@@ -185,7 +201,7 @@ fn notif_data_field_offsets_are_stable() {
 }
 
 use sandlock_ffi::handler::{
-    sandlock_exception_policy_t, sandlock_handler_free, sandlock_handler_fn_t,
+    sandlock_exception_policy_t, sandlock_handler_fn_t, sandlock_handler_free,
     sandlock_handler_new, sandlock_handler_t,
 };
 
@@ -204,7 +220,9 @@ static ROUND_TRIP_DROPPER_CALLS: std::sync::atomic::AtomicUsize =
 
 extern "C-unwind" fn round_trip_dropper(ud: *mut std::ffi::c_void) {
     // Reclaim the leaked Box so its destructor runs (real drop path).
-    unsafe { drop(Box::from_raw(ud as *mut u32)); }
+    unsafe {
+        drop(Box::from_raw(ud as *mut u32));
+    }
     ROUND_TRIP_DROPPER_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 }
 
@@ -265,9 +283,15 @@ use sandlock_ffi::handler::FfiHandler;
 fn fake_ctx() -> HandlerCtx {
     HandlerCtx {
         notif: SeccompNotif {
-            id: 1, pid: std::process::id(), flags: 0,
-            data: SeccompData { nr: 39, arch: 0xC000003E,
-                                instruction_pointer: 0, args: [0; 6] },
+            id: 1,
+            pid: std::process::id(),
+            flags: 0,
+            data: SeccompData {
+                nr: 39,
+                arch: 0xC000003E,
+                instruction_pointer: 0,
+                args: [0; 6],
+            },
         },
         notif_fd: -1,
     }
@@ -324,9 +348,15 @@ fn fake_ctx_with_isolated_child() -> (HandlerCtx, std::process::Child) {
     );
     let ctx = HandlerCtx {
         notif: SeccompNotif {
-            id: 1, pid: child_pid as u32, flags: 0,
-            data: SeccompData { nr: 39, arch: 0xC000003E,
-                                instruction_pointer: 0, args: [0; 6] },
+            id: 1,
+            pid: child_pid as u32,
+            flags: 0,
+            data: SeccompData {
+                nr: 39,
+                arch: 0xC000003E,
+                instruction_pointer: 0,
+                args: [0; 6],
+            },
         },
         notif_fd: -1,
     };
@@ -424,10 +454,8 @@ async fn ffi_handler_applies_exception_policy_on_failure() {
     assert!(matches!(action, NotifAction::Errno(e) if e == libc::EPERM));
 }
 
+use sandlock_ffi::handler::{sandlock_handler_registration_t, sandlock_run_with_handlers};
 use std::ffi::CString;
-use sandlock_ffi::handler::{
-    sandlock_handler_registration_t, sandlock_run_with_handlers,
-};
 
 extern "C-unwind" fn force_getpid_to_777(
     _ud: *mut std::ffi::c_void,
@@ -492,20 +520,14 @@ fn run_with_handlers_intercepts_getpid() {
         handler,
     }];
 
-    let script = CString::new(
-        "import os, sys; sys.stdout.write(str(os.getpid()))",
-    ).unwrap();
+    let script = CString::new("import os, sys; sys.stdout.write(str(os.getpid()))").unwrap();
     // Use the system python3 directly. Running through `/usr/bin/env
     // python3` would pick up any venv shim in $PATH whose pyvenv.cfg
     // sits outside the sandbox's read allowlist and fail before our
     // handler ever gets a chance to fire.
     let arg0 = CString::new("/usr/bin/python3").unwrap();
     let arg1 = CString::new("-c").unwrap();
-    let argv = [
-        arg0.as_ptr(),
-        arg1.as_ptr(),
-        script.as_ptr(),
-    ];
+    let argv = [arg0.as_ptr(), arg1.as_ptr(), script.as_ptr()];
 
     let rr = unsafe {
         sandlock_run_with_handlers(
@@ -521,12 +543,20 @@ fn run_with_handlers_intercepts_getpid() {
     let stdout = unsafe {
         let mut len: usize = 0;
         let p = sandlock_result_stdout_bytes(rr, &mut len);
-        if p.is_null() { Vec::new() } else { std::slice::from_raw_parts(p, len).to_vec() }
+        if p.is_null() {
+            Vec::new()
+        } else {
+            std::slice::from_raw_parts(p, len).to_vec()
+        }
     };
     let stderr = unsafe {
         let mut len: usize = 0;
         let p = sandlock_result_stderr_bytes(rr, &mut len);
-        if p.is_null() { Vec::new() } else { std::slice::from_raw_parts(p, len).to_vec() }
+        if p.is_null() {
+            Vec::new()
+        } else {
+            std::slice::from_raw_parts(p, len).to_vec()
+        }
     };
     let stdout_str = String::from_utf8_lossy(&stdout);
     let stderr_str = String::from_utf8_lossy(&stderr);
@@ -536,12 +566,21 @@ fn run_with_handlers_intercepts_getpid() {
     // the full stdout — a substring check would silently pass on a
     // mutation that broke dispatch when the real pid happened to
     // contain "777" (pids 7770-7779, 17770-17779, ...).
-    assert_eq!(stdout_str.trim_end_matches('\n'), "777",
-               "expected getpid to be intercepted; exit={} stdout={:?} stderr={:?}",
-               exit_code, stdout_str, stderr_str);
+    assert_eq!(
+        stdout_str.trim_end_matches('\n'),
+        "777",
+        "expected getpid to be intercepted; exit={} stdout={:?} stderr={:?}",
+        exit_code,
+        stdout_str,
+        stderr_str
+    );
 
-    unsafe { sandlock_result_free(rr); }
-    unsafe { sandlock_sandbox_free(policy); }
+    unsafe {
+        sandlock_result_free(rr);
+    }
+    unsafe {
+        sandlock_sandbox_free(policy);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1130,12 +1169,14 @@ async fn ffi_handler_callback_returns_zero_but_never_sets_action_triggers_fallba
 
 // ---- Group F: handler_new edge cases ------------------------------------
 
-static NULL_UD_DROP_CALLS: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+static NULL_UD_DROP_CALLS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
 extern "C-unwind" fn counting_null_ud_dropper(ud: *mut std::ffi::c_void) {
     // Sanity: confirm the dropper sees the null ud we passed in.
-    assert!(ud.is_null(), "dropper invoked with non-null ud unexpectedly");
+    assert!(
+        ud.is_null(),
+        "dropper invoked with non-null ud unexpectedly"
+    );
     NULL_UD_DROP_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 }
 
@@ -1220,9 +1261,14 @@ fn run_with_handlers_null_argv_returns_null() {
             0,
         )
     };
-    assert!(rr.is_null(), "expected null result for null argv with argc > 0");
+    assert!(
+        rr.is_null(),
+        "expected null result for null argv with argc > 0"
+    );
 
-    unsafe { sandlock_sandbox_free(policy); }
+    unsafe {
+        sandlock_sandbox_free(policy);
+    }
 }
 
 #[test]
@@ -1252,7 +1298,9 @@ fn run_with_handlers_zero_argc_returns_null() {
     };
     assert!(rr.is_null(), "expected null result for argc == 0");
 
-    unsafe { sandlock_sandbox_free(policy); }
+    unsafe {
+        sandlock_sandbox_free(policy);
+    }
 }
 
 #[test]
@@ -1277,9 +1325,14 @@ fn run_with_handlers_null_registrations_with_nonzero_count_returns_null() {
             1,
         )
     };
-    assert!(rr.is_null(), "expected null result for null registrations + count > 0");
+    assert!(
+        rr.is_null(),
+        "expected null result for null registrations + count > 0"
+    );
 
-    unsafe { sandlock_sandbox_free(policy); }
+    unsafe {
+        sandlock_sandbox_free(policy);
+    }
 }
 
 #[test]
@@ -1315,7 +1368,9 @@ fn run_with_handlers_rejects_oversize_argc() {
     };
     assert!(rr.is_null(), "expected null result for argc > MAX_ARGV");
 
-    unsafe { sandlock_sandbox_free(policy); }
+    unsafe {
+        sandlock_sandbox_free(policy);
+    }
 }
 
 #[test]
@@ -1353,9 +1408,14 @@ fn run_with_handlers_rejects_oversize_nregistrations() {
             5000, // > MAX_REGISTRATIONS (4096)
         )
     };
-    assert!(rr.is_null(), "expected null result for nregistrations > MAX_REGISTRATIONS");
+    assert!(
+        rr.is_null(),
+        "expected null result for nregistrations > MAX_REGISTRATIONS"
+    );
 
-    unsafe { sandlock_sandbox_free(policy); }
+    unsafe {
+        sandlock_sandbox_free(policy);
+    }
 }
 
 #[test]
@@ -1409,13 +1469,24 @@ fn run_with_handlers_empty_registrations_runs_normally() {
             0,
         )
     };
-    assert!(!rr.is_null(), "empty registrations should still run /bin/true");
+    assert!(
+        !rr.is_null(),
+        "empty registrations should still run /bin/true"
+    );
     let success = unsafe { sandlock_result_success(rr) };
     let exit_code = unsafe { sandlock_result_exit_code(rr) };
-    assert!(success, "/bin/true should exit successfully; exit={}", exit_code);
+    assert!(
+        success,
+        "/bin/true should exit successfully; exit={}",
+        exit_code
+    );
 
-    unsafe { sandlock_result_free(rr); }
-    unsafe { sandlock_sandbox_free(policy); }
+    unsafe {
+        sandlock_result_free(rr);
+    }
+    unsafe {
+        sandlock_sandbox_free(policy);
+    }
 }
 
 static ONE_SHOT_DROPPER_CALLS: std::sync::atomic::AtomicUsize =
@@ -1425,7 +1496,9 @@ extern "C-unwind" fn one_shot_dropper(ud: *mut std::ffi::c_void) {
     ONE_SHOT_DROPPER_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     if !ud.is_null() {
         // Reclaim the leaked Box so leak-sanitizer builds stay clean.
-        unsafe { drop(Box::from_raw(ud as *mut u32)); }
+        unsafe {
+            drop(Box::from_raw(ud as *mut u32));
+        }
     }
 }
 
@@ -1483,14 +1556,19 @@ fn run_with_handlers_null_handler_in_array_returns_null() {
             regs.len(),
         )
     };
-    assert!(rr.is_null(), "expected null result when an array entry is null");
+    assert!(
+        rr.is_null(),
+        "expected null result when an array entry is null"
+    );
     assert_eq!(
         ONE_SHOT_DROPPER_CALLS.load(std::sync::atomic::Ordering::SeqCst),
         1,
         "dropper must fire exactly once (from the supervisor's release_registrations)",
     );
 
-    unsafe { sandlock_sandbox_free(policy); }
+    unsafe {
+        sandlock_sandbox_free(policy);
+    }
 }
 
 // ---- Group H: multiple handlers -----------------------------------------
@@ -1580,16 +1658,12 @@ fn run_with_handlers_two_handlers_each_fires_for_own_syscall() {
         },
     ];
 
-    let script = CString::new(
-        "import os, sys; sys.stdout.write(str(os.getpid())+'|'+str(os.getppid()))",
-    ).unwrap();
+    let script =
+        CString::new("import os, sys; sys.stdout.write(str(os.getpid())+'|'+str(os.getppid()))")
+            .unwrap();
     let arg0 = CString::new("/usr/bin/python3").unwrap();
     let arg1 = CString::new("-c").unwrap();
-    let argv = [
-        arg0.as_ptr(),
-        arg1.as_ptr(),
-        script.as_ptr(),
-    ];
+    let argv = [arg0.as_ptr(), arg1.as_ptr(), script.as_ptr()];
 
     let rr = unsafe {
         sandlock_run_with_handlers(
@@ -1605,12 +1679,20 @@ fn run_with_handlers_two_handlers_each_fires_for_own_syscall() {
     let stdout = unsafe {
         let mut len: usize = 0;
         let p = sandlock_result_stdout_bytes(rr, &mut len);
-        if p.is_null() { Vec::new() } else { std::slice::from_raw_parts(p, len).to_vec() }
+        if p.is_null() {
+            Vec::new()
+        } else {
+            std::slice::from_raw_parts(p, len).to_vec()
+        }
     };
     let stderr = unsafe {
         let mut len: usize = 0;
         let p = sandlock_result_stderr_bytes(rr, &mut len);
-        if p.is_null() { Vec::new() } else { std::slice::from_raw_parts(p, len).to_vec() }
+        if p.is_null() {
+            Vec::new()
+        } else {
+            std::slice::from_raw_parts(p, len).to_vec()
+        }
     };
     let stdout_str = String::from_utf8_lossy(&stdout);
     let stderr_str = String::from_utf8_lossy(&stderr);
@@ -1623,11 +1705,17 @@ fn run_with_handlers_two_handlers_each_fires_for_own_syscall() {
         stdout_str.trim_end_matches('\n'),
         "111|222",
         "expected both handlers to fire; exit={} stdout={:?} stderr={:?}",
-        exit_code, stdout_str, stderr_str,
+        exit_code,
+        stdout_str,
+        stderr_str,
     );
 
-    unsafe { sandlock_result_free(rr); }
-    unsafe { sandlock_sandbox_free(policy); }
+    unsafe {
+        sandlock_result_free(rr);
+    }
+    unsafe {
+        sandlock_sandbox_free(policy);
+    }
 }
 
 // ---- Group I: live-fd mem_read_cstr -------------------------------------
@@ -1647,7 +1735,11 @@ extern "C-unwind" fn deny_magic_marker_path(
     let mut n: usize = 0;
     let rc = unsafe {
         sandlock_ffi::handler::sandlock_mem_read_cstr(
-            mem, addr, buf.as_mut_ptr(), buf.len(), &mut n,
+            mem,
+            addr,
+            buf.as_mut_ptr(),
+            buf.len(),
+            &mut n,
         )
     };
     if rc != 0 {
@@ -1724,14 +1816,11 @@ fn mem_read_cstr_reads_path_from_intercepted_openat() {
          except OSError as e:\n\
          \x20   sys.stderr.write('errno=' + str(e.errno) + '\\n')\n\
          \x20   sys.exit(1)\n",
-    ).unwrap();
+    )
+    .unwrap();
     let arg0 = CString::new("/usr/bin/python3").unwrap();
     let arg1 = CString::new("-c").unwrap();
-    let argv = [
-        arg0.as_ptr(),
-        arg1.as_ptr(),
-        script.as_ptr(),
-    ];
+    let argv = [arg0.as_ptr(), arg1.as_ptr(), script.as_ptr()];
 
     let rr = unsafe {
         sandlock_run_with_handlers(
@@ -1747,12 +1836,20 @@ fn mem_read_cstr_reads_path_from_intercepted_openat() {
     let stderr = unsafe {
         let mut len: usize = 0;
         let p = sandlock_result_stderr_bytes(rr, &mut len);
-        if p.is_null() { Vec::new() } else { std::slice::from_raw_parts(p, len).to_vec() }
+        if p.is_null() {
+            Vec::new()
+        } else {
+            std::slice::from_raw_parts(p, len).to_vec()
+        }
     };
     let stdout = unsafe {
         let mut len: usize = 0;
         let p = sandlock_result_stdout_bytes(rr, &mut len);
-        if p.is_null() { Vec::new() } else { std::slice::from_raw_parts(p, len).to_vec() }
+        if p.is_null() {
+            Vec::new()
+        } else {
+            std::slice::from_raw_parts(p, len).to_vec()
+        }
     };
     let stderr_str = String::from_utf8_lossy(&stderr);
     let stdout_str = String::from_utf8_lossy(&stdout);
@@ -1765,11 +1862,17 @@ fn mem_read_cstr_reads_path_from_intercepted_openat() {
         stderr_str.contains("errno=13"),
         "expected handler to inject EACCES via mem_read_cstr; \
          exit={} stdout={:?} stderr={:?}",
-        exit_code, stdout_str, stderr_str,
+        exit_code,
+        stdout_str,
+        stderr_str,
     );
 
-    unsafe { sandlock_result_free(rr); }
-    unsafe { sandlock_sandbox_free(policy); }
+    unsafe {
+        sandlock_result_free(rr);
+    }
+    unsafe {
+        sandlock_sandbox_free(policy);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1809,7 +1912,12 @@ fn make_pipe() -> (i32, i32) {
     // success and returns 0; we assert success below.
     let mut fds = [0i32; 2];
     let rc = unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) };
-    assert_eq!(rc, 0, "pipe2() failed: errno={}", std::io::Error::last_os_error());
+    assert_eq!(
+        rc,
+        0,
+        "pipe2() failed: errno={}",
+        std::io::Error::last_os_error()
+    );
     (fds[0], fds[1])
 }
 
@@ -1825,7 +1933,11 @@ fn make_pipe() -> (i32, i32) {
 // copy) is gone.
 fn wait_for_eof(fd: i32) -> isize {
     const TIMEOUT_MS: i32 = 2000;
-    let mut pfd = libc::pollfd { fd, events: libc::POLLIN, revents: 0 };
+    let mut pfd = libc::pollfd {
+        fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
     // SAFETY: `pfd` is a stack-local with a single valid fd; `poll`
     // reads/writes only the supplied entry.
     let pret = unsafe { libc::poll(&mut pfd, 1, TIMEOUT_MS) };
@@ -1912,9 +2024,13 @@ async fn a1_ffi_handler_drains_inject_fd_on_panic() {
     // leak-clean. `write_fd` itself is owned by the drain path; do NOT
     // close it here.
     // SAFETY: `fd_ptr` came from `Box::into_raw` on a `Box<i32>`.
-    unsafe { drop(Box::from_raw(fd_ptr as *mut i32)); }
+    unsafe {
+        drop(Box::from_raw(fd_ptr as *mut i32));
+    }
     // SAFETY: `read_fd` is still open; close it.
-    unsafe { libc::close(read_fd); }
+    unsafe {
+        libc::close(read_fd);
+    }
 }
 
 extern "C-unwind" fn arm_inject_fd_send_tracked_discriminant(
@@ -1976,13 +2092,16 @@ async fn a2_ffi_handler_drains_inject_fd_tracked_discriminant() {
     );
 
     // SAFETY: `fd_ptr` came from `Box::into_raw` on a `Box<i32>`.
-    unsafe { drop(Box::from_raw(fd_ptr as *mut i32)); }
+    unsafe {
+        drop(Box::from_raw(fd_ptr as *mut i32));
+    }
     // SAFETY: `read_fd` is still open; close it.
-    unsafe { libc::close(read_fd); }
+    unsafe {
+        libc::close(read_fd);
+    }
 }
 
-static A3_UD_DROPPER_CALLS: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+static A3_UD_DROPPER_CALLS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
 extern "C-unwind" fn a3_counter_dropper(_ud: *mut std::ffi::c_void) {
     A3_UD_DROPPER_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -2034,10 +2153,8 @@ extern "C-unwind" fn a5_panicking_dropper(_ud: *mut std::ffi::c_void) {
     panic!("test panic from dropper");
 }
 
-static C_NEW_1_DROPPER_A: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
-static C_NEW_1_DROPPER_B: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+static C_NEW_1_DROPPER_A: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+static C_NEW_1_DROPPER_B: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
 extern "C-unwind" fn c_new_1_dropper_a(_ud: *mut std::ffi::c_void) {
     C_NEW_1_DROPPER_A.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -2082,24 +2199,28 @@ fn release_registrations_continues_after_mid_loop_panic() {
     };
     assert!(!h1.is_null() && !h2.is_null(), "handler_new must succeed");
     let regs = [
-        sandlock_handler_registration_t { syscall_nr: libc::SYS_getpid, handler: h1 },
-        sandlock_handler_registration_t { syscall_nr: libc::SYS_getppid, handler: h2 },
+        sandlock_handler_registration_t {
+            syscall_nr: libc::SYS_getpid,
+            handler: h1,
+        },
+        sandlock_handler_registration_t {
+            syscall_nr: libc::SYS_getppid,
+            handler: h2,
+        },
     ];
     // Null policy triggers `release_registrations` on the
     // early-return path. With the fix, `sandlock_run_with_handlers`
     // unwinds (extern "C-unwind") because dropper_a panics;
     // `catch_unwind` here captures it.
-    let result = std::panic::catch_unwind(|| {
-        unsafe {
-            sandlock_run_with_handlers(
-                std::ptr::null(),
-                std::ptr::null(),
-                std::ptr::null(),
-                0,
-                regs.as_ptr(),
-                regs.len(),
-            )
-        }
+    let result = std::panic::catch_unwind(|| unsafe {
+        sandlock_run_with_handlers(
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null(),
+            0,
+            regs.as_ptr(),
+            regs.len(),
+        )
     });
     assert!(
         result.is_err(),
@@ -2174,8 +2295,11 @@ async fn ffi_handler_deny_eio_policy_on_callback_rc_nonzero() {
     let h = unsafe { sandlock_ffi::handler::FfiHandler::from_raw(raw) };
     let cx = fake_ctx();
     let action = h.handle(&cx).await;
-    assert!(matches!(action, NotifAction::Errno(e) if e == libc::EIO),
-            "expected Errno(EIO), got {:?}", action);
+    assert!(
+        matches!(action, NotifAction::Errno(e) if e == libc::EIO),
+        "expected Errno(EIO), got {:?}",
+        action
+    );
 }
 
 // ----------------------------------------------------------------
@@ -2187,7 +2311,8 @@ fn syscall_nr_resolves_a_known_name() {
     let name = std::ffi::CString::new("openat").unwrap();
     let nr = unsafe { sandlock_ffi::sandlock_syscall_nr(name.as_ptr()) };
     assert_eq!(
-        nr, libc::SYS_openat,
+        nr,
+        libc::SYS_openat,
         "\"openat\" must resolve to the host-arch SYS_openat",
     );
 }

--- a/crates/sandlock-ffi/tests/policy_fn.rs
+++ b/crates/sandlock-ffi/tests/policy_fn.rs
@@ -1,0 +1,48 @@
+use std::ffi::c_void;
+use std::ptr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use sandlock_ffi::{
+    sandlock_ctx_t, sandlock_event_t, sandlock_sandbox_build, sandlock_sandbox_builder_new,
+    sandlock_sandbox_builder_policy_fn, sandlock_sandbox_free,
+};
+
+static DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
+const USER_DATA_TOKEN: usize = 0x5150;
+
+unsafe extern "C" fn policy_callback(
+    _event: *const sandlock_event_t,
+    _ctx: *mut sandlock_ctx_t,
+    user_data: *mut c_void,
+) -> i32 {
+    assert_eq!(user_data as usize, USER_DATA_TOKEN);
+    0
+}
+
+unsafe extern "C" fn drop_user_data(user_data: *mut c_void) {
+    assert_eq!(user_data as usize, USER_DATA_TOKEN);
+    DROP_COUNT.fetch_add(1, Ordering::SeqCst);
+}
+
+#[test]
+fn policy_fn_user_data_drop_fires_on_policy_free() {
+    DROP_COUNT.store(0, Ordering::SeqCst);
+
+    let mut builder = sandlock_sandbox_builder_new();
+    builder = unsafe {
+        sandlock_sandbox_builder_policy_fn(
+            builder,
+            policy_callback,
+            USER_DATA_TOKEN as *mut c_void,
+            Some(drop_user_data),
+        )
+    };
+
+    let mut err = 0;
+    let policy = unsafe { sandlock_sandbox_build(builder, &mut err, ptr::null_mut()) };
+    assert!(!policy.is_null(), "build failed with err={err}");
+    assert_eq!(DROP_COUNT.load(Ordering::SeqCst), 0);
+
+    unsafe { sandlock_sandbox_free(policy) };
+    assert_eq!(DROP_COUNT.load(Ordering::SeqCst), 1);
+}

--- a/crates/sandlock-ffi/tests/protection.rs
+++ b/crates/sandlock-ffi/tests/protection.rs
@@ -64,12 +64,25 @@ fn protection_discriminants_cover_rust_enum_in_order() {
     // order so external callers (Python ctypes, hand-written C) can
     // index via the raw integer.
     let rust_order: Vec<Protection> = Protection::all().collect();
-    assert_eq!(rust_order.len(), 6, "if a new protection lands, extend the FFI discriminants and the PROT_* constants");
+    assert_eq!(
+        rust_order.len(),
+        6,
+        "if a new protection lands, extend the FFI discriminants and the PROT_* constants"
+    );
     assert_eq!(rust_order[PROT_FS_REFER as usize], Protection::FsRefer);
-    assert_eq!(rust_order[PROT_FS_TRUNCATE as usize], Protection::FsTruncate);
+    assert_eq!(
+        rust_order[PROT_FS_TRUNCATE as usize],
+        Protection::FsTruncate
+    );
     assert_eq!(rust_order[PROT_NET_TCP as usize], Protection::NetTcp);
-    assert_eq!(rust_order[PROT_FS_IOCTL_DEV as usize], Protection::FsIoctlDev);
-    assert_eq!(rust_order[PROT_SIGNAL_SCOPE as usize], Protection::SignalScope);
+    assert_eq!(
+        rust_order[PROT_FS_IOCTL_DEV as usize],
+        Protection::FsIoctlDev
+    );
+    assert_eq!(
+        rust_order[PROT_SIGNAL_SCOPE as usize],
+        Protection::SignalScope
+    );
     assert_eq!(
         rust_order[PROT_ABSTRACT_UNIX_SOCKET_SCOPE as usize],
         Protection::AbstractUnixSocketScope,
@@ -82,7 +95,9 @@ fn protection_discriminants_cover_rust_enum_in_order() {
 /// inspect `protection_policy`.
 fn build_via_ffi<F>(configure: F) -> Sandbox
 where
-    F: FnOnce(*mut sandlock_core::sandbox::SandboxBuilder) -> *mut sandlock_core::sandbox::SandboxBuilder,
+    F: FnOnce(
+        *mut sandlock_core::sandbox::SandboxBuilder,
+    ) -> *mut sandlock_core::sandbox::SandboxBuilder,
 {
     let b = sandlock_sandbox_builder_new();
     assert!(!b.is_null(), "builder_new returned null");
@@ -96,9 +111,8 @@ where
 
 #[test]
 fn builder_allow_degraded_marks_protection_degradable() {
-    let sandbox = build_via_ffi(|b| unsafe {
-        sandlock_sandbox_builder_allow_degraded(b, PROT_SIGNAL_SCOPE)
-    });
+    let sandbox =
+        build_via_ffi(|b| unsafe { sandlock_sandbox_builder_allow_degraded(b, PROT_SIGNAL_SCOPE) });
     assert_eq!(
         sandbox.protection_policy.state(Protection::SignalScope),
         ProtectionState::Degradable,
@@ -116,7 +130,9 @@ fn builder_disable_marks_protection_disabled() {
         sandlock_sandbox_builder_disable(b, PROT_ABSTRACT_UNIX_SOCKET_SCOPE)
     });
     assert_eq!(
-        sandbox.protection_policy.state(Protection::AbstractUnixSocketScope),
+        sandbox
+            .protection_policy
+            .state(Protection::AbstractUnixSocketScope),
         ProtectionState::Disabled,
     );
     assert_eq!(
@@ -161,14 +177,11 @@ fn builder_setters_chain_and_last_call_wins() {
 fn builder_setters_tolerate_null_builder() {
     // Null in, null out — no panic. Matches the convention of every
     // other `sandlock_sandbox_builder_*` setter.
-    let out = unsafe {
-        sandlock_sandbox_builder_allow_degraded(std::ptr::null_mut(), PROT_SIGNAL_SCOPE)
-    };
+    let out =
+        unsafe { sandlock_sandbox_builder_allow_degraded(std::ptr::null_mut(), PROT_SIGNAL_SCOPE) };
     assert!(out.is_null(), "allow_degraded(null, _) must return null");
 
-    let out = unsafe {
-        sandlock_sandbox_builder_disable(std::ptr::null_mut(), PROT_FS_REFER)
-    };
+    let out = unsafe { sandlock_sandbox_builder_disable(std::ptr::null_mut(), PROT_FS_REFER) };
     assert!(out.is_null(), "disable(null, _) must return null");
 }
 
@@ -200,15 +213,14 @@ fn allow_degraded_with_unknown_discriminant_is_a_noop() {
     // The builder pointer must be returned untouched, and the
     // resulting Sandbox must have no `Degradable` state set.
     for &raw in INVALID_DISCRIMINANTS {
-        let sandbox = build_via_ffi(|b| unsafe {
-            sandlock_sandbox_builder_allow_degraded(b, raw)
-        });
+        let sandbox = build_via_ffi(|b| unsafe { sandlock_sandbox_builder_allow_degraded(b, raw) });
         for p in Protection::all() {
             assert_eq!(
                 sandbox.protection_policy.state(p),
                 ProtectionState::Strict,
                 "raw discriminant {} must leave {:?} at the default Strict state",
-                raw, p,
+                raw,
+                p,
             );
         }
     }
@@ -217,15 +229,14 @@ fn allow_degraded_with_unknown_discriminant_is_a_noop() {
 #[test]
 fn disable_with_unknown_discriminant_is_a_noop() {
     for &raw in INVALID_DISCRIMINANTS {
-        let sandbox = build_via_ffi(|b| unsafe {
-            sandlock_sandbox_builder_disable(b, raw)
-        });
+        let sandbox = build_via_ffi(|b| unsafe { sandlock_sandbox_builder_disable(b, raw) });
         for p in Protection::all() {
             assert_eq!(
                 sandbox.protection_policy.state(p),
                 ProtectionState::Strict,
                 "raw discriminant {} must leave {:?} at the default Strict state",
-                raw, p,
+                raw,
+                p,
             );
         }
     }

--- a/go/README.md
+++ b/go/README.md
@@ -76,6 +76,7 @@ fresh native policy on each call.
 | Environment | `CleanEnv`, `Env` |
 | Misc | `UID`, `NoCoredump`, `Name` |
 | COW branch | `FSStorage`, `OnExit`, `OnError` |
+| Dynamic policy | `PolicyFn` |
 
 `NetAllow` entries follow sandlock's rule grammar: bare `host:port` is TCP
 (`"api.openai.com:443"`, `"github.com:22,443"`, `":53"`); a target may be a
@@ -105,6 +106,44 @@ func (s *Sandbox) Spawn(cmd ...string) (*Process, error)
   filesystem `Changes` it would have made, and discards them. Requires
   `Workdir`.
 - **Spawn** starts a process without waiting, returning a `*Process`.
+
+### Dynamic policy callbacks
+
+```go
+type PolicyFunc func(event SyscallEvent, ctx *PolicyContext) PolicyDecision
+
+func Allow() PolicyDecision
+func Deny() PolicyDecision
+func Audit() PolicyDecision
+func DenyWith(errnoValue int) PolicyDecision
+
+func (e SyscallEvent) ArgvContains(sub string) bool
+
+func (ctx *PolicyContext) RestrictNetwork(ips []string) error
+func (ctx *PolicyContext) GrantNetwork(ips []string) error
+func (ctx *PolicyContext) RestrictMaxMemory(bytes uint64)
+func (ctx *PolicyContext) RestrictMaxProcesses(n uint32)
+func (ctx *PolicyContext) RestrictPIDNetwork(pid uint32, ips []string) error
+func (ctx *PolicyContext) DenyPath(path string) error
+func (ctx *PolicyContext) AllowPath(path string) error
+```
+
+`PolicyFn` receives dynamic syscall events from sandlock's policy-fn worker
+thread. Path strings are deliberately absent; use Landlock fields for static
+path policy and `DenyPath`/`AllowPath` for the dynamic path-deny hook. `Argv`
+is populated for `execve`/`execveat` events.
+
+```go
+sb := &sandlock.Sandbox{
+    FSReadable: []string{"/usr", "/lib", "/lib64", "/bin", "/etc"},
+    PolicyFn: func(event sandlock.SyscallEvent, ctx *sandlock.PolicyContext) sandlock.PolicyDecision {
+        if event.Syscall == "execve" && event.ArgvContains("curl") {
+            return sandlock.Deny()
+        }
+        return sandlock.Allow()
+    },
+}
+```
 
 ### Process lifecycle
 
@@ -140,14 +179,10 @@ func SyscallNr(name string) (int, error)
 
 ## Status
 
-This SDK covers the static policy surface plus in-process `Confine`. The
-following sandlock features are not yet bound and are tracked as follow-ups:
-dynamic `policy_fn` callbacks, custom seccomp handlers, pipelines, gather
-(fan-in), COW `fork`/`reduce`, and `checkpoint`/restore.
-
-`policy_fn` in particular needs a small upstream addition — a `void *user_data`
-parameter on `sandlock_sandbox_builder_policy_fn` — before Go can route the
-callback to a per-`Sandbox` closure. See the SDK's tracking issue.
+This SDK covers the static policy surface, dynamic `policy_fn` callbacks, and
+in-process `Confine`. The following sandlock features are not yet bound and are
+tracked as follow-ups: custom seccomp handlers, pipelines, gather (fan-in), COW
+`fork`/`reduce`, and `checkpoint`/restore.
 
 ## License
 

--- a/go/sandbox.go
+++ b/go/sandbox.go
@@ -30,6 +30,11 @@
 //	fmt.Printf("%d: %s", res.ExitCode, res.Stdout)
 package sandlock
 
+import (
+	"strings"
+	"unsafe"
+)
+
 // BranchAction is the action taken on a copy-on-write working-directory
 // branch when the sandbox exits. The zero value, BranchActionDefault, leaves
 // the choice to sandlock's own defaults (commit on success, abort on error).
@@ -45,6 +50,105 @@ const (
 	// BranchActionKeep leaves the branch in place for the caller to handle.
 	BranchActionKeep
 )
+
+// SyscallCategory is the high-level category of an intercepted syscall event.
+type SyscallCategory uint8
+
+const (
+	// CategoryFile covers filesystem operations such as openat and unlinkat.
+	CategoryFile SyscallCategory = iota
+	// CategoryNetwork covers network operations such as connect and bind.
+	CategoryNetwork
+	// CategoryProcess covers process lifecycle operations such as execve.
+	CategoryProcess
+	// CategoryMemory covers memory-management operations such as mmap.
+	CategoryMemory
+)
+
+// String returns the category name used by the Python SDK.
+func (c SyscallCategory) String() string {
+	switch c {
+	case CategoryFile:
+		return "file"
+	case CategoryNetwork:
+		return "network"
+	case CategoryProcess:
+		return "process"
+	case CategoryMemory:
+		return "memory"
+	default:
+		return "unknown"
+	}
+}
+
+// SyscallEvent is a policy_fn event delivered by the sandbox supervisor.
+//
+// Path strings are intentionally absent. Path-based access control belongs in
+// Landlock rules (FSReadable, FSWritable, FSDenied). Argv is populated only for
+// execve/execveat events, where sandlock freezes sibling tasks before exposing
+// it to the policy callback.
+type SyscallEvent struct {
+	Syscall   string
+	Category  SyscallCategory
+	PID       uint32
+	ParentPID uint32
+	Host      string
+	Port      uint16
+	Denied    bool
+	Argv      []string
+}
+
+// ArgvContains reports whether any argv element contains sub.
+func (e SyscallEvent) ArgvContains(sub string) bool {
+	for _, arg := range e.Argv {
+		if strings.Contains(arg, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// PolicyDecision is the result returned by a PolicyFunc.
+type PolicyDecision int32
+
+const (
+	// DecisionAllow allows the syscall.
+	DecisionAllow PolicyDecision = 0
+	// DecisionDeny denies the syscall with EPERM.
+	DecisionDeny PolicyDecision = -1
+	// DecisionAudit allows the syscall and flags it for audit.
+	DecisionAudit PolicyDecision = -2
+)
+
+// Allow returns a decision that allows the syscall.
+func Allow() PolicyDecision { return DecisionAllow }
+
+// Deny returns a decision that denies the syscall with EPERM.
+func Deny() PolicyDecision { return DecisionDeny }
+
+// Audit returns a decision that allows the syscall and flags it for audit.
+func Audit() PolicyDecision { return DecisionAudit }
+
+// DenyWith returns a decision that denies the syscall with errnoValue.
+func DenyWith(errnoValue int) PolicyDecision {
+	if errnoValue <= 0 {
+		return DecisionDeny
+	}
+	return PolicyDecision(errnoValue)
+}
+
+// PolicyContext lets a PolicyFunc adjust selected live policy state.
+//
+// A PolicyContext is valid only during the PolicyFunc call that received it.
+// Do not retain it after the callback returns.
+type PolicyContext struct {
+	ptr unsafe.Pointer
+}
+
+// PolicyFunc is a dynamic policy callback invoked from sandlock's policy-fn
+// worker thread. Callbacks may be invoked concurrently with other sandbox
+// activity, so captured state should be synchronized when mutated.
+type PolicyFunc func(event SyscallEvent, ctx *PolicyContext) PolicyDecision
 
 // Sandbox holds the policy configuration for confining a process. Every field
 // is optional; an unset field means "no restriction" unless documented
@@ -136,6 +240,10 @@ type Sandbox struct {
 	// Name is the sandbox name and its virtual hostname inside the sandbox.
 	// Empty auto-generates "sandbox-{pid}".
 	Name string
+
+	// PolicyFn receives dynamic syscall events and may return an allow/deny
+	// decision or modify live policy through the supplied context.
+	PolicyFn PolicyFunc
 }
 
 // Result is the outcome of a captured run.

--- a/go/sandlock_linux.go
+++ b/go/sandlock_linux.go
@@ -10,6 +10,9 @@ package sandlock
 // prototypes stay in lock-step with crates/sandlock-ffi automatically.
 #include <stdlib.h>
 #include "sandlock.h"
+
+extern int32_t goPolicyCallback(sandlock_event_t *event, sandlock_ctx_t *ctx, void *user_data);
+extern void goPolicyDrop(void *user_data);
 */
 import "C"
 
@@ -20,6 +23,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 	"unsafe"
@@ -32,6 +36,88 @@ import (
 func hasNUL(s string) bool { return strings.IndexByte(s, 0) >= 0 }
 
 func cbool(v bool) C.bool { return C.bool(v) }
+
+var (
+	nextPolicyCallbackID atomic.Uint64
+	policyCallbacks      sync.Map // uint64 -> PolicyFunc
+)
+
+func registerPolicyCallback(fn PolicyFunc) unsafe.Pointer {
+	id := nextPolicyCallbackID.Add(1)
+	userData := C.malloc(C.size_t(unsafe.Sizeof(C.uint64_t(0))))
+	if userData == nil {
+		panic("sandlock: failed to allocate policy callback handle")
+	}
+	*(*C.uint64_t)(userData) = C.uint64_t(id)
+	policyCallbacks.Store(id, fn)
+	return userData
+}
+
+func unregisterPolicyCallback(userData unsafe.Pointer) {
+	if userData == nil {
+		return
+	}
+	policyCallbacks.Delete(uint64(*(*C.uint64_t)(userData)))
+	C.free(userData)
+}
+
+func policyCallbackID(userData unsafe.Pointer) uint64 {
+	if userData == nil {
+		return 0
+	}
+	return uint64(*(*C.uint64_t)(userData))
+}
+
+func policyEventFromC(ev *C.sandlock_event_t) SyscallEvent {
+	if ev == nil {
+		return SyscallEvent{}
+	}
+	out := SyscallEvent{
+		Syscall:   C.GoString(ev.syscall),
+		Category:  SyscallCategory(ev.category),
+		PID:       uint32(ev.pid),
+		ParentPID: uint32(ev.parent_pid),
+		Port:      uint16(ev.port),
+		Denied:    bool(ev.denied),
+	}
+	if ev.host != nil {
+		out.Host = C.GoString(ev.host)
+	}
+	if ev.argv != nil && ev.argc > 0 {
+		args := unsafe.Slice((**C.char)(unsafe.Pointer(ev.argv)), int(ev.argc))
+		out.Argv = make([]string, 0, len(args))
+		for _, arg := range args {
+			if arg != nil {
+				out.Argv = append(out.Argv, C.GoString(arg))
+			}
+		}
+	}
+	return out
+}
+
+//export goPolicyCallback
+func goPolicyCallback(event *C.sandlock_event_t, ctx *C.sandlock_ctx_t, userData unsafe.Pointer) (ret C.int32_t) {
+	ret = C.int32_t(DecisionDeny)
+	defer func() {
+		if recover() != nil {
+			ret = C.int32_t(DecisionDeny)
+		}
+	}()
+
+	fn, ok := policyCallbacks.Load(policyCallbackID(userData))
+	if !ok {
+		return C.int32_t(DecisionDeny)
+	}
+	decision := fn.(PolicyFunc)(policyEventFromC(event), &PolicyContext{
+		ptr: unsafe.Pointer(ctx),
+	})
+	return C.int32_t(decision)
+}
+
+//export goPolicyDrop
+func goPolicyDrop(userData unsafe.Pointer) {
+	unregisterPolicyCallback(userData)
+}
 
 // validateStrings rejects any configuration string carrying a NUL byte before
 // a builder is allocated. The FFI has no builder-free entry point, so a failure
@@ -284,6 +370,14 @@ func (s *Sandbox) buildPolicy() (*C.sandlock_sandbox_t, error) {
 	if s.OnError != BranchActionDefault {
 		b = C.sandlock_sandbox_builder_on_error(b, C.uint8_t(s.OnError-1))
 	}
+	if s.PolicyFn != nil {
+		b = C.sandlock_sandbox_builder_policy_fn(
+			b,
+			(C.sandlock_policy_fn_t)(C.goPolicyCallback),
+			registerPolicyCallback(s.PolicyFn),
+			(*[0]byte)(C.goPolicyDrop),
+		)
+	}
 
 	var errCode C.int
 	var errMsg *C.char
@@ -337,6 +431,102 @@ func freeArgv(argv []*C.char) {
 	for _, p := range argv {
 		C.free(unsafe.Pointer(p))
 	}
+}
+
+func cStringArray(vals []string) ([]*C.char, error) {
+	out := make([]*C.char, len(vals))
+	for i, v := range vals {
+		if hasNUL(v) {
+			for j := 0; j < i; j++ {
+				C.free(unsafe.Pointer(out[j]))
+			}
+			return nil, ErrInvalidString
+		}
+		out[i] = C.CString(v)
+	}
+	return out, nil
+}
+
+func cStringArrayPtr(vals []*C.char) (**C.char, C.uint32_t) {
+	if len(vals) == 0 {
+		return nil, 0
+	}
+	return (**C.char)(unsafe.Pointer(&vals[0])), C.uint32_t(len(vals))
+}
+
+func (c *PolicyContext) cptr() *C.sandlock_ctx_t {
+	if c == nil || c.ptr == nil {
+		return nil
+	}
+	return (*C.sandlock_ctx_t)(c.ptr)
+}
+
+// RestrictNetwork permanently restricts the live network policy to ips.
+func (c *PolicyContext) RestrictNetwork(ips []string) error {
+	cips, err := cStringArray(ips)
+	if err != nil {
+		return err
+	}
+	defer freeArgv(cips)
+	ptr, n := cStringArrayPtr(cips)
+	C.sandlock_ctx_restrict_network(c.cptr(), ptr, n)
+	return nil
+}
+
+// GrantNetwork grants ips within the sandbox's immutable network ceiling.
+func (c *PolicyContext) GrantNetwork(ips []string) error {
+	cips, err := cStringArray(ips)
+	if err != nil {
+		return err
+	}
+	defer freeArgv(cips)
+	ptr, n := cStringArrayPtr(cips)
+	C.sandlock_ctx_grant_network(c.cptr(), ptr, n)
+	return nil
+}
+
+// RestrictMaxMemory permanently restricts the live max-memory policy.
+func (c *PolicyContext) RestrictMaxMemory(bytes uint64) {
+	C.sandlock_ctx_restrict_max_memory(c.cptr(), C.uint64_t(bytes))
+}
+
+// RestrictMaxProcesses permanently restricts the live max-processes policy.
+func (c *PolicyContext) RestrictMaxProcesses(n uint32) {
+	C.sandlock_ctx_restrict_max_processes(c.cptr(), C.uint32_t(n))
+}
+
+// RestrictPIDNetwork restricts network access for a specific process.
+func (c *PolicyContext) RestrictPIDNetwork(pid uint32, ips []string) error {
+	cips, err := cStringArray(ips)
+	if err != nil {
+		return err
+	}
+	defer freeArgv(cips)
+	ptr, n := cStringArrayPtr(cips)
+	C.sandlock_ctx_restrict_pid_network(c.cptr(), C.uint32_t(pid), ptr, n)
+	return nil
+}
+
+// DenyPath dynamically denies access to path for mediated openat checks.
+func (c *PolicyContext) DenyPath(path string) error {
+	if hasNUL(path) {
+		return ErrInvalidString
+	}
+	cp := C.CString(path)
+	defer C.free(unsafe.Pointer(cp))
+	C.sandlock_ctx_deny_path(c.cptr(), cp)
+	return nil
+}
+
+// AllowPath removes a dynamic path denial previously added by DenyPath.
+func (c *PolicyContext) AllowPath(path string) error {
+	if hasNUL(path) {
+		return ErrInvalidString
+	}
+	cp := C.CString(path)
+	defer C.free(unsafe.Pointer(cp))
+	C.sandlock_ctx_allow_path(c.cptr(), cp)
+	return nil
 }
 
 // argvPtr returns the pointer/count pair for an argv slice.

--- a/go/sandlock_linux_test.go
+++ b/go/sandlock_linux_test.go
@@ -91,6 +91,86 @@ func TestRunNULRejected(t *testing.T) {
 	}
 }
 
+func TestSyscallEventArgvContains(t *testing.T) {
+	ev := sandlock.SyscallEvent{Argv: []string{"python3", "-c", "print(1)"}}
+	if !ev.ArgvContains("python") {
+		t.Fatal("ArgvContains did not find substring")
+	}
+	if ev.ArgvContains("ruby") {
+		t.Fatal("ArgvContains found absent substring")
+	}
+}
+
+func TestPolicyDecisionValues(t *testing.T) {
+	if sandlock.Allow() != sandlock.DecisionAllow {
+		t.Fatal("Allow did not return DecisionAllow")
+	}
+	if sandlock.Deny() != sandlock.DecisionDeny {
+		t.Fatal("Deny did not return DecisionDeny")
+	}
+	if sandlock.Audit() != sandlock.DecisionAudit {
+		t.Fatal("Audit did not return DecisionAudit")
+	}
+	if got := sandlock.DenyWith(13); got == sandlock.DecisionAllow {
+		t.Fatal("DenyWith returned allow for positive errno")
+	}
+	if got := sandlock.DenyWith(0); got != sandlock.DecisionDeny {
+		t.Fatalf("DenyWith(0) = %d, want deny", got)
+	}
+}
+
+func TestPolicyFnDenyByArgv(t *testing.T) {
+	requireLandlock(t)
+	sb := &sandlock.Sandbox{
+		FSReadable: rootfs,
+		PolicyFn: func(event sandlock.SyscallEvent, ctx *sandlock.PolicyContext) sandlock.PolicyDecision {
+			if event.Syscall == "execve" && event.ArgvContains("sandlock-go-deny-token") {
+				return sandlock.Deny()
+			}
+			return sandlock.Allow()
+		},
+	}
+	res, err := sb.Run(context.Background(), "sh", "-c", "echo sandlock-go-deny-token")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Success {
+		t.Fatalf("expected policy_fn to deny execve, got success stdout=%q", res.Stdout)
+	}
+}
+
+func TestPolicyFnReceivesExecveArgv(t *testing.T) {
+	requireLandlock(t)
+	seen := make(chan []string, 1)
+	sb := &sandlock.Sandbox{
+		FSReadable: rootfs,
+		PolicyFn: func(event sandlock.SyscallEvent, ctx *sandlock.PolicyContext) sandlock.PolicyDecision {
+			if event.Syscall == "execve" && len(event.Argv) > 0 {
+				select {
+				case seen <- append([]string(nil), event.Argv...):
+				default:
+				}
+			}
+			return sandlock.Allow()
+		},
+	}
+	res, err := sb.Run(context.Background(), "echo", "policy-fn-ok")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !res.Success {
+		t.Fatalf("expected success, got exit=%d stderr=%q", res.ExitCode, res.Stderr)
+	}
+	select {
+	case argv := <-seen:
+		if len(argv) == 0 {
+			t.Fatal("empty argv")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("policy_fn did not receive execve argv")
+	}
+}
+
 func TestDryRun(t *testing.T) {
 	requireLandlock(t)
 	dir := t.TempDir()

--- a/python/src/sandlock/_sdk.py
+++ b/python/src/sandlock/_sdk.py
@@ -180,10 +180,20 @@ class _CEvent(ctypes.Structure):
     ]
 
 _c_ctx_p = ctypes.c_void_p
-_POLICY_FN_TYPE = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.POINTER(_CEvent), _c_ctx_p)
+_POLICY_FN_TYPE = ctypes.CFUNCTYPE(
+    ctypes.c_int32,
+    ctypes.POINTER(_CEvent),
+    _c_ctx_p,
+    ctypes.c_void_p,
+)
 
 _lib.sandlock_sandbox_builder_policy_fn.restype = _c_builder_p
-_lib.sandlock_sandbox_builder_policy_fn.argtypes = [_c_builder_p, _POLICY_FN_TYPE]
+_lib.sandlock_sandbox_builder_policy_fn.argtypes = [
+    _c_builder_p,
+    _POLICY_FN_TYPE,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+]
 
 _lib.sandlock_ctx_restrict_network.restype = None
 _lib.sandlock_ctx_restrict_network.argtypes = [_c_ctx_p, ctypes.POINTER(ctypes.c_char_p), ctypes.c_uint32]
@@ -1130,7 +1140,7 @@ class _NativePolicy:
         # Store callback reference to prevent GC
         c_callback = None
         if policy_fn is not None:
-            def _c_callback(event_p, ctx_p):
+            def _c_callback(event_p, ctx_p, _user_data):
                 ev = event_p.contents
                 py_argv = None
                 if ev.argv and ev.argc > 0:
@@ -1169,7 +1179,7 @@ class _NativePolicy:
                 return 0
 
             c_callback = _POLICY_FN_TYPE(_c_callback)
-            b = _lib.sandlock_sandbox_builder_policy_fn(b, c_callback)
+            b = _lib.sandlock_sandbox_builder_policy_fn(b, c_callback, None, None)
 
         err = ctypes.c_int(0)
         err_msg = ctypes.c_char_p()


### PR DESCRIPTION
## Summary

This updates the FFI `policy_fn` ABI so bindings can associate callback invocations with per-binding/per-sandbox state, and wires that through the Go SDK in the same PR.

- add `void *user_data` to `sandlock_policy_fn_t`
- add an optional `user_data_drop` hook to `sandlock_sandbox_builder_policy_fn`
- keep callback state alive inside the native policy callback and call the drop hook when the final native callback reference is released
- regenerate `crates/sandlock-ffi/include/sandlock.h`
- update Python ctypes bindings to the new signature while preserving existing Python behavior by passing null user data/drop
- add lifecycle coverage for the drop hook plus C smoke coverage for the new C signature
- add Go `PolicyFn`, `SyscallEvent`, `PolicyDecision`, and `PolicyContext` bindings
- expose Go dynamic policy context helpers for network, resource, PID network, and path allow/deny adjustments
- document the dynamic policy callback API in `go/README.md`

This implements the Go `policy_fn` binding discussed in #76: Go/cgo uses one exported callback and routes to a per-`Sandbox` closure via `user_data`.

## Verification

Passed:

- GitHub Actions: Go SDK on `ubuntu-latest` and `ubuntu-24.04-arm`
- GitHub Actions: Python tests on `ubuntu-latest` / `ubuntu-24.04-arm`, py3.10/3.11/3.12
- GitHub Actions: Rust tests on `ubuntu-latest` / `ubuntu-24.04-arm`
- GitHub Actions: Rust cross-build `riscv64`
- GitHub Actions: cbindgen header up to date
- `cbindgen --config crates/sandlock-ffi/cbindgen.toml --crate sandlock-ffi --output crates/sandlock-ffi/include/sandlock.h && git diff --check`
- `python3 -m py_compile python/src/sandlock/_sdk.py`
- Docker Linux: `cargo check -p sandlock-ffi`
- Docker Linux: `cargo test -p sandlock-ffi --test policy_fn -- --nocapture`
- Docker Linux: `cd go && go vet ./...`
- Docker Linux: pure Go tests for validation/helpers (`go test . -run 'Test(SyscallEventArgvContains|PolicyDecisionValues|RunEmptyCommand|RunNULRejected|SyscallNr)$'`)
- Debian 12 host, Rust 1.96: `cargo test -p sandlock-ffi --test policy_fn -- --nocapture`

Notes:

- The local Docker environment cannot create live sandboxes, so full runtime suites are not reliable there.
- The extra Debian 12 / Linux 6.1.0-44 host exposes Landlock ABI v2, below sandlock's required ABI v6. Go runtime tests skip there, and live Rust/FFI sandbox tests fail before the child writes its seccomp notification fd. Child stderr shows the underlying cause: `required protection FsTruncate is not available: host Landlock ABI is v2, requires v3`.
