### PR TITLE
go: support pkg-config builds and add install-go-lib for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,5 +142,5 @@ jobs:
       - name: Vet and test
         working-directory: go
         run: |
-          go vet ./...
-          go test ./... -v
+          go vet -tags sandlock_repo ./...
+          go test -tags sandlock_repo ./... -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,10 +213,86 @@ jobs:
           pip install twine
           twine upload dist/*
 
+  # Stage a pkg-config-installable tree (libsandlock_ffi.so + sandlock.h +
+  # sandlock.pc) so Go SDK users can install the native side from a release
+  # asset instead of building it from source. Built natively per arch so the
+  # shared library matches the target's glibc, mirroring the `build` job.
+  go-libs:
+    name: Go native libs (${{ matrix.target }})
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runs-on: ubuntu-22.04
+          - target: aarch64-unknown-linux-gnu
+            runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      # PREFIX=/usr/local is baked into the generated sandlock.pc; users extract
+      # the tarball into / (so files land under /usr/local) and pkg-config finds
+      # it via its default search path.
+      - name: Stage pkg-config install tree
+        run: |
+          make install-go-lib PREFIX=/usr/local DESTDIR="$PWD/stage"
+          tar -czf sandlock-go-${{ matrix.target }}.tar.gz -C stage .
+
+      # Smoke-test the released (default, pkg-config) build mode against the very
+      # tree we are shipping. Copy the staged files into the real prefix rather
+      # than re-running the Makefile, which would invoke cargo under sudo without
+      # the toolchain on PATH.
+      - name: Verify the Go SDK builds in released mode
+        run: |
+          sudo cp -a stage/usr/local/. /usr/local/
+          sudo ldconfig
+          (cd go && go build ./...)
+
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: sandlock-go-${{ matrix.target }}
+          path: sandlock-go-${{ matrix.target }}.tar.gz
+
+  # Publish the Go module by pushing a subdirectory-prefixed tag. `go get
+  # github.com/multikernel/sandlock/go` resolves `go/vX.Y.Z` tags; the plain
+  # `vX.Y.Z` release tag does not publish the module. Pushing `go/<ver>` does
+  # not re-trigger this workflow, whose tag filter is `v*` (which `go/...` does
+  # not match).
+  tag-go-module:
+    name: Tag Go module
+    needs: [build, test, go-libs]
+    # Only on a real tag push; a manual workflow_dispatch has no release tag.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create and push go/<version> tag
+        run: |
+          gotag="go/${{ github.ref_name }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${gotag}" >/dev/null 2>&1; then
+            echo "::notice::${gotag} already exists; leaving it untouched."
+            exit 0
+          fi
+          git tag "${gotag}" "${{ github.sha }}"
+          git push origin "${gotag}"
+
   # Create GitHub Release with Rust binaries
   github-release:
     name: GitHub Release
-    needs: [build, test]
+    needs: [build, test, go-libs]
     # Only cut a GitHub Release on a real tag push, not on a manual
     # workflow_dispatch (which has no tag to attach assets to).
     if: github.event_name == 'push'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+# sandlock build helpers.
+#
+# The Go SDK links the native libsandlock_ffi via cgo. Released builds discover
+# it through pkg-config; `install-go-lib` lays down the three files pkg-config
+# needs (the shared library, the cbindgen header, and sandlock.pc).
+
+PREFIX ?= /usr/local
+DESTDIR ?=
+VERSION := $(shell sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+
+LIBDIR := $(DESTDIR)$(PREFIX)/lib
+INCLUDEDIR := $(DESTDIR)$(PREFIX)/include
+PCDIR := $(LIBDIR)/pkgconfig
+
+.PHONY: ffi install-go-lib uninstall-go-lib
+
+# Build the native FFI shared library.
+ffi:
+	cargo build --release -p sandlock-ffi
+
+# Install the native library, header, and pkg-config file so that
+# `pkg-config --cflags --libs sandlock` resolves and the Go SDK builds in its
+# default (pkg-config) mode. Honors PREFIX and DESTDIR.
+install-go-lib: ffi
+	install -Dm755 target/release/libsandlock_ffi.so $(LIBDIR)/libsandlock_ffi.so
+	install -Dm644 crates/sandlock-ffi/include/sandlock.h $(INCLUDEDIR)/sandlock.h
+	install -d $(PCDIR)
+	sed -e 's|@PREFIX@|$(PREFIX)|g' -e 's|@VERSION@|$(VERSION)|g' \
+		go/sandlock.pc.in > $(PCDIR)/sandlock.pc
+
+uninstall-go-lib:
+	rm -f $(LIBDIR)/libsandlock_ffi.so \
+		$(INCLUDEDIR)/sandlock.h \
+		$(PCDIR)/sandlock.pc

--- a/go/README.md
+++ b/go/README.md
@@ -14,19 +14,41 @@ import sandlock "github.com/multikernel/sandlock/go"
 
 ## Building
 
-cgo links against `libsandlock_ffi`, produced by the Rust workspace. The
-default link flags resolve the library relative to this package
-(`../target/release`), so build from a checkout of the sandlock repository:
+cgo links against `libsandlock_ffi`, produced by the Rust workspace. There are
+two build modes.
+
+### Released mode (default): installed library via pkg-config
+
+The default build resolves the library and header through `pkg-config`, so the
+SDK is usable from another module once the native side is installed. From a
+checkout of the sandlock repository:
 
 ```bash
-cargo build --release            # writes target/release/libsandlock_ffi.so
-cd go && go test ./...
+sudo make install-go-lib         # installs libsandlock_ffi.so, sandlock.h, sandlock.pc
+go get github.com/multikernel/sandlock/go
 ```
 
-To use the SDK from another module, point cgo at an installed library, e.g.:
+`make install-go-lib` honors `PREFIX` (default `/usr/local`) and `DESTDIR`. For
+a non-standard prefix, point pkg-config at it:
 
 ```bash
-CGO_LDFLAGS="-L/usr/local/lib -Wl,-rpath,/usr/local/lib" go build
+make install-go-lib PREFIX=$HOME/.local
+export PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig
+```
+
+The installed `sandlock.pc` bakes an rpath to its `libdir`, so binaries find the
+shared library at runtime without `LD_LIBRARY_PATH`.
+
+### In-tree mode: build against this checkout (`-tags sandlock_repo`)
+
+For development without installing, build with `-tags sandlock_repo`, which
+points cgo at this checkout's `target/release`:
+
+```bash
+cargo build --release -p sandlock-ffi    # writes target/release/libsandlock_ffi.so
+cd go && go build -tags sandlock_repo ./...
+# run the test suite the same way:
+go test -tags sandlock_repo ./...
 ```
 
 ## Quick start

--- a/go/cgo_pkgconfig.go
+++ b/go/cgo_pkgconfig.go
@@ -1,0 +1,13 @@
+//go:build linux && !sandlock_repo
+
+package sandlock
+
+// Default build mode: resolve the installed libsandlock_ffi and its header
+// through pkg-config. Install the native side first (for example with
+// `make install-go-lib` from the repository root, or a release tarball that
+// provides sandlock.pc, sandlock.h, and libsandlock_ffi.so), so that
+// `pkg-config --cflags --libs sandlock` succeeds. To build against an
+// uninstalled checkout instead, use `-tags sandlock_repo` (see cgo_repo.go).
+
+// #cgo pkg-config: sandlock
+import "C"

--- a/go/cgo_repo.go
+++ b/go/cgo_repo.go
@@ -1,0 +1,14 @@
+//go:build linux && sandlock_repo
+
+package sandlock
+
+// In-tree build mode (opt in with `-tags sandlock_repo`): resolve the header
+// and libsandlock_ffi from this checkout's build output, with no install step.
+// Build the native library first: `cargo build --release -p sandlock-ffi`.
+// This is the mode used by the repository's own CI and local development.
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/../crates/sandlock-ffi/include
+#cgo LDFLAGS: -L${SRCDIR}/../target/release -Wl,-rpath,${SRCDIR}/../target/release -lsandlock_ffi -lpthread -ldl -lm
+*/
+import "C"

--- a/go/sandlock.pc.in
+++ b/go/sandlock.pc.in
@@ -1,0 +1,11 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: sandlock
+Description: Lightweight Linux sandbox (sandlock-ffi C ABI)
+Version: @VERSION@
+Libs: -L${libdir} -Wl,-rpath,${libdir} -lsandlock_ffi
+Libs.private: -lpthread -ldl -lm
+Cflags: -I${includedir}

--- a/go/sandlock_linux.go
+++ b/go/sandlock_linux.go
@@ -3,9 +3,11 @@
 package sandlock
 
 /*
-#cgo CFLAGS: -I${SRCDIR}/../crates/sandlock-ffi/include
-#cgo LDFLAGS: -L${SRCDIR}/../target/release -Wl,-rpath,${SRCDIR}/../target/release -lsandlock_ffi -lpthread -ldl -lm
-
+// Build flags (include path plus link flags) are supplied by build-tagged
+// companion files: cgo_pkgconfig.go by default (resolves the installed library
+// via pkg-config) and cgo_repo.go under `-tags sandlock_repo` (resolves the
+// library from this checkout's target/release without installing).
+//
 // The C declarations come from the cbindgen-generated header, so the cgo
 // prototypes stay in lock-step with crates/sandlock-ffi automatically.
 #include <stdlib.h>


### PR DESCRIPTION
## Summary

Makes the Go SDK installable outside a repository checkout. Previously cgo
hardcoded `-I${SRCDIR}/../crates/...` and `-L${SRCDIR}/../target/release`, paths
that live outside the `go/` module subtree, so `go get github.com/multikernel/sandlock/go`
could never find the header or link `libsandlock_ffi`. This adds a pkg-config
default build mode plus a `make install-go-lib` target that lays down the three
files pkg-config needs.

## Build modes

- **Released (default):** `#cgo pkg-config: sandlock` resolves the installed
  library and header. `make install-go-lib` installs `libsandlock_ffi.so`,
  `sandlock.h`, and a generated `sandlock.pc` (honoring `PREFIX`/`DESTDIR`).
  The `.pc` bakes an rpath to its libdir, so consumer binaries find the `.so`
  at runtime with no `LD_LIBRARY_PATH`.
- **In-tree (`-tags sandlock_repo`):** keeps the old behavior of building
  against this checkout's `target/release`, with no install step. Used by CI
  and local development.

The two modes are selected by build-tagged companion files (`cgo_pkgconfig.go`,
`cgo_repo.go`) that carry only the `#cgo` directives; `sandlock_linux.go` keeps
the includes and code.

## Changes

- `go/cgo_pkgconfig.go`, `go/cgo_repo.go`: build-tagged cgo directives.
- `go/sandlock_linux.go`: drop the hardcoded `#cgo` lines.
- `go/sandlock.pc.in`: pkg-config template (filled in at install time).
- `Makefile`: `ffi`, `install-go-lib`, `uninstall-go-lib` targets; version
  derived from `Cargo.toml`.
- `.github/workflows/ci.yml`: Go job now builds with `-tags sandlock_repo`.
- `go/README.md`: documents both build modes.

## Verification

- In-tree: `go vet -tags sandlock_repo ./...`, `go build -tags sandlock_repo ./...`,
  `go test -tags sandlock_repo ./...` all pass.
- Released: `make install-go-lib PREFIX=/tmp/...`, then `pkg-config --cflags --libs sandlock`
  resolves; default-mode `go build ./...` links; an external consumer module
  (replace-directive, simulating `go get`) builds and runs (`exit=0 out="hi"`),
  proving runtime resolution via the baked rpath.
- `gofmt` clean.

## Note

This is the build/distribution half. Cutting an actual Go release still needs a
subdirectory-prefixed tag (`go/vX.Y.Z`; plain `vX.Y.Z` does not publish the
`.../go` module) and, ideally, prebuilt `libsandlock_ffi` artifacts on GitHub
Releases so users without the Rust toolchain can install the native side.