### PR TITLE
ffi: fail closed on unrecognized policy_fn return values

### DIFF
--- a/crates/sandlock-ffi/include/sandlock.h
+++ b/crates/sandlock-ffi/include/sandlock.h
@@ -160,7 +160,8 @@ typedef struct {
 /**
  * C callback type for policy_fn.
  * Return value: 0 = allow, -1 = deny (EPERM), -2 = audit (allow + flag),
- * positive = deny with that errno (e.g. 13 = EACCES).
+ * positive = deny with that errno (e.g. 13 = EACCES). Any other value fails
+ * closed (deny); do not return `-errno`, which is reserved and not allowed.
  */
 typedef int32_t (*sandlock_policy_fn_t)(const sandlock_event_t *event,
                                         sandlock_ctx_t *ctx,

--- a/crates/sandlock-ffi/src/lib.rs
+++ b/crates/sandlock-ffi/src/lib.rs
@@ -1813,7 +1813,8 @@ pub struct sandlock_ctx_t {
 
 /// C callback type for policy_fn.
 /// Return value: 0 = allow, -1 = deny (EPERM), -2 = audit (allow + flag),
-/// positive = deny with that errno (e.g. 13 = EACCES).
+/// positive = deny with that errno (e.g. 13 = EACCES). Any other value fails
+/// closed (deny); do not return `-errno`, which is reserved and not allowed.
 #[allow(non_camel_case_types)]
 pub type sandlock_policy_fn_t = unsafe extern "C" fn(
     event: *const sandlock_event_t,
@@ -1852,6 +1853,24 @@ impl Drop for PolicyCallbackState {
         if let Some(drop_fn) = self.user_data_drop {
             unsafe { drop_fn(self.user_data) };
         }
+    }
+}
+
+/// Translate a C policy callback's return value into a core `Verdict`.
+///
+/// `0` allows, `-1` denies (EPERM), `-2` audits, and any positive value denies
+/// with that errno. Every other value fails closed (`Deny`): a negative other
+/// than -1/-2 is reserved and a likely `-errno` mistake by a caller used to
+/// kernel convention, so denying keeps a typo'd verdict from silently disabling
+/// the policy.
+fn policy_ret_to_verdict(ret: i32) -> sandlock_core::policy_fn::Verdict {
+    use sandlock_core::policy_fn::Verdict;
+    match ret {
+        0 => Verdict::Allow,
+        -1 => Verdict::Deny,
+        -2 => Verdict::Audit,
+        errno if errno > 0 => Verdict::DenyWith(errno),
+        _ => Verdict::Deny,
     }
 }
 
@@ -1928,13 +1947,7 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_policy_fn(
         let mut c_ctx = sandlock_ctx_t { ctx: ctx as *mut _ };
 
         let ret = unsafe { state.call(&c_event, &mut c_ctx) };
-        match ret {
-            0 => sandlock_core::policy_fn::Verdict::Allow,
-            -1 => sandlock_core::policy_fn::Verdict::Deny,
-            -2 => sandlock_core::policy_fn::Verdict::Audit,
-            errno if errno > 0 => sandlock_core::policy_fn::Verdict::DenyWith(errno),
-            _ => sandlock_core::policy_fn::Verdict::Allow,
-        }
+        policy_ret_to_verdict(ret)
     };
 
     Box::into_raw(Box::new(builder.policy_fn(cb_fn)))
@@ -2425,4 +2438,27 @@ unsafe fn read_argv(argv: *const *const c_char, argc: c_uint) -> Vec<String> {
         args.push(arg);
     }
     args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::policy_ret_to_verdict;
+    use sandlock_core::policy_fn::Verdict;
+
+    #[test]
+    fn policy_ret_maps_documented_values() {
+        assert_eq!(policy_ret_to_verdict(0), Verdict::Allow);
+        assert_eq!(policy_ret_to_verdict(-1), Verdict::Deny);
+        assert_eq!(policy_ret_to_verdict(-2), Verdict::Audit);
+        assert_eq!(policy_ret_to_verdict(13), Verdict::DenyWith(13));
+    }
+
+    #[test]
+    fn policy_ret_unrecognized_values_fail_closed() {
+        // A negative other than -1/-2 is the classic `-errno` mistake; it must
+        // deny, not silently allow.
+        assert_eq!(policy_ret_to_verdict(-13), Verdict::Deny);
+        assert_eq!(policy_ret_to_verdict(-3), Verdict::Deny);
+        assert_eq!(policy_ret_to_verdict(i32::MIN), Verdict::Deny);
+    }
 }

--- a/python/src/sandlock/_sdk.py
+++ b/python/src/sandlock/_sdk.py
@@ -1176,7 +1176,9 @@ class _NativePolicy:
                     return -2
                 if isinstance(result, int) and result > 0:
                     return result
-                return 0
+                # Unrecognized return values fail closed (deny) rather than
+                # silently allowing the syscall.
+                return -1
 
             c_callback = _POLICY_FN_TYPE(_c_callback)
             b = _lib.sandlock_sandbox_builder_policy_fn(b, c_callback, None, None)

--- a/python/tests/test_policy_fn.py
+++ b/python/tests/test_policy_fn.py
@@ -206,6 +206,16 @@ class TestPolicyFnVerdict:
         )
         assert result.success, "audit should allow the syscall"
 
+    def test_unrecognized_return_fails_closed(self):
+        """An unrecognized return value denies rather than silently allowing."""
+        def on_event(event, ctx):
+            if event.syscall in ("execve", "execveat"):
+                return "bogus"  # not a recognized verdict
+            return 0
+
+        result = _policy(policy_fn=on_event).run(["echo", "should-not-run"])
+        assert not result.success, "unrecognized verdict must fail closed (deny)"
+
     def test_deny_returns_true(self):
         """Return True to deny with EPERM (backward compat)."""
         def on_event(event, ctx):


### PR DESCRIPTION
## Summary

Follow-up to #91. The `policy_fn` return-value adapter mapped any unrecognized
value to `Allow`, so a callback that returned a negative other than -1/-2 (the
classic `-errno` mistake by a caller used to kernel convention) would silently
*allow* the syscall instead of denying it: a security control disabling itself
with no error. This makes the unrecognized case fail closed (`Deny`).

## Changes

- crates/sandlock-ffi/src/lib.rs: extract the return-to-`Verdict` mapping into
  `policy_ret_to_verdict` and change the catch-all from `Allow` to `Deny`. Add
  unit tests pinning the documented arms plus the fail-closed default.
- crates/sandlock-ffi/include/sandlock.h: regenerated; documents that any other
  value fails closed and that `-errno` is reserved.
- python/src/sandlock/_sdk.py: the Python adapter had the same fail-open
  catch-all one layer up (it normalizes Python returns before the FFI). Harden
  its final `return 0` to `return -1` for consistency, plus an integration test.

Go needs no change: its decisions come only from the typed `Allow`/`Deny`/
`Audit`/`DenyWith` constructors (`DenyWith` already maps `<= 0` to deny), and a
raw `PolicyDecision` cast now benefits from the FFI fix.

## Verification

- `cargo test --release -p sandlock-ffi --lib` (incl. new `policy_ret_*` tests)
- `cargo test --release -p sandlock-ffi --test policy_fn` (drop lifecycle)
- `cargo fmt -p sandlock-ffi -- --check`
- cbindgen header regenerated and matches
- `python3 -m pytest tests/test_policy_fn.py` (18 passed, incl. new fail-closed test)