### PR TITLE
net: gate named unix socket access by fs-write grants

### DIFF
--- a/crates/sandlock-core/src/context.rs
+++ b/crates/sandlock-core/src/context.rs
@@ -409,6 +409,11 @@ pub fn notif_syscalls(policy: &Sandbox, sandbox_name: Option<&str>) -> Vec<u32> 
 
     if needs_network_supervision(policy) {
         nrs.extend(NETWORK_POLICY_SYSCALLS);
+    } else if policy.has_unix_fs_gate() {
+        // Named-unix connect gate: trap connect() so a connect to a unix socket
+        // outside the fs-write grants is denied, even when no IP network rules
+        // are present. Landlock cannot gate this.
+        nrs.push(libc::SYS_connect);
     }
 
     if policy.random_seed.is_some() {

--- a/crates/sandlock-core/src/context.rs
+++ b/crates/sandlock-core/src/context.rs
@@ -410,10 +410,13 @@ pub fn notif_syscalls(policy: &Sandbox, sandbox_name: Option<&str>) -> Vec<u32> 
     if needs_network_supervision(policy) {
         nrs.extend(NETWORK_POLICY_SYSCALLS);
     } else if policy.has_unix_fs_gate() {
-        // Named-unix connect gate: trap connect() so a connect to a unix socket
-        // outside the fs-write grants is denied, even when no IP network rules
-        // are present. Landlock cannot gate this.
+        // Named-unix gate: trap connect() (stream) and sendto()/sendmsg()
+        // (datagram) so reaching a unix socket outside the fs-write grants is
+        // denied, even when no IP network rules are present. Landlock cannot
+        // gate this. Handlers bail cheaply on addr-less (connected) sends.
         nrs.push(libc::SYS_connect);
+        nrs.push(libc::SYS_sendto);
+        nrs.push(libc::SYS_sendmsg);
     }
 
     if policy.random_seed.is_some() {

--- a/crates/sandlock-core/src/network.rs
+++ b/crates/sandlock-core/src/network.rs
@@ -708,9 +708,64 @@ async fn connect_on_behalf(
         }
         // dup_fd dropped here, closing supervisor's copy
     } else {
-        // Non-IP family (AF_UNIX etc.) — allow through
-        NotifAction::Continue
+        // Non-IP family. A NAMED (pathname) AF_UNIX connect is a gap Landlock
+        // cannot close (it has no access right for unix-socket connect), so a
+        // netns-less sandbox could reach a host service socket and escape.
+        // Connecting is a WRITE on the socket inode (kernel: unix_find_other ->
+        // path_permission(MAY_WRITE)), so require the path to be covered by an
+        // fs-write grant, mirroring the kernel's own DAC; otherwise deny with
+        // EACCES. The decision is made on `addr_bytes` (our immune copy) and we
+        // never return Continue on the deny path, so it is TOCTOU-safe.
+        // Abstract sockets (no path) are handled by the Landlock abstract scope.
+        match named_unix_socket_path(&addr_bytes) {
+            Some(path) if ctx.policy.has_unix_fs_gate => {
+                if path_under_any(&path, &ctx.policy.chroot_writable) {
+                    // Permitted by an fs-write grant. Hardening the allow path
+                    // into an on-behalf connect is a follow-up; this preserves
+                    // prior behavior for paths the operator already granted.
+                    NotifAction::Continue
+                } else {
+                    NotifAction::Errno(libc::EACCES)
+                }
+            }
+            // Abstract/unnamed socket, non-AF_UNIX family, or gate disabled.
+            _ => NotifAction::Continue,
+        }
     }
+}
+
+/// Extract the filesystem path of a NAMED `AF_UNIX` connect target from a raw
+/// `sockaddr`. Returns `None` for abstract sockets (`sun_path[0] == 0`),
+/// unnamed sockets, or any non-`AF_UNIX` family (none of which the fs gate
+/// applies to).
+fn named_unix_socket_path(addr_bytes: &[u8]) -> Option<std::path::PathBuf> {
+    // sockaddr_un layout: u16 sun_family, then sun_path. Need the family plus
+    // at least one path byte.
+    if addr_bytes.len() < 3 {
+        return None;
+    }
+    let family = u16::from_ne_bytes([addr_bytes[0], addr_bytes[1]]);
+    if family != libc::AF_UNIX as u16 {
+        return None;
+    }
+    let sun_path = &addr_bytes[2..];
+    if sun_path[0] == 0 {
+        return None; // abstract namespace (Landlock scope handles it)
+    }
+    let end = sun_path.iter().position(|&b| b == 0).unwrap_or(sun_path.len());
+    let raw = &sun_path[..end];
+    if raw.is_empty() {
+        return None;
+    }
+    std::str::from_utf8(raw).ok().map(std::path::PathBuf::from)
+}
+
+/// True if `path`, lexically normalized (`.`/`..` resolved without touching the
+/// filesystem), is at or under any of the granted `prefixes`. Mirrors the
+/// prefix matching the chroot fs enforcement uses.
+fn path_under_any(path: &std::path::Path, prefixes: &[std::path::PathBuf]) -> bool {
+    let norm = crate::chroot::resolve::confine(&path.to_string_lossy());
+    prefixes.iter().any(|p| norm.starts_with(p))
 }
 
 // ============================================================

--- a/crates/sandlock-core/src/network.rs
+++ b/crates/sandlock-core/src/network.rs
@@ -6,7 +6,7 @@
 use std::collections::{HashMap, HashSet};
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -719,19 +719,110 @@ async fn connect_on_behalf(
         // Abstract sockets (no path) are handled by the Landlock abstract scope.
         match named_unix_socket_path(&addr_bytes) {
             Some(path) if ctx.policy.has_unix_fs_gate => {
-                if path_under_any(&path, &ctx.policy.chroot_writable) {
-                    // Permitted by an fs-write grant. Hardening the allow path
-                    // into an on-behalf connect is a follow-up; this preserves
-                    // prior behavior for paths the operator already granted.
-                    NotifAction::Continue
+                if ctx.policy.chroot_root.is_some() {
+                    // Chroot mode: the child's paths are virtual, so a lexical
+                    // check against the (virtual) write grants is consistent,
+                    // and host socket paths are absent from the chroot view
+                    // anyway. Deny unless under a write grant.
+                    if path_under_any(&path, &ctx.policy.chroot_writable) {
+                        NotifAction::Continue
+                    } else {
+                        NotifAction::Errno(libc::EACCES)
+                    }
                 } else {
-                    NotifAction::Errno(libc::EACCES)
+                    // Non-chroot: resolve the symlink-followed real target and
+                    // connect on-behalf to the pinned inode, so a symlink inside
+                    // a granted dir cannot redirect to an ungranted socket.
+                    connect_named_unix_on_behalf(
+                        notif.pid,
+                        sockfd,
+                        &path,
+                        &ctx.policy.chroot_writable,
+                    )
                 }
             }
             // Abstract/unnamed socket, non-AF_UNIX family, or gate disabled.
             _ => NotifAction::Continue,
         }
     }
+}
+
+/// On-behalf connect for a NAMED `AF_UNIX` socket in non-chroot mode. Resolves
+/// `sun_path` to its real target inode (following symlinks in the child's root
+/// view via `/proc/<pid>/root`), verifies the target is under an fs-write
+/// grant, then connects the child's socket to that pinned inode through
+/// `/proc/self/fd`. TOCTOU- and symlink-safe: the inode that is checked is the
+/// exact inode that is connected, and the verdict never depends on re-resolving
+/// a path string the child could swap.
+fn connect_named_unix_on_behalf(
+    child_pid: u32,
+    sockfd: i32,
+    sun_path: &std::path::Path,
+    writable: &[std::path::PathBuf],
+) -> NotifAction {
+    // Resolve in the child's mount/root view so its symlinks (not ours) decide
+    // the target. `O_PATH` follows symlinks to the real socket inode and pins
+    // it without performing any I/O on the socket.
+    let proc_path = format!("/proc/{}/root{}", child_pid, sun_path.display());
+    let c_proc = match std::ffi::CString::new(proc_path) {
+        Ok(c) => c,
+        Err(_) => return NotifAction::Errno(libc::EACCES),
+    };
+    let pinned_raw = unsafe { libc::open(c_proc.as_ptr(), libc::O_PATH | libc::O_CLOEXEC) };
+    if pinned_raw < 0 {
+        // Target missing or unreachable: refuse without leaking the reason.
+        return NotifAction::Errno(ECONNREFUSED);
+    }
+    let pinned = unsafe { OwnedFd::from_raw_fd(pinned_raw) };
+
+    // Canonical path of the pinned inode in our mount namespace.
+    let real = match std::fs::read_link(format!("/proc/self/fd/{}", pinned.as_raw_fd())) {
+        Ok(p) => p,
+        Err(_) => return NotifAction::Errno(libc::EACCES),
+    };
+    if !real_path_under_any(&real, writable) {
+        return NotifAction::Errno(libc::EACCES);
+    }
+
+    // Connect the child's socket to the validated inode. Targeting
+    // `/proc/self/fd/<fd>` reaches the exact inode we checked, immune to a path
+    // swap after the check.
+    let dup_fd = match crate::seccomp::notif::dup_fd_from_pid(child_pid, sockfd) {
+        Ok(fd) => fd,
+        Err(e) => return NotifAction::Errno(e.raw_os_error().unwrap_or(libc::EBADF)),
+    };
+    let fd_path = format!("/proc/self/fd/{}", pinned.as_raw_fd());
+    let mut sun: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+    sun.sun_family = libc::AF_UNIX as libc::sa_family_t;
+    let bytes = fd_path.as_bytes();
+    if bytes.len() >= sun.sun_path.len() {
+        return NotifAction::Errno(libc::ENAMETOOLONG);
+    }
+    for (i, &b) in bytes.iter().enumerate() {
+        sun.sun_path[i] = b as libc::c_char;
+    }
+    let len = (std::mem::size_of::<libc::sa_family_t>() + bytes.len() + 1) as libc::socklen_t;
+    let ret = unsafe {
+        libc::connect(
+            dup_fd.as_raw_fd(),
+            &sun as *const libc::sockaddr_un as *const libc::sockaddr,
+            len,
+        )
+    };
+    if ret == 0 {
+        NotifAction::ReturnValue(0)
+    } else {
+        NotifAction::Errno(unsafe { *libc::__errno_location() })
+    }
+}
+
+/// True if `real` (an already-canonical path) is at or under any of `prefixes`,
+/// canonicalizing each prefix so a symlinked grant path still matches.
+fn real_path_under_any(real: &std::path::Path, prefixes: &[std::path::PathBuf]) -> bool {
+    prefixes.iter().any(|p| {
+        let canon = std::fs::canonicalize(p);
+        real.starts_with(canon.as_deref().unwrap_or(p))
+    })
 }
 
 /// Extract the filesystem path of a NAMED `AF_UNIX` connect target from a raw

--- a/crates/sandlock-core/src/network.rs
+++ b/crates/sandlock-core/src/network.rs
@@ -747,61 +747,80 @@ async fn connect_on_behalf(
     }
 }
 
-/// On-behalf connect for a NAMED `AF_UNIX` socket in non-chroot mode. Resolves
-/// `sun_path` to its real target inode (following symlinks in the child's root
-/// view via `/proc/<pid>/root`), verifies the target is under an fs-write
-/// grant, then connects the child's socket to that pinned inode through
-/// `/proc/self/fd`. TOCTOU- and symlink-safe: the inode that is checked is the
-/// exact inode that is connected, and the verdict never depends on re-resolving
-/// a path string the child could swap.
+/// Resolve a named unix socket `sun_path` to its real, symlink-followed inode
+/// in the child's root view (`/proc/<pid>/root`) and verify that inode is under
+/// an fs-write grant. On success returns a pinned `O_PATH` fd to that exact
+/// inode; on failure returns the deny/refuse `NotifAction`. Callers must
+/// operate on the pinned fd via `/proc/self/fd` so the checked inode is the one
+/// acted on, immune to a path swap after the check (TOCTOU- and symlink-safe).
+fn resolve_named_unix_target(
+    child_pid: u32,
+    sun_path: &std::path::Path,
+    writable: &[std::path::PathBuf],
+) -> Result<OwnedFd, NotifAction> {
+    // Resolve in the child's mount/root view so its symlinks (not ours) decide
+    // the target. `O_PATH` follows symlinks to the real socket inode and pins
+    // it without performing any I/O on the socket.
+    let proc_path = format!("/proc/{}/root{}", child_pid, sun_path.display());
+    let c_proc = std::ffi::CString::new(proc_path)
+        .map_err(|_| NotifAction::Errno(libc::EACCES))?;
+    let pinned_raw = unsafe { libc::open(c_proc.as_ptr(), libc::O_PATH | libc::O_CLOEXEC) };
+    if pinned_raw < 0 {
+        // Target missing or unreachable: refuse without leaking the reason.
+        return Err(NotifAction::Errno(ECONNREFUSED));
+    }
+    let pinned = unsafe { OwnedFd::from_raw_fd(pinned_raw) };
+
+    // Canonical path of the pinned inode in our mount namespace.
+    let real = std::fs::read_link(format!("/proc/self/fd/{}", pinned.as_raw_fd()))
+        .map_err(|_| NotifAction::Errno(libc::EACCES))?;
+    if real_path_under_any(&real, writable) {
+        Ok(pinned)
+    } else {
+        Err(NotifAction::Errno(libc::EACCES))
+    }
+}
+
+/// Build a `sockaddr_un` addressing `/proc/self/fd/<fd>`. The kernel resolves
+/// it to the exact pinned inode, so connecting/sending to it targets the inode
+/// we validated rather than re-resolving a path string. Returns `None` only if
+/// the rendered path would overflow `sun_path` (never, in practice).
+fn proc_self_fd_sockaddr(fd: RawFd) -> Option<(libc::sockaddr_un, libc::socklen_t)> {
+    let path = format!("/proc/self/fd/{}", fd);
+    let bytes = path.as_bytes();
+    let mut sun: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+    if bytes.len() >= sun.sun_path.len() {
+        return None;
+    }
+    sun.sun_family = libc::AF_UNIX as libc::sa_family_t;
+    for (i, &b) in bytes.iter().enumerate() {
+        sun.sun_path[i] = b as libc::c_char;
+    }
+    let len = (std::mem::size_of::<libc::sa_family_t>() + bytes.len() + 1) as libc::socklen_t;
+    Some((sun, len))
+}
+
+/// On-behalf `connect()` for a NAMED `AF_UNIX` socket in non-chroot mode:
+/// resolve+verify the target, then connect the child's socket to the pinned
+/// inode through `/proc/self/fd`.
 fn connect_named_unix_on_behalf(
     child_pid: u32,
     sockfd: i32,
     sun_path: &std::path::Path,
     writable: &[std::path::PathBuf],
 ) -> NotifAction {
-    // Resolve in the child's mount/root view so its symlinks (not ours) decide
-    // the target. `O_PATH` follows symlinks to the real socket inode and pins
-    // it without performing any I/O on the socket.
-    let proc_path = format!("/proc/{}/root{}", child_pid, sun_path.display());
-    let c_proc = match std::ffi::CString::new(proc_path) {
-        Ok(c) => c,
-        Err(_) => return NotifAction::Errno(libc::EACCES),
+    let pinned = match resolve_named_unix_target(child_pid, sun_path, writable) {
+        Ok(fd) => fd,
+        Err(action) => return action,
     };
-    let pinned_raw = unsafe { libc::open(c_proc.as_ptr(), libc::O_PATH | libc::O_CLOEXEC) };
-    if pinned_raw < 0 {
-        // Target missing or unreachable: refuse without leaking the reason.
-        return NotifAction::Errno(ECONNREFUSED);
-    }
-    let pinned = unsafe { OwnedFd::from_raw_fd(pinned_raw) };
-
-    // Canonical path of the pinned inode in our mount namespace.
-    let real = match std::fs::read_link(format!("/proc/self/fd/{}", pinned.as_raw_fd())) {
-        Ok(p) => p,
-        Err(_) => return NotifAction::Errno(libc::EACCES),
+    let (sun, len) = match proc_self_fd_sockaddr(pinned.as_raw_fd()) {
+        Some(s) => s,
+        None => return NotifAction::Errno(libc::ENAMETOOLONG),
     };
-    if !real_path_under_any(&real, writable) {
-        return NotifAction::Errno(libc::EACCES);
-    }
-
-    // Connect the child's socket to the validated inode. Targeting
-    // `/proc/self/fd/<fd>` reaches the exact inode we checked, immune to a path
-    // swap after the check.
     let dup_fd = match crate::seccomp::notif::dup_fd_from_pid(child_pid, sockfd) {
         Ok(fd) => fd,
         Err(e) => return NotifAction::Errno(e.raw_os_error().unwrap_or(libc::EBADF)),
     };
-    let fd_path = format!("/proc/self/fd/{}", pinned.as_raw_fd());
-    let mut sun: libc::sockaddr_un = unsafe { std::mem::zeroed() };
-    sun.sun_family = libc::AF_UNIX as libc::sa_family_t;
-    let bytes = fd_path.as_bytes();
-    if bytes.len() >= sun.sun_path.len() {
-        return NotifAction::Errno(libc::ENAMETOOLONG);
-    }
-    for (i, &b) in bytes.iter().enumerate() {
-        sun.sun_path[i] = b as libc::c_char;
-    }
-    let len = (std::mem::size_of::<libc::sa_family_t>() + bytes.len() + 1) as libc::socklen_t;
     let ret = unsafe {
         libc::connect(
             dup_fd.as_raw_fd(),
@@ -816,6 +835,52 @@ fn connect_named_unix_on_behalf(
     }
 }
 
+/// On-behalf `sendto()` for a NAMED `AF_UNIX` datagram in non-chroot mode:
+/// resolve+verify the target, copy the child's data, then send to the pinned
+/// inode through `/proc/self/fd`.
+fn sendto_named_unix_on_behalf(
+    notif: &SeccompNotif,
+    notif_fd: RawFd,
+    sockfd: i32,
+    buf_ptr: u64,
+    buf_len: usize,
+    flags: i32,
+    sun_path: &std::path::Path,
+    writable: &[std::path::PathBuf],
+) -> NotifAction {
+    let pinned = match resolve_named_unix_target(notif.pid, sun_path, writable) {
+        Ok(fd) => fd,
+        Err(action) => return action,
+    };
+    let (sun, len) = match proc_self_fd_sockaddr(pinned.as_raw_fd()) {
+        Some(s) => s,
+        None => return NotifAction::Errno(libc::ENAMETOOLONG),
+    };
+    let data = match read_child_mem(notif_fd, notif.id, notif.pid, buf_ptr, buf_len) {
+        Ok(b) => b,
+        Err(_) => return NotifAction::Errno(libc::EIO),
+    };
+    let dup_fd = match crate::seccomp::notif::dup_fd_from_pid(notif.pid, sockfd) {
+        Ok(fd) => fd,
+        Err(e) => return NotifAction::Errno(e.raw_os_error().unwrap_or(libc::EBADF)),
+    };
+    let ret = unsafe {
+        libc::sendto(
+            dup_fd.as_raw_fd(),
+            data.as_ptr() as *const libc::c_void,
+            data.len(),
+            flags,
+            &sun as *const libc::sockaddr_un as *const libc::sockaddr,
+            len,
+        )
+    };
+    if ret >= 0 {
+        NotifAction::ReturnValue(ret as i64)
+    } else {
+        NotifAction::Errno(unsafe { *libc::__errno_location() })
+    }
+}
+
 /// True if `real` (an already-canonical path) is at or under any of `prefixes`,
 /// canonicalizing each prefix so a symlinked grant path still matches.
 fn real_path_under_any(real: &std::path::Path, prefixes: &[std::path::PathBuf]) -> bool {
@@ -823,6 +888,142 @@ fn real_path_under_any(real: &std::path::Path, prefixes: &[std::path::PathBuf]) 
         let canon = std::fs::canonicalize(p);
         real.starts_with(canon.as_deref().unwrap_or(p))
     })
+}
+
+/// Apply the named-unix fs gate to a `sendmsg()` whose `msg_name` may address a
+/// unix socket. Returns `Some(action)` when the target is a named `AF_UNIX`
+/// socket (handled here), or `None` to fall through to the IP path (connected
+/// socket, IP family, abstract socket, or an unreadable header).
+fn unix_sendmsg_gate(
+    notif: &SeccompNotif,
+    ctx: &Arc<SupervisorCtx>,
+    notif_fd: RawFd,
+    sockfd: i32,
+    msghdr_ptr: u64,
+    flags: i32,
+) -> Option<NotifAction> {
+    let msghdr_bytes = read_child_mem(notif_fd, notif.id, notif.pid, msghdr_ptr, 56).ok()?;
+    if msghdr_bytes.len() < 56 {
+        return None;
+    }
+    let msg_name_ptr = u64::from_ne_bytes(msghdr_bytes[0..8].try_into().unwrap());
+    if msg_name_ptr == 0 {
+        return None; // connected socket: no address to gate
+    }
+    let msg_namelen = u32::from_ne_bytes(msghdr_bytes[8..12].try_into().unwrap());
+    let addr_bytes =
+        read_child_mem(notif_fd, notif.id, notif.pid, msg_name_ptr, msg_namelen as usize).ok()?;
+    // None unless this is a NAMED AF_UNIX target; IP/abstract fall through.
+    let path = named_unix_socket_path(&addr_bytes)?;
+
+    if ctx.policy.chroot_root.is_some() {
+        return Some(if path_under_any(&path, &ctx.policy.chroot_writable) {
+            NotifAction::Continue
+        } else {
+            NotifAction::Errno(libc::EACCES)
+        });
+    }
+    Some(sendmsg_named_unix_on_behalf(
+        notif,
+        notif_fd,
+        sockfd,
+        msghdr_ptr,
+        flags,
+        &path,
+        &ctx.policy.chroot_writable,
+    ))
+}
+
+/// On-behalf `sendmsg()` for a NAMED `AF_UNIX` datagram in non-chroot mode:
+/// resolve+verify the target, copy the message's iovecs and control data, then
+/// send to the pinned inode through `/proc/self/fd`.
+fn sendmsg_named_unix_on_behalf(
+    notif: &SeccompNotif,
+    notif_fd: RawFd,
+    sockfd: i32,
+    msghdr_ptr: u64,
+    flags: i32,
+    sun_path: &std::path::Path,
+    writable: &[std::path::PathBuf],
+) -> NotifAction {
+    let pinned = match resolve_named_unix_target(notif.pid, sun_path, writable) {
+        Ok(fd) => fd,
+        Err(action) => return action,
+    };
+    let (sun, sun_len) = match proc_self_fd_sockaddr(pinned.as_raw_fd()) {
+        Some(s) => s,
+        None => return NotifAction::Errno(libc::ENAMETOOLONG),
+    };
+
+    let msghdr_bytes = match read_child_mem(notif_fd, notif.id, notif.pid, msghdr_ptr, 56) {
+        Ok(b) if b.len() >= 56 => b,
+        _ => return NotifAction::Errno(libc::EFAULT),
+    };
+    let msg_iov_ptr = u64::from_ne_bytes(msghdr_bytes[16..24].try_into().unwrap());
+    let msg_iovlen = u64::from_ne_bytes(msghdr_bytes[24..32].try_into().unwrap());
+    let msg_control_ptr = u64::from_ne_bytes(msghdr_bytes[32..40].try_into().unwrap());
+    let msg_controllen = u64::from_ne_bytes(msghdr_bytes[40..48].try_into().unwrap());
+
+    let iovlen = (msg_iovlen as usize).min(1024);
+    let iov_bytes = match read_child_mem(notif_fd, notif.id, notif.pid, msg_iov_ptr, iovlen * 16) {
+        Ok(b) => b,
+        Err(_) => return NotifAction::Errno(libc::EIO),
+    };
+    let mut data_bufs: Vec<Vec<u8>> = Vec::with_capacity(iovlen);
+    for i in 0..iovlen {
+        let off = i * 16;
+        if off + 16 > iov_bytes.len() {
+            break;
+        }
+        let base = u64::from_ne_bytes(iov_bytes[off..off + 8].try_into().unwrap());
+        let len = u64::from_ne_bytes(iov_bytes[off + 8..off + 16].try_into().unwrap()) as usize;
+        if len > MAX_SEND_BUF {
+            return NotifAction::Errno(libc::EMSGSIZE);
+        }
+        if base == 0 || len == 0 {
+            data_bufs.push(Vec::new());
+            continue;
+        }
+        match read_child_mem(notif_fd, notif.id, notif.pid, base, len) {
+            Ok(b) => data_bufs.push(b),
+            Err(_) => return NotifAction::Errno(libc::EIO),
+        }
+    }
+    let mut local_iovs: Vec<libc::iovec> = data_bufs
+        .iter()
+        .map(|b| libc::iovec {
+            iov_base: b.as_ptr() as *mut libc::c_void,
+            iov_len: b.len(),
+        })
+        .collect();
+
+    let control_buf = if msg_control_ptr != 0 && msg_controllen > 0 {
+        let len = (msg_controllen as usize).min(4096);
+        read_child_mem(notif_fd, notif.id, notif.pid, msg_control_ptr, len).ok()
+    } else {
+        None
+    };
+
+    let dup_fd = match crate::seccomp::notif::dup_fd_from_pid(notif.pid, sockfd) {
+        Ok(fd) => fd,
+        Err(e) => return NotifAction::Errno(e.raw_os_error().unwrap_or(libc::EBADF)),
+    };
+
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_name = &sun as *const libc::sockaddr_un as *mut libc::c_void;
+    msg.msg_namelen = sun_len;
+    msg.msg_iov = local_iovs.as_mut_ptr();
+    msg.msg_iovlen = local_iovs.len();
+    if let Some(ref ctrl) = control_buf {
+        msg.msg_control = ctrl.as_ptr() as *mut libc::c_void;
+        msg.msg_controllen = ctrl.len();
+    }
+    let ret = unsafe { libc::sendmsg(dup_fd.as_raw_fd(), &msg, flags) };
+    if ret >= 0 {
+        NotifAction::ReturnValue(ret as i64)
+    } else {
+        NotifAction::Errno(unsafe { *libc::__errno_location() })
+    }
 }
 
 /// Extract the filesystem path of a NAMED `AF_UNIX` connect target from a raw
@@ -959,8 +1160,32 @@ async fn sendto_on_behalf(
             NotifAction::Errno(errno)
         }
     } else {
-        // Non-IP family (AF_UNIX etc.) — allow through
-        NotifAction::Continue
+        // Non-IP family. Gate a NAMED AF_UNIX datagram the same way as connect:
+        // sendto to a named socket is a WRITE on its inode, so deny unless the
+        // resolved real target is under an fs-write grant.
+        match named_unix_socket_path(&addr_bytes) {
+            Some(path) if ctx.policy.has_unix_fs_gate => {
+                if ctx.policy.chroot_root.is_some() {
+                    if path_under_any(&path, &ctx.policy.chroot_writable) {
+                        NotifAction::Continue
+                    } else {
+                        NotifAction::Errno(libc::EACCES)
+                    }
+                } else {
+                    sendto_named_unix_on_behalf(
+                        notif,
+                        notif_fd,
+                        sockfd,
+                        buf_ptr,
+                        buf_len,
+                        flags,
+                        &path,
+                        &ctx.policy.chroot_writable,
+                    )
+                }
+            }
+            _ => NotifAction::Continue,
+        }
     }
 }
 
@@ -983,6 +1208,15 @@ async fn sendmsg_on_behalf(
     let sockfd = args[0] as i32;
     let msghdr_ptr = args[1];
     let flags = args[2] as i32;
+
+    // Named-unix datagram gate. A named AF_UNIX `msg_name` is handled here; the
+    // IP path below only covers AF_INET/AF_INET6, and would pass a unix target
+    // straight through.
+    if ctx.policy.has_unix_fs_gate {
+        if let Some(action) = unix_sendmsg_gate(notif, ctx, notif_fd, sockfd, msghdr_ptr, flags) {
+            return action;
+        }
+    }
 
     // Pre-scan for Continue cases (connected socket / non-IP family).
     // Same TOCTOU-aware semantics as before: EFAULT on unreadable

--- a/crates/sandlock-core/src/resource.rs
+++ b/crates/sandlock-core/src/resource.rs
@@ -639,6 +639,7 @@ mod tests {
             has_memory_limit: false,
             has_net_allowlist: false,
             has_bind_denylist: false,
+            has_unix_fs_gate: false,
             has_random_seed: false,
             has_time_start: false,
             argv_safety_required,

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -1075,6 +1075,15 @@ impl Sandbox {
         reducer.wait().await
     }
 
+    /// Whether named (pathname) `AF_UNIX` connects should be gated by the
+    /// fs-write grants (`has_unix_fs_gate`). Active whenever the sandbox
+    /// confines the filesystem; Landlock cannot gate unix-socket connect, so
+    /// the seccomp layer does. Single source of truth for both the
+    /// `NotifPolicy` flag and the `notif_syscalls` BPF set.
+    pub(crate) fn has_unix_fs_gate(&self) -> bool {
+        !self.fs_readable.is_empty() || !self.fs_writable.is_empty()
+    }
+
     /// Lazily initialize the runtime block.
     ///
     /// Called by lifecycle methods (`spawn`, `run`, `fork`, etc.) on first
@@ -1408,6 +1417,7 @@ impl Sandbox {
                     || !self.http_allow.is_empty()
                     || !self.http_deny.is_empty(),
                 has_bind_denylist: !self.net_deny_bind.is_empty(),
+                has_unix_fs_gate: self.has_unix_fs_gate(),
                 has_random_seed: self.random_seed.is_some(),
                 has_time_start: self.time_start.is_some(),
                 argv_safety_required: self.policy_fn.is_some()

--- a/crates/sandlock-core/src/seccomp/dispatch.rs
+++ b/crates/sandlock-core/src/seccomp/dispatch.rs
@@ -324,9 +324,10 @@ pub(crate) fn build_dispatch_table(
     }
 
     // ------------------------------------------------------------------
-    // Network (conditional on has_net_allowlist || has_http_acl)
+    // Network (conditional on has_net_allowlist || has_http_acl ||
+    // has_unix_fs_gate; the last traps connect() to gate named unix sockets)
     // ------------------------------------------------------------------
-    if policy.has_net_allowlist || policy.has_http_acl {
+    if policy.has_net_allowlist || policy.has_http_acl || policy.has_unix_fs_gate {
         for &nr in &[
             libc::SYS_connect,
             libc::SYS_sendto,
@@ -1085,6 +1086,7 @@ mod handler_tests {
                 has_memory_limit: false,
                 has_net_allowlist: false,
                 has_bind_denylist: false,
+                has_unix_fs_gate: false,
                 has_random_seed: false,
                 has_time_start: false,
                 time_offset: 0,

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -409,6 +409,12 @@ pub struct NotifPolicy {
     /// handler so denied TCP ports can be refused (independent of the
     /// connect-side `has_net_allowlist`).
     pub has_bind_denylist: bool,
+    /// Named (pathname) `AF_UNIX` connect gate. When true, `connect()` to a
+    /// named unix socket whose path is not covered by an fs-write grant is
+    /// denied with EACCES. Landlock has no access right for unix-socket
+    /// connect, so the seccomp layer closes the escape; abstract sockets are
+    /// handled by `LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET` instead.
+    pub has_unix_fs_gate: bool,
     pub has_random_seed: bool,
     pub has_time_start: bool,
     /// Argv-safety gate: the supervisor must freeze every task that

--- a/crates/sandlock-core/tests/integration/test_landlock.rs
+++ b/crates/sandlock-core/tests/integration/test_landlock.rs
@@ -714,6 +714,125 @@ async fn test_named_unix_socket_connect_allowed_with_fs_write() {
     let _ = std::fs::remove_dir_all(&sock_dir);
 }
 
+// Allow-path hardening (stage 2): a symlink inside a WRITE-granted directory
+// whose real target is a socket OUTSIDE the grants must not be a bypass. A
+// lexical check on the symlink's own path would see only the in-grant location
+// and permit it; the decision must be made on the symlink's REAL target, which
+// is ungranted, so the connect must be denied with EACCES.
+#[tokio::test]
+async fn test_named_unix_socket_symlink_escape_denied() {
+    if sandlock_core::landlock_abi_version().unwrap_or(0) < 6 {
+        eprintln!("Skipping: Landlock ABI v6 required");
+        return;
+    }
+
+    let base = std::path::Path::new(env!("CARGO_TARGET_TMPDIR"))
+        .join(format!("named-unixsock-symlink-{}", std::process::id()));
+    let granted = base.join("granted"); // fs_write granted
+    let outside = base.join("outside"); // NOT granted: the escape target
+    let _ = std::fs::create_dir_all(&granted);
+    let _ = std::fs::create_dir_all(&outside);
+    let real_sock = outside.join("real.sock");
+    let link_sock = granted.join("link.sock");
+    let _ = std::fs::remove_file(&real_sock);
+    let _ = std::fs::remove_file(&link_sock);
+    std::os::unix::fs::symlink(&real_sock, &link_sock).unwrap();
+
+    let out = temp_file("named-sock-symlink-result");
+    let ready_file = temp_file("named-sock-symlink-ready");
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&ready_file);
+
+    // Listener binds the REAL socket, in the ungranted directory.
+    let listener_script = format!(
+        concat!(
+            "import socket, time\n",
+            "s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)\n",
+            "s.bind('{sock}')\n",
+            "s.listen(5)\n",
+            "open('{ready}', 'w').write('ready')\n",
+            "time.sleep(15)\n",
+            "s.close()\n",
+        ),
+        sock = real_sock.display(),
+        ready = ready_file.display(),
+    );
+    let mut listener_proc = std::process::Command::new("python3")
+        .args(["-c", &listener_script])
+        .spawn()
+        .unwrap();
+    for _ in 0..100 {
+        if ready_file.exists() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(ready_file.exists(), "listener should signal readiness");
+
+    // Positive control: the symlink really does resolve and connect from outside
+    // the sandbox, so the escape path is live and the sandbox must refuse it.
+    {
+        let control = std::os::unix::net::UnixStream::connect(&link_sock);
+        assert!(
+            control.is_ok(),
+            "positive control: symlink must resolve+connect from host (got {control:?})"
+        );
+    }
+
+    // Child connects to the in-grant SYMLINK; its real target is ungranted.
+    let child_script = format!(
+        concat!(
+            "import socket\n",
+            "s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)\n",
+            "try:\n",
+            "    s.connect('{sock}')\n",
+            "    result = 'CONNECTED'\n",
+            "except OSError as e:\n",
+            "    result = 'ERRNO:%d' % e.errno\n",
+            "finally:\n",
+            "    s.close()\n",
+            "open('{out}', 'w').write(result)\n",
+        ),
+        sock = link_sock.display(),
+        out = out.display(),
+    );
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr")
+        .fs_read("/lib")
+        .fs_read_if_exists("/lib64")
+        .fs_read("/bin")
+        .fs_read("/etc")
+        .fs_read("/proc")
+        .fs_read("/dev")
+        .fs_write("/tmp")
+        // the symlink's directory is writable; the real target's dir is NOT granted
+        .fs_write(granted.to_str().unwrap())
+        .build()
+        .unwrap();
+
+    policy
+        .clone()
+        .with_name("test")
+        .run_interactive(&["python3", "-c", &child_script])
+        .await
+        .unwrap();
+
+    let contents = std::fs::read_to_string(&out).unwrap_or_default();
+    assert_eq!(
+        contents, "ERRNO:13",
+        "a symlink to an ungranted socket must be denied on its real target (got {contents:?})"
+    );
+
+    let _ = listener_proc.kill();
+    let _ = listener_proc.wait();
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&ready_file);
+    let _ = std::fs::remove_file(&real_sock);
+    let _ = std::fs::remove_file(&link_sock);
+    let _ = std::fs::remove_dir_all(&base);
+}
+
 #[tokio::test]
 async fn test_isolate_signals_blocks_parent() {
     if sandlock_core::landlock_abi_version().unwrap_or(0) < 6 {

--- a/crates/sandlock-core/tests/integration/test_landlock.rs
+++ b/crates/sandlock-core/tests/integration/test_landlock.rs
@@ -495,6 +495,225 @@ async fn test_abstract_unix_socket_contained() {
     let _ = std::fs::remove_file(&ready_file);
 }
 
+// Named (pathname) unix sockets are a gap Landlock does not close: it has no
+// access right for connecting to one, so a netns-less sandbox can reach a host
+// service socket and escape. Connecting is a WRITE on the socket inode (kernel:
+// unix_find_other -> path_permission(MAY_WRITE)), so the sandlock fs gate must
+// deny a connect whose path is not covered by an fs-WRITE grant. Here the
+// socket's directory is granted fs-READ (so the path resolves) but not write,
+// so the connect must fail with EACCES.
+#[tokio::test]
+async fn test_named_unix_socket_connect_denied_without_fs_write() {
+    if sandlock_core::landlock_abi_version().unwrap_or(0) < 6 {
+        eprintln!("Skipping: Landlock ABI v6 required");
+        return;
+    }
+
+    // Socket lives under the cargo target tmpdir (a real host mount visible in
+    // the sandbox, unlike the virtualized /tmp), in a dir we grant READ only.
+    let sock_dir = std::path::Path::new(env!("CARGO_TARGET_TMPDIR"))
+        .join(format!("named-unixsock-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&sock_dir);
+    let sock_path = sock_dir.join("svc.sock");
+    let _ = std::fs::remove_file(&sock_path);
+
+    // Result/ready files use the proven /tmp + fs_write("/tmp") pattern.
+    let out = temp_file("named-sock-result");
+    let ready_file = temp_file("named-sock-ready");
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&ready_file);
+
+    // Host-side NAMED unix socket listener, created outside any sandbox.
+    let listener_script = format!(
+        concat!(
+            "import socket, time\n",
+            "s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)\n",
+            "s.bind('{sock}')\n",
+            "s.listen(5)\n",
+            "open('{ready}', 'w').write('ready')\n",
+            "time.sleep(15)\n",
+            "s.close()\n",
+        ),
+        sock = sock_path.display(),
+        ready = ready_file.display(),
+    );
+    let mut listener_proc = std::process::Command::new("python3")
+        .args(["-c", &listener_script])
+        .spawn()
+        .unwrap();
+    for _ in 0..100 {
+        if ready_file.exists() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(ready_file.exists(), "listener should signal readiness");
+
+    // Positive control: the unsandboxed test process can reach the socket, so a
+    // negative result inside the sandbox is attributable to the gate, not a dead
+    // listener.
+    {
+        let control = std::os::unix::net::UnixStream::connect(&sock_path);
+        assert!(
+            control.is_ok(),
+            "positive control: host must reach the named socket (got {control:?})"
+        );
+    }
+
+    let child_script = format!(
+        concat!(
+            "import socket\n",
+            "s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)\n",
+            "try:\n",
+            "    s.connect('{sock}')\n",
+            "    result = 'CONNECTED'\n",
+            "except OSError as e:\n",
+            "    result = 'ERRNO:%d' % e.errno\n",
+            "finally:\n",
+            "    s.close()\n",
+            "open('{out}', 'w').write(result)\n",
+        ),
+        sock = sock_path.display(),
+        out = out.display(),
+    );
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr")
+        .fs_read("/lib")
+        .fs_read_if_exists("/lib64")
+        .fs_read("/bin")
+        .fs_read("/etc")
+        .fs_read("/proc")
+        .fs_read("/dev")
+        .fs_write("/tmp")
+        // socket dir is READable (path resolves) but NOT writable -> connect denied
+        .fs_read(sock_dir.to_str().unwrap())
+        .build()
+        .unwrap();
+
+    policy
+        .clone()
+        .with_name("test")
+        .run_interactive(&["python3", "-c", &child_script])
+        .await
+        .unwrap();
+
+    let contents = std::fs::read_to_string(&out).unwrap_or_default();
+    // EACCES (13) mirrors the kernel's own DAC for connecting to a socket
+    // without write permission. CONNECTED means the gap is still open;
+    // ERRNO:2 (ENOENT) would mean the path wasn't even visible (test bug).
+    assert_eq!(
+        contents, "ERRNO:13",
+        "connect to a named unix socket with no fs-write grant must be denied with EACCES (got {contents:?})"
+    );
+
+    let _ = listener_proc.kill();
+    let _ = listener_proc.wait();
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&ready_file);
+    let _ = std::fs::remove_file(&sock_path);
+    let _ = std::fs::remove_dir_all(&sock_dir);
+}
+
+// Selectivity guard for the gate above: the same connect that is denied under
+// an fs-READ grant must SUCCEED when the socket's directory is fs-WRITE granted.
+// This pins the gate to write permission (mirroring the kernel's DAC) and stops
+// a future regression from turning the gate into a blanket deny-all.
+#[tokio::test]
+async fn test_named_unix_socket_connect_allowed_with_fs_write() {
+    if sandlock_core::landlock_abi_version().unwrap_or(0) < 6 {
+        eprintln!("Skipping: Landlock ABI v6 required");
+        return;
+    }
+
+    let sock_dir = std::path::Path::new(env!("CARGO_TARGET_TMPDIR"))
+        .join(format!("named-unixsock-rw-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&sock_dir);
+    let sock_path = sock_dir.join("svc.sock");
+    let _ = std::fs::remove_file(&sock_path);
+
+    let out = temp_file("named-sock-rw-result");
+    let ready_file = temp_file("named-sock-rw-ready");
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&ready_file);
+
+    let listener_script = format!(
+        concat!(
+            "import socket, time\n",
+            "s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)\n",
+            "s.bind('{sock}')\n",
+            "s.listen(5)\n",
+            "open('{ready}', 'w').write('ready')\n",
+            "time.sleep(15)\n",
+            "s.close()\n",
+        ),
+        sock = sock_path.display(),
+        ready = ready_file.display(),
+    );
+    let mut listener_proc = std::process::Command::new("python3")
+        .args(["-c", &listener_script])
+        .spawn()
+        .unwrap();
+    for _ in 0..100 {
+        if ready_file.exists() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(ready_file.exists(), "listener should signal readiness");
+
+    let child_script = format!(
+        concat!(
+            "import socket\n",
+            "s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)\n",
+            "try:\n",
+            "    s.connect('{sock}')\n",
+            "    result = 'CONNECTED'\n",
+            "except OSError as e:\n",
+            "    result = 'ERRNO:%d' % e.errno\n",
+            "finally:\n",
+            "    s.close()\n",
+            "open('{out}', 'w').write(result)\n",
+        ),
+        sock = sock_path.display(),
+        out = out.display(),
+    );
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr")
+        .fs_read("/lib")
+        .fs_read_if_exists("/lib64")
+        .fs_read("/bin")
+        .fs_read("/etc")
+        .fs_read("/proc")
+        .fs_read("/dev")
+        .fs_write("/tmp")
+        // socket dir is WRITE granted -> connect permitted
+        .fs_write(sock_dir.to_str().unwrap())
+        .build()
+        .unwrap();
+
+    policy
+        .clone()
+        .with_name("test")
+        .run_interactive(&["python3", "-c", &child_script])
+        .await
+        .unwrap();
+
+    let contents = std::fs::read_to_string(&out).unwrap_or_default();
+    assert_eq!(
+        contents, "CONNECTED",
+        "connect to a named unix socket under an fs-write grant must be permitted (got {contents:?})"
+    );
+
+    let _ = listener_proc.kill();
+    let _ = listener_proc.wait();
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&ready_file);
+    let _ = std::fs::remove_file(&sock_path);
+    let _ = std::fs::remove_dir_all(&sock_dir);
+}
+
 #[tokio::test]
 async fn test_isolate_signals_blocks_parent() {
     if sandlock_core::landlock_abi_version().unwrap_or(0) < 6 {

--- a/crates/sandlock-core/tests/integration/test_landlock.rs
+++ b/crates/sandlock-core/tests/integration/test_landlock.rs
@@ -833,6 +833,337 @@ async fn test_named_unix_socket_symlink_escape_denied() {
     let _ = std::fs::remove_dir_all(&base);
 }
 
+// Datagram vector: a unix SOCK_DGRAM `sendto()` to a named socket reaches it
+// without a prior connect(), and is a WRITE on the target inode just like
+// connect. The gate must cover it too: a sendto to a socket whose path is not
+// under an fs-write grant must be denied with EACCES.
+#[tokio::test]
+async fn test_named_unix_dgram_sendto_denied_without_fs_write() {
+    if sandlock_core::landlock_abi_version().unwrap_or(0) < 6 {
+        eprintln!("Skipping: Landlock ABI v6 required");
+        return;
+    }
+
+    let sock_dir = std::path::Path::new(env!("CARGO_TARGET_TMPDIR"))
+        .join(format!("named-unixdgram-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&sock_dir);
+    let sock_path = sock_dir.join("svc.dgram");
+    let _ = std::fs::remove_file(&sock_path);
+
+    let out = temp_file("named-dgram-result");
+    let ready_file = temp_file("named-dgram-ready");
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&ready_file);
+
+    // Host-side NAMED datagram socket, bound outside any sandbox.
+    let listener_script = format!(
+        concat!(
+            "import socket, time\n",
+            "s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)\n",
+            "s.bind('{sock}')\n",
+            "open('{ready}', 'w').write('ready')\n",
+            "time.sleep(15)\n",
+            "s.close()\n",
+        ),
+        sock = sock_path.display(),
+        ready = ready_file.display(),
+    );
+    let mut listener_proc = std::process::Command::new("python3")
+        .args(["-c", &listener_script])
+        .spawn()
+        .unwrap();
+    for _ in 0..100 {
+        if ready_file.exists() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(ready_file.exists(), "listener should signal readiness");
+
+    let child_script = format!(
+        concat!(
+            "import socket\n",
+            "s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)\n",
+            "try:\n",
+            "    s.sendto(b'escape', '{sock}')\n",
+            "    result = 'SENT'\n",
+            "except OSError as e:\n",
+            "    result = 'ERRNO:%d' % e.errno\n",
+            "finally:\n",
+            "    s.close()\n",
+            "open('{out}', 'w').write(result)\n",
+        ),
+        sock = sock_path.display(),
+        out = out.display(),
+    );
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr")
+        .fs_read("/lib")
+        .fs_read_if_exists("/lib64")
+        .fs_read("/bin")
+        .fs_read("/etc")
+        .fs_read("/proc")
+        .fs_read("/dev")
+        .fs_write("/tmp")
+        // socket dir is READable but NOT writable -> sendto denied
+        .fs_read(sock_dir.to_str().unwrap())
+        .build()
+        .unwrap();
+
+    policy
+        .clone()
+        .with_name("test")
+        .run_interactive(&["python3", "-c", &child_script])
+        .await
+        .unwrap();
+
+    let contents = std::fs::read_to_string(&out).unwrap_or_default();
+    assert_eq!(
+        contents, "ERRNO:13",
+        "sendto to a named dgram socket with no fs-write grant must be denied with EACCES (got {contents:?})"
+    );
+
+    let _ = listener_proc.kill();
+    let _ = listener_proc.wait();
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&ready_file);
+    let _ = std::fs::remove_file(&sock_path);
+    let _ = std::fs::remove_dir_all(&sock_dir);
+}
+
+// sendmsg() is an equivalent datagram path to sendto() (the address sits in
+// msg_name), so it must be gated too or it is a trivial bypass. A sendmsg to a
+// named socket outside the fs-write grants must be denied with EACCES.
+#[tokio::test]
+async fn test_named_unix_dgram_sendmsg_denied_without_fs_write() {
+    if sandlock_core::landlock_abi_version().unwrap_or(0) < 6 {
+        eprintln!("Skipping: Landlock ABI v6 required");
+        return;
+    }
+
+    let sock_dir = std::path::Path::new(env!("CARGO_TARGET_TMPDIR"))
+        .join(format!("named-unixmsg-{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&sock_dir);
+    let sock_path = sock_dir.join("svc.dgram");
+    let _ = std::fs::remove_file(&sock_path);
+
+    let out = temp_file("named-msg-result");
+    let ready_file = temp_file("named-msg-ready");
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&ready_file);
+
+    let listener_script = format!(
+        concat!(
+            "import socket, time\n",
+            "s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)\n",
+            "s.bind('{sock}')\n",
+            "open('{ready}', 'w').write('ready')\n",
+            "time.sleep(15)\n",
+            "s.close()\n",
+        ),
+        sock = sock_path.display(),
+        ready = ready_file.display(),
+    );
+    let mut listener_proc = std::process::Command::new("python3")
+        .args(["-c", &listener_script])
+        .spawn()
+        .unwrap();
+    for _ in 0..100 {
+        if ready_file.exists() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(ready_file.exists(), "listener should signal readiness");
+
+    // sendmsg with msg_name set to the named socket address.
+    let child_script = format!(
+        concat!(
+            "import socket\n",
+            "s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)\n",
+            "try:\n",
+            "    s.sendmsg([b'escape'], [], 0, '{sock}')\n",
+            "    result = 'SENT'\n",
+            "except OSError as e:\n",
+            "    result = 'ERRNO:%d' % e.errno\n",
+            "finally:\n",
+            "    s.close()\n",
+            "open('{out}', 'w').write(result)\n",
+        ),
+        sock = sock_path.display(),
+        out = out.display(),
+    );
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr")
+        .fs_read("/lib")
+        .fs_read_if_exists("/lib64")
+        .fs_read("/bin")
+        .fs_read("/etc")
+        .fs_read("/proc")
+        .fs_read("/dev")
+        .fs_write("/tmp")
+        .fs_read(sock_dir.to_str().unwrap())
+        .build()
+        .unwrap();
+
+    policy
+        .clone()
+        .with_name("test")
+        .run_interactive(&["python3", "-c", &child_script])
+        .await
+        .unwrap();
+
+    let contents = std::fs::read_to_string(&out).unwrap_or_default();
+    assert_eq!(
+        contents, "ERRNO:13",
+        "sendmsg to a named dgram socket with no fs-write grant must be denied with EACCES (got {contents:?})"
+    );
+
+    let _ = listener_proc.kill();
+    let _ = listener_proc.wait();
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&ready_file);
+    let _ = std::fs::remove_file(&sock_path);
+    let _ = std::fs::remove_dir_all(&sock_dir);
+}
+
+// Allow+delivery guard for the datagram on-behalf send paths: a sendto/sendmsg
+// to a socket UNDER a write grant must not only be permitted but actually
+// deliver the payload (the supervisor performs the send on-behalf). Exercises
+// the success path of sendto_named_unix_on_behalf / sendmsg_named_unix_on_behalf
+// that the deny tests never reach. `which` selects the syscall.
+async fn dgram_allow_delivers(which: &str, tag: &str) {
+    if sandlock_core::landlock_abi_version().unwrap_or(0) < 6 {
+        eprintln!("Skipping: Landlock ABI v6 required");
+        return;
+    }
+
+    let sock_dir = std::path::Path::new(env!("CARGO_TARGET_TMPDIR"))
+        .join(format!("named-dgram-allow-{}-{}", tag, std::process::id()));
+    let _ = std::fs::create_dir_all(&sock_dir);
+    let sock_path = sock_dir.join("svc.dgram");
+    let _ = std::fs::remove_file(&sock_path);
+
+    let out = temp_file(&format!("dgram-allow-{tag}-result"));
+    let ready_file = temp_file(&format!("dgram-allow-{tag}-ready"));
+    let recv_file = temp_file(&format!("dgram-allow-{tag}-recv"));
+    for f in [&out, &ready_file, &recv_file] {
+        let _ = std::fs::remove_file(f);
+    }
+
+    // Listener receives one datagram and records the payload it got.
+    let listener_script = format!(
+        concat!(
+            "import socket\n",
+            "s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)\n",
+            "s.bind('{sock}')\n",
+            "s.settimeout(12)\n",
+            "open('{ready}', 'w').write('ready')\n",
+            "try:\n",
+            "    data, _ = s.recvfrom(64)\n",
+            "    open('{recv}', 'w').write(data.decode())\n",
+            "except socket.timeout:\n",
+            "    open('{recv}', 'w').write('TIMEOUT')\n",
+            "s.close()\n",
+        ),
+        sock = sock_path.display(),
+        ready = ready_file.display(),
+        recv = recv_file.display(),
+    );
+    let mut listener_proc = std::process::Command::new("python3")
+        .args(["-c", &listener_script])
+        .spawn()
+        .unwrap();
+    for _ in 0..100 {
+        if ready_file.exists() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(ready_file.exists(), "listener should signal readiness");
+
+    let send_call = if which == "sendmsg" {
+        format!("s.sendmsg([b'payload-42'], [], 0, '{}')", sock_path.display())
+    } else {
+        format!("s.sendto(b'payload-42', '{}')", sock_path.display())
+    };
+    let child_script = format!(
+        concat!(
+            "import socket\n",
+            "s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)\n",
+            "try:\n",
+            "    {send_call}\n",
+            "    result = 'SENT'\n",
+            "except OSError as e:\n",
+            "    result = 'ERRNO:%d' % e.errno\n",
+            "finally:\n",
+            "    s.close()\n",
+            "open('{out}', 'w').write(result)\n",
+        ),
+        send_call = send_call,
+        out = out.display(),
+    );
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr")
+        .fs_read("/lib")
+        .fs_read_if_exists("/lib64")
+        .fs_read("/bin")
+        .fs_read("/etc")
+        .fs_read("/proc")
+        .fs_read("/dev")
+        .fs_write("/tmp")
+        // socket dir is WRITE granted -> send permitted, on-behalf
+        .fs_write(sock_dir.to_str().unwrap())
+        .build()
+        .unwrap();
+
+    policy
+        .clone()
+        .with_name("test")
+        .run_interactive(&["python3", "-c", &child_script])
+        .await
+        .unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(&out).unwrap_or_default(),
+        "SENT",
+        "{which} to a write-granted dgram socket must be permitted"
+    );
+
+    // Wait for the listener to record the delivered payload.
+    for _ in 0..100 {
+        if recv_file.exists() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let _ = listener_proc.wait();
+    assert_eq!(
+        std::fs::read_to_string(&recv_file).unwrap_or_default(),
+        "payload-42",
+        "{which} on-behalf send must actually deliver the payload"
+    );
+
+    let _ = listener_proc.kill();
+    for f in [&out, &ready_file, &recv_file, &sock_path] {
+        let _ = std::fs::remove_file(f);
+    }
+    let _ = std::fs::remove_dir_all(&sock_dir);
+}
+
+#[tokio::test]
+async fn test_named_unix_dgram_sendto_allowed_delivers() {
+    dgram_allow_delivers("sendto", "to").await;
+}
+
+#[tokio::test]
+async fn test_named_unix_dgram_sendmsg_allowed_delivers() {
+    dgram_allow_delivers("sendmsg", "msg").await;
+}
+
 #[tokio::test]
 async fn test_isolate_signals_blocks_parent() {
     if sandlock_core::landlock_abi_version().unwrap_or(0) < 6 {


### PR DESCRIPTION
## Problem

Landlock has no access right for connecting to a **named (pathname) unix socket**, and path resolution is not a gated Landlock operation. So a non-chroot sandbox (which relies on Landlock as its enforcement boundary, no netns) can `connect()` or `sendto()` a host service socket and escape, regardless of its filesystem rules. This is the gap described in Tingmao Wang's upstream Landlock series (cover.1767115163.git.m@maowtm.org); this PR closes it in the seccomp layer today, without waiting for the kernel feature.

Verified empirically before/after: a sandboxed process could reach a host named socket whose directory was never granted.

## Approach

Connecting/sending to a named unix socket is a **WRITE on the socket inode** (kernel `unix_find_other` -> `path_permission(MAY_WRITE)`; confirmed empirically: a `0444` socket gives `EACCES`, `0644` connects). So the gate mirrors the kernel's own DAC: a named-unix target is permitted only if its path is under an **fs-write grant**, reusing the existing `fs-allow` policy (no new flag).

The gate runs in the seccomp on-behalf path sandlock already owns; the decision is made on an immune copy and never returns `Continue` on deny, so it is TOCTOU-safe. Abstract sockets remain covered by `LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET`; named-socket *creation* (`bind`) is already covered by Landlock `FS_MAKE_SOCK`.

## Commits

1. **gate named unix socket connect by fs-write grants** - traps `connect()` for any fs-confined sandbox; denies named targets outside the write grants with `EACCES`. Adds `Sandbox::has_unix_fs_gate()` as the single source of truth for the flag and the BPF notify set.
2. **resolve real path for allowed unix socket connect** - the allow path resolves the symlink-followed real target via `/proc/<pid>/root` + `O_PATH`, verifies it, and connects to the pinned inode through `/proc/self/fd`. Closes a symlink-in-a-granted-dir escape that a lexical check misses.
3. **gate unix datagram sendto/sendmsg by fs-write grants** - extends the same resolver to the datagram vector (both `sendto` and `sendmsg`, the latter to prevent a trivial bypass), with on-behalf send to the pinned inode.

Chroot mode keeps the lexical check (virtual paths are self-consistent and host socket paths are absent from the chroot view); the resolve-based path is non-chroot only.

## Tests

8 new integration tests (RED-verified where they drive behavior):
- connect denied without fs-write / allowed with fs-write
- connect symlink-escape denied (real-target resolution)
- dgram sendto/sendmsg denied without fs-write
- dgram sendto/sendmsg allowed **and payload delivered** (exercises the on-behalf send success path)

Full suite green: 252 integration + 395 lib.

## Notes

- The gate is default-on for every fs-confined sandbox, so `connect`/`sendto`/`sendmsg` now trap to the supervisor (handlers bail cheaply on addr-less connected sends). Acceptable for sandlock's execute-only-agent workload; a future optimization could BPF arg-filter `sendto` on `addrlen != 0`.
- `sendmmsg` (multi-message send) still passes `AF_UNIX` through - a narrow remaining vector, left for a follow-up.