### PR TITLE
oci: review follow-ups (cleanup, root.readonly, tmpfs mounts, lifecycle fixes)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
         run: |
           mkdir -p dist
           cp target/${{ matrix.target }}/release/sandlock dist/ 2>/dev/null || true
+          cp target/${{ matrix.target }}/release/sandlock-oci dist/ 2>/dev/null || true
           cp target/${{ matrix.target }}/release/libsandlock_ffi.so dist/ 2>/dev/null || true
           tar -czf sandlock-${{ matrix.target }}.tar.gz -C dist .
 
@@ -176,10 +177,13 @@ jobs:
       - name: Publish crates
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        # Order matters: dependents publish after their dependencies. core
+        # goes first; oci depends on core, so it follows.
         run: |
           cargo publish -p sandlock-core
           cargo publish -p sandlock-ffi
           cargo publish -p sandlock-cli
+          cargo publish -p sandlock-oci
 
   # Publish Python package to PyPI
   publish-pypi:

--- a/crates/sandlock-oci/Cargo.toml
+++ b/crates/sandlock-oci/Cargo.toml
@@ -17,7 +17,7 @@ name = "sandlock-oci"
 path = "src/main.rs"
 
 [dependencies]
-sandlock-core = { version = "0.8.1", path = "../sandlock-core" }
+sandlock-core = { version = "0.8.3", path = "../sandlock-core" }
 anyhow      = "1"
 clap        = { version = "4", features = ["derive"] }
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util"] }

--- a/crates/sandlock-oci/src/lib.rs
+++ b/crates/sandlock-oci/src/lib.rs
@@ -6,7 +6,7 @@
 //! ## Key types
 //!
 //! - [`OciPolicy`] — in-memory representation of the translated OCI config
-//! - [`ContainerState`] — on-disk lifecycle state for a container
+//! - [`SandboxState`] — on-disk lifecycle state for a sandbox
 //! - [`SupervisorCmd`] / [`SupervisorReply`] — IPC messages for the supervisor
 
 pub mod policy;
@@ -15,5 +15,5 @@ pub mod state;
 pub mod supervisor;
 
 pub use policy::OciPolicy;
-pub use state::{ContainerState, ExitInfo, Status};
+pub use state::{SandboxState, ExitInfo, Status};
 pub use supervisor::{SupervisorCmd, SupervisorReply, SUPERVISOR_SOCKET};

--- a/crates/sandlock-oci/src/main.rs
+++ b/crates/sandlock-oci/src/main.rs
@@ -35,6 +35,14 @@ use std::path::PathBuf;
     version
 )]
 struct Cli {
+    /// Root directory for container state (one subdir per container).
+    ///
+    /// The OCI-standard knob that containerd/CRI-O pass. When omitted,
+    /// defaults to `$XDG_RUNTIME_DIR/sandlock-oci` for unprivileged users
+    /// and `/run/sandlock-oci` for root.
+    #[arg(long, global = true)]
+    root: Option<PathBuf>,
+
     #[command(subcommand)]
     command: Command,
 }
@@ -116,6 +124,10 @@ enum Command {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    // Resolve the state-dir root once, before any state I/O or fork, so the
+    // supervisor child inherits the same location.
+    state::init_state_dir(cli.root.as_deref().and_then(|p| p.to_str()));
 
     match cli.command {
         Command::Create { id, bundle, pid_file, console_socket: _ } => {

--- a/crates/sandlock-oci/src/main.rs
+++ b/crates/sandlock-oci/src/main.rs
@@ -35,10 +35,6 @@ use std::path::PathBuf;
     version
 )]
 struct Cli {
-    /// Enable debug logging to stderr.
-    #[arg(long, global = true)]
-    debug: bool,
-
     #[command(subcommand)]
     command: Command,
 }

--- a/crates/sandlock-oci/src/main.rs
+++ b/crates/sandlock-oci/src/main.rs
@@ -207,6 +207,14 @@ fn main() -> Result<()> {
 /// 4. Fork a Supervisor (double-fork daemon) which forks the Child.
 /// 5. Child is SIGSTOP'd; supervisor writes PID to CLI via pipe (no sleep/race).
 fn cmd_create(id: &str, bundle: &PathBuf, pid_file: Option<&std::path::Path>) -> Result<()> {
+    // OCI requires the container ID to be unique within the runtime root.
+    // Reject a re-used ID up front rather than overwriting the existing
+    // container's state and orphaning its supervisor + parked child.  The
+    // caller must `delete` the old container first.
+    if ContainerState::load(id).is_ok() {
+        bail!("container {} already exists", id);
+    }
+
     let bundle = bundle
         .canonicalize()
         .with_context(|| format!("bundle path {:?} does not exist", bundle))?;

--- a/crates/sandlock-oci/src/main.rs
+++ b/crates/sandlock-oci/src/main.rs
@@ -201,7 +201,7 @@ fn cmd_create(id: &str, bundle: &PathBuf, pid_file: Option<&std::path::Path>) ->
 
     // Load and validate spec
     let spec = spec::load_spec(&bundle)?;
-    let policy = spec::spec_to_policy(&spec, &bundle)?;
+    let policy = spec::spec_to_policy(&spec, &bundle, id)?;
 
     // Extract the command from the spec — OCI requires non-empty args
     let cmd_args: Vec<String> = spec

--- a/crates/sandlock-oci/src/main.rs
+++ b/crates/sandlock-oci/src/main.rs
@@ -25,7 +25,7 @@ mod supervisor;
 
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
-use state::{ContainerState, Status};
+use state::{SandboxState, Status};
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -35,7 +35,7 @@ use std::path::PathBuf;
     version
 )]
 struct Cli {
-    /// Root directory for container state (one subdir per container).
+    /// Root directory for sandbox state (one subdir per sandbox).
     ///
     /// The OCI-standard knob that containerd/CRI-O pass. When omitted,
     /// defaults to `$XDG_RUNTIME_DIR/sandlock-oci` for unprivileged users
@@ -49,15 +49,15 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
-    /// Create a container. Spawns the Supervisor and forks the child in a
+    /// Create a sandbox. Spawns the Supervisor and forks the child in a
     /// paused state. Saves state to /run/sandlock-oci/<id>/state.json.
     Create {
-        /// Unique container identifier.
+        /// Unique sandbox identifier.
         id: String,
         /// Path to the OCI bundle directory.
         #[arg(short = 'b', long)]
         bundle: PathBuf,
-        /// File descriptor to write the container PID to (optional, for CRI).
+        /// File descriptor to write the sandbox PID to (optional, for CRI).
         #[arg(long = "pid-file")]
         pid_file: Option<PathBuf>,
         /// Console socket path (ignored — sandlock doesn't use PTYs by default).
@@ -65,57 +65,57 @@ enum Command {
         console_socket: Option<PathBuf>,
     },
 
-    /// Start a previously created container.
+    /// Start a previously created sandbox.
     Start {
-        /// Container identifier.
+        /// Sandbox identifier.
         id: String,
     },
 
-    /// Output the state of a container as JSON.
+    /// Output the state of a sandbox as JSON.
     State {
-        /// Container identifier.
+        /// Sandbox identifier.
         id: String,
     },
 
-    /// Send a signal to a container's init process.
+    /// Send a signal to a sandbox's init process.
     Kill {
-        /// Container identifier.
+        /// Sandbox identifier.
         id: String,
         /// Signal name or number (e.g. SIGTERM or 15).
         #[arg(default_value = "SIGTERM")]
         signal: String,
-        /// Send signal to all processes in the container (not just init).
+        /// Send signal to all processes in the sandbox (not just init).
         #[arg(short, long)]
         all: bool,
     },
 
-    /// Delete a container and its state.
+    /// Delete a sandbox and its state.
     Delete {
-        /// Container identifier.
+        /// Sandbox identifier.
         id: String,
-        /// Force deletion even if the container is still running.
+        /// Force deletion even if the sandbox is still running.
         #[arg(short, long)]
         force: bool,
     },
 
-    /// List all containers managed by sandlock-oci.
+    /// List all sandboxes managed by sandlock-oci.
     List,
 
     /// Check kernel feature support (delegates to sandlock-core checks).
     Check,
 
-    /// Execute a process inside a running container.
+    /// Execute a process inside a running sandbox.
     ///
     /// **Not yet implemented.** Required for `kubectl exec` and exec-based
     /// liveness/readiness probes.  Tracked as a known limitation.
     ///
     /// All arguments are accepted without validation so that containerd/CRI-O
     /// invocations (which pass flags like `--process`, `--detach`, `--pid-file`
-    /// *before* the container-id) parse cleanly and receive a clear error.
+    /// *before* the sandbox-id) parse cleanly and receive a clear error.
     Exec {
         /// All exec arguments captured as-is (id, flags, command).
         /// `allow_hyphen_values` + `trailing_var_arg` ensure that runc-style
-        /// flags preceding the container-id do not trigger an "unexpected
+        /// flags preceding the sandbox-id do not trigger an "unexpected
         /// argument" error.
         #[arg(num_args = 0.., trailing_var_arg = true, allow_hyphen_values = true)]
         _args: Vec<String>,
@@ -137,9 +137,9 @@ fn main() -> Result<()> {
             cmd_start(&id)?;
         }
         Command::State { id } => {
-            let mut state = ContainerState::load(&id)
-                .with_context(|| format!("no such container: {}", id))?;
-            // Reconcile: if we believe the container is running but the process
+            let mut state = SandboxState::load(&id)
+                .with_context(|| format!("no such sandbox: {}", id))?;
+            // Reconcile: if we believe the sandbox is running but the process
             // is gone (killed out-of-band), transition to stopped so callers
             // see the current truth rather than stale state.
             if state.status == Status::Running && !state.is_alive() {
@@ -155,13 +155,13 @@ fn main() -> Result<()> {
             cmd_delete(&id, force)?;
         }
         Command::List => {
-            let ids = state::list_containers()?;
+            let ids = state::list_sandboxes()?;
             if ids.is_empty() {
-                println!("No sandlock-oci containers.");
+                println!("No sandlock-oci sandboxes.");
             } else {
                 println!("{:<40} {:<10} {}", "ID", "STATUS", "PID");
                 for id in ids {
-                    if let Ok(s) = ContainerState::load(&id) {
+                    if let Ok(s) = SandboxState::load(&id) {
                         println!("{:<40} {:<10} {}", s.id, s.status, s.pid);
                     }
                 }
@@ -207,12 +207,12 @@ fn main() -> Result<()> {
 /// 4. Fork a Supervisor (double-fork daemon) which forks the Child.
 /// 5. Child is SIGSTOP'd; supervisor writes PID to CLI via pipe (no sleep/race).
 fn cmd_create(id: &str, bundle: &PathBuf, pid_file: Option<&std::path::Path>) -> Result<()> {
-    // OCI requires the container ID to be unique within the runtime root.
+    // OCI requires the sandbox ID to be unique within the runtime root.
     // Reject a re-used ID up front rather than overwriting the existing
-    // container's state and orphaning its supervisor + parked child.  The
-    // caller must `delete` the old container first.
-    if ContainerState::load(id).is_ok() {
-        bail!("container {} already exists", id);
+    // sandbox's state and orphaning its supervisor + parked child.  The
+    // caller must `delete` the old sandbox first.
+    if SandboxState::load(id).is_ok() {
+        bail!("sandbox {} already exists", id);
     }
 
     let bundle = bundle
@@ -231,13 +231,13 @@ fn cmd_create(id: &str, bundle: &PathBuf, pid_file: Option<&std::path::Path>) ->
         .filter(|args| !args.is_empty())
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "OCI spec process.args is empty; cannot create container without a command"
+                "OCI spec process.args is empty; cannot create sandbox without a command"
             )
         })?;
 
     // Create initial state
-    let state = ContainerState::new(id, &bundle, spec.version());
-    state.save().with_context(|| format!("save state for container {}", id))?;
+    let state = SandboxState::new(id, &bundle, spec.version());
+    state.save().with_context(|| format!("save state for sandbox {}", id))?;
 
     // ── Pipe for synchronous PID notification ────────────────────────────────
     // Supervisor writes the child PID here immediately after forking, so the
@@ -293,15 +293,15 @@ fn cmd_create(id: &str, bundle: &PathBuf, pid_file: Option<&std::path::Path>) ->
 
         // Detach the daemon's working directory from the caller's so we don't
         // pin a filesystem the caller may later want to unmount.  The
-        // container's own cwd comes from the OCI spec via the sandbox policy,
+        // sandbox's own cwd comes from the OCI spec via the sandbox policy,
         // independent of the supervisor's cwd.
         unsafe { libc::chdir(b"/\0".as_ptr() as *const libc::c_char); }
 
         // Redirect only stdin to /dev/null — the supervisor daemon doesn't
         // need input.  stdout/stderr are intentionally *not* redirected:
-        // containerd/CRI-O wire the runtime's stdio to the container's log
+        // containerd/CRI-O wire the runtime's stdio to the sandbox's log
         // FIFOs, so fds 1 and 2 must be passed through to the child process
-        // so that container output reaches `kubectl logs`.
+        // so that sandbox output reaches `kubectl logs`.
         unsafe {
             let devnull = libc::open(
                 b"/dev/null\0".as_ptr() as *const libc::c_char,
@@ -334,8 +334,8 @@ fn cmd_create(id: &str, bundle: &PathBuf, pid_file: Option<&std::path::Path>) ->
     // Read the supervisor's response from the pipe.
     //
     // Protocol: supervisor writes one of:
-    //   `OK <pid>\n`   — sandbox created, <pid> is the container's init PID
-    //   `ERR <msg>\n`  — setup failed; the container was never created
+    //   `OK <pid>\n`   — sandbox created, <pid> is the sandbox's init PID
+    //   `ERR <msg>\n`  — setup failed; the sandbox was never created
     //   (EOF)          — supervisor crashed before writing; treated as error
     let child_pid = {
         let mut buf = [0u8; 512];
@@ -352,7 +352,7 @@ fn cmd_create(id: &str, bundle: &PathBuf, pid_file: Option<&std::path::Path>) ->
             rest.parse::<i32>()
                 .with_context(|| format!("invalid PID in supervisor response: {:?}", response))?
         } else if let Some(msg) = response.strip_prefix("ERR ") {
-            bail!("container create failed: {}", msg);
+            bail!("sandbox create failed: {}", msg);
         } else {
             bail!("unexpected supervisor response: {:?}", response);
         }
@@ -360,7 +360,7 @@ fn cmd_create(id: &str, bundle: &PathBuf, pid_file: Option<&std::path::Path>) ->
 
     // Update the state file with the actual PID.
     {
-        let mut state = ContainerState::load(id)?;
+        let mut state = SandboxState::load(id)?;
         state.set_created(child_pid);
         state.save()?;
     }
@@ -378,15 +378,15 @@ fn cmd_create(id: &str, bundle: &PathBuf, pid_file: Option<&std::path::Path>) ->
 ///
 /// Signals the Supervisor to release the paused child (SIGCONT → execve).
 fn cmd_start(id: &str) -> Result<()> {
-    // Verify the container exists and is in Created state.
-    let state = ContainerState::load(id)
-        .with_context(|| format!("no such container: {}", id))?;
+    // Verify the sandbox exists and is in Created state.
+    let state = SandboxState::load(id)
+        .with_context(|| format!("no such sandbox: {}", id))?;
 
     match state.status {
         Status::Created => {} // expected
-        Status::Creating => bail!("container {} is still being created", id),
-        Status::Running => bail!("container {} is already running", id),
-        Status::Stopped => bail!("container {} has already stopped", id),
+        Status::Creating => bail!("sandbox {} is still being created", id),
+        Status::Running => bail!("sandbox {} is already running", id),
+        Status::Stopped => bail!("sandbox {} has already stopped", id),
     }
 
     // Send Start command to supervisor.
@@ -399,14 +399,14 @@ fn cmd_start(id: &str) -> Result<()> {
 
 /// `sandlock-oci kill <id> <signal>`
 ///
-/// Forwards a signal to the container's init process.
+/// Forwards a signal to the sandbox's init process.
 fn cmd_kill(id: &str, signal: &str, all: bool) -> Result<()> {
-    let state = ContainerState::load(id)
-        .with_context(|| format!("no such container: {}", id))?;
+    let state = SandboxState::load(id)
+        .with_context(|| format!("no such sandbox: {}", id))?;
 
     if state.pid <= 0 {
         bail!(
-            "container {} has no PID (status: {})",
+            "sandbox {} has no PID (status: {})",
             id,
             state.status
         );
@@ -433,15 +433,15 @@ fn cmd_kill(id: &str, signal: &str, all: bool) -> Result<()> {
 
 /// `sandlock-oci delete <id>`
 ///
-/// Kills the container (if running) and removes the state directory.
+/// Kills the sandbox (if running) and removes the state directory.
 fn cmd_delete(id: &str, force: bool) -> Result<()> {
-    let state = match ContainerState::load(id) {
+    let state = match SandboxState::load(id) {
         Ok(s) => s,
         Err(_) => return Ok(()),
     };
 
     if state.status == Status::Running && !force {
-        bail!("container {} is still running; use --force or kill it first", id);
+        bail!("sandbox {} is still running; use --force or kill it first", id);
     }
 
     // If the supervisor is blocked waiting for `start`, send Shutdown so it
@@ -451,7 +451,7 @@ fn cmd_delete(id: &str, force: bool) -> Result<()> {
         let _ = supervisor::send_command(id, supervisor::SupervisorCmd::Shutdown);
     }
 
-    // Kill the container process if it's still alive (Running + force, or any
+    // Kill the sandbox process if it's still alive (Running + force, or any
     // state where the child is alive).
     if state.pid > 0 && state.is_alive() {
         unsafe { libc::killpg(state.pid, libc::SIGKILL) };

--- a/crates/sandlock-oci/src/main.rs
+++ b/crates/sandlock-oci/src/main.rs
@@ -271,6 +271,12 @@ fn cmd_create(id: &str, bundle: &PathBuf, pid_file: Option<&std::path::Path>) ->
         // Close the read end (inherited from intermediate, not needed here)
         unsafe { libc::close(read_fd); }
 
+        // Detach the daemon's working directory from the caller's so we don't
+        // pin a filesystem the caller may later want to unmount.  The
+        // container's own cwd comes from the OCI spec via the sandbox policy,
+        // independent of the supervisor's cwd.
+        unsafe { libc::chdir(b"/\0".as_ptr() as *const libc::c_char); }
+
         // Redirect only stdin to /dev/null — the supervisor daemon doesn't
         // need input.  stdout/stderr are intentionally *not* redirected:
         // containerd/CRI-O wire the runtime's stdio to the container's log

--- a/crates/sandlock-oci/src/policy.rs
+++ b/crates/sandlock-oci/src/policy.rs
@@ -16,18 +16,18 @@ use std::path::{Path, PathBuf};
 
 /// Serializable OCI-to-sandlock policy representation.
 ///
-/// Stored alongside state.json in the container's state directory so that
+/// Stored alongside state.json in the sandbox's state directory so that
 /// the supervisor (or any recovery tool) can reconstruct the confinement
 /// parameters without re-parsing the OCI bundle.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OciPolicy {
-    /// Absolute path to the container rootfs (chroot target).
+    /// Absolute path to the sandbox rootfs (chroot target).
     pub rootfs: Option<PathBuf>,
 
-    /// Paths readable inside the container (relative to rootfs if set).
+    /// Paths readable inside the sandbox (relative to rootfs if set).
     pub fs_read: Vec<PathBuf>,
 
-    /// Paths writable inside the container (relative to rootfs if set).
+    /// Paths writable inside the sandbox (relative to rootfs if set).
     pub fs_write: Vec<PathBuf>,
 
     /// Explicit bind mounts: (dest_inside_rootfs, host_source_path).
@@ -36,7 +36,7 @@ pub struct OciPolicy {
     /// Initial working directory (relative to rootfs if set).
     pub cwd: Option<PathBuf>,
 
-    /// Environment variables to set in the container.
+    /// Environment variables to set in the sandbox.
     pub env: HashMap<String, String>,
 
     /// Memory limit (optional).
@@ -49,7 +49,7 @@ pub struct OciPolicy {
     pub max_cpu: Option<u8>,
 
     /// Host directories backing emulated tmpfs mounts.  Created before launch
-    /// and removed with the container state dir on `delete`.
+    /// and removed with the sandbox state dir on `delete`.
     #[serde(default)]
     pub scratch_dirs: Vec<PathBuf>,
 }
@@ -59,7 +59,7 @@ impl OciPolicy {
     pub fn from_spec(spec: &Spec, bundle: &Path, id: &str) -> Result<Self> {
         let rootfs = rootfs_path(spec, bundle)?;
 
-        // OCI `root.readonly`: when set, the container rootfs must be read-only,
+        // OCI `root.readonly`: when set, the sandbox rootfs must be read-only,
         // so the whole chroot is granted read access rather than read-write.
         let root_readonly = spec
             .root()
@@ -73,7 +73,7 @@ impl OciPolicy {
         let mut scratch_dirs = Vec::new();
 
         if rootfs.is_some() {
-            // The container owns its rootfs, so grant the whole chroot rather
+            // The sandbox owns its rootfs, so grant the whole chroot rather
             // than guessing a fixed set of system directories.  `root.readonly`
             // selects read-only vs. read-write for the entire tree (fs_write's
             // Landlock mask already includes read access).  Individual mounts,
@@ -187,7 +187,7 @@ impl OciPolicy {
             builder = builder.cwd(cwd);
         }
 
-        // Start from a clean environment so the container sees exactly the
+        // Start from a clean environment so the sandbox sees exactly the
         // vars declared in the OCI spec, not the supervisor's inherited env.
         builder = builder.clean_env(true);
         for (k, v) in &self.env {
@@ -238,7 +238,7 @@ fn rootfs_path(spec: &Spec, bundle: &Path) -> Result<Option<PathBuf>> {
 ///
 /// - **bind** (real source): `fs_mount(dest, source)`, ro/rw from options.
 /// - **tmpfs** writable scratch (`/tmp`, `/run`, `/dev/shm`, …): backed by a
-///   host directory under the container state dir and bind-mounted read-write,
+///   host directory under the sandbox state dir and bind-mounted read-write,
 ///   so it works on a read-only root and stays isolated from the rootfs.
 /// - **tmpfs at `/dev`, proc, sysfs**: passed through read-only so sandlock's
 ///   `/dev` interception and `/proc` virtualization service them; an empty

--- a/crates/sandlock-oci/src/policy.rs
+++ b/crates/sandlock-oci/src/policy.rs
@@ -54,17 +54,29 @@ impl OciPolicy {
     pub fn from_spec(spec: &Spec, bundle: &Path) -> Result<Self> {
         let rootfs = rootfs_path(spec, bundle);
 
+        // OCI `root.readonly`: when set, the container rootfs must be read-only,
+        // so the whole chroot is granted read access rather than read-write.
+        let root_readonly = spec
+            .root()
+            .as_ref()
+            .and_then(|r| r.readonly())
+            .unwrap_or(false);
+
         let mut fs_read = Vec::new();
         let mut fs_write = Vec::new();
         let mut fs_mount = Vec::new();
 
         if rootfs.is_some() {
-            // Standard read-only paths inside the chroot
-            for p in &["/usr", "/lib", "/lib64", "/bin", "/sbin", "/etc", "/proc", "/dev"] {
-                fs_read.push(PathBuf::from(*p));
+            // The container owns its rootfs, so grant the whole chroot rather
+            // than guessing a fixed set of system directories.  `root.readonly`
+            // selects read-only vs. read-write for the entire tree (fs_write's
+            // Landlock mask already includes read access).  Individual mounts,
+            // with their ro/rw options, layer on top via map_mounts.
+            if root_readonly {
+                fs_read.push(PathBuf::from("/"));
+            } else {
+                fs_write.push(PathBuf::from("/"));
             }
-            // /tmp is writable by default
-            fs_write.push(PathBuf::from("/tmp"));
         }
 
         // Process mounts — populate fs_mount, fs_read, fs_write
@@ -330,6 +342,41 @@ mod tests {
         assert!(policy.max_memory.is_none());
         assert!(policy.max_processes.is_none());
         assert!(policy.max_cpu.is_none());
+    }
+
+    #[test]
+    fn readonly_root_grants_rootfs_read_only() {
+        let dir = tempdir().unwrap();
+        let bundle = dir.path();
+        fs::create_dir_all(bundle.join("rootfs")).unwrap();
+
+        let spec = SpecBuilder::default()
+            .version("1.0.2")
+            .root(RootBuilder::default().path("rootfs").readonly(true).build().unwrap())
+            .process(
+                ProcessBuilder::default()
+                    .args(vec!["sh".to_string()])
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        let policy = OciPolicy::from_spec(&spec, bundle).unwrap();
+        assert!(policy.fs_read.contains(&PathBuf::from("/")));
+        assert!(!policy.fs_write.contains(&PathBuf::from("/")));
+    }
+
+    #[test]
+    fn writable_root_grants_rootfs_writable() {
+        let dir = tempdir().unwrap();
+        let bundle = dir.path();
+        fs::create_dir_all(bundle.join("rootfs")).unwrap();
+
+        // minimal_spec() sets readonly(false).
+        let policy = OciPolicy::from_spec(&minimal_spec(), bundle).unwrap();
+        assert!(policy.fs_write.contains(&PathBuf::from("/")));
+        assert!(!policy.fs_read.contains(&PathBuf::from("/")));
     }
 
     #[test]

--- a/crates/sandlock-oci/src/policy.rs
+++ b/crates/sandlock-oci/src/policy.rs
@@ -411,7 +411,6 @@ mod tests {
 
     #[test]
     fn tmpfs_scratch_backed_proc_dev_passthrough() {
-        std::env::set_var("SANDLOCK_OCI_STATE_DIR", "/tmp/sandlock-oci-test-mounts");
         let dir = tempdir().unwrap();
         let bundle = dir.path();
         fs::create_dir_all(bundle.join("rootfs")).unwrap();
@@ -443,8 +442,6 @@ mod tests {
         assert!(policy.fs_read.contains(&PathBuf::from("/proc")));
         assert!(policy.fs_read.contains(&PathBuf::from("/dev")));
         assert!(!policy.fs_mount.iter().any(|(d, _)| d == Path::new("/dev")));
-
-        std::env::remove_var("SANDLOCK_OCI_STATE_DIR");
     }
 
     #[test]

--- a/crates/sandlock-oci/src/policy.rs
+++ b/crates/sandlock-oci/src/policy.rs
@@ -47,11 +47,16 @@ pub struct OciPolicy {
 
     /// CPU percentage limit, 1-100 (optional).
     pub max_cpu: Option<u8>,
+
+    /// Host directories backing emulated tmpfs mounts.  Created before launch
+    /// and removed with the container state dir on `delete`.
+    #[serde(default)]
+    pub scratch_dirs: Vec<PathBuf>,
 }
 
 impl OciPolicy {
     /// Build an OciPolicy from a parsed OCI Spec and its bundle directory.
-    pub fn from_spec(spec: &Spec, bundle: &Path) -> Result<Self> {
+    pub fn from_spec(spec: &Spec, bundle: &Path, id: &str) -> Result<Self> {
         let rootfs = rootfs_path(spec, bundle);
 
         // OCI `root.readonly`: when set, the container rootfs must be read-only,
@@ -65,6 +70,7 @@ impl OciPolicy {
         let mut fs_read = Vec::new();
         let mut fs_write = Vec::new();
         let mut fs_mount = Vec::new();
+        let mut scratch_dirs = Vec::new();
 
         if rootfs.is_some() {
             // The container owns its rootfs, so grant the whole chroot rather
@@ -79,9 +85,12 @@ impl OciPolicy {
             }
         }
 
-        // Process mounts — populate fs_mount, fs_read, fs_write
+        // Process mounts — populate fs_mount, fs_read, fs_write, scratch_dirs
         if let Some(mounts) = spec.mounts() {
-            map_mounts(mounts, bundle, &rootfs, &mut fs_mount, &mut fs_read, &mut fs_write);
+            map_mounts(
+                mounts, bundle, &rootfs, id,
+                &mut fs_mount, &mut fs_read, &mut fs_write, &mut scratch_dirs,
+            );
         }
 
         // oci-spec 0.7: sub-struct getters (via #[getset]) return &T / &Option<T>.
@@ -146,6 +155,7 @@ impl OciPolicy {
             max_memory,
             max_processes,
             max_cpu,
+            scratch_dirs,
         })
     }
 
@@ -216,66 +226,86 @@ fn rootfs_path(spec: &Spec, bundle: &Path) -> Option<PathBuf> {
     }
 }
 
-/// Process OCI mounts into fs_mount, fs_read, and fs_write lists.
+/// Translate OCI mounts into sandlock primitives by intent:
 ///
-/// Skips kernel-only mount types (proc, sysfs, etc.) and applies
-/// read/write permissions from mount options to the fs_read/fs_write
-/// vectors rather than hardcoding paths.
+/// - **bind** (real source): `fs_mount(dest, source)`, ro/rw from options.
+/// - **tmpfs** writable scratch (`/tmp`, `/run`, `/dev/shm`, …): backed by a
+///   host directory under the container state dir and bind-mounted read-write,
+///   so it works on a read-only root and stays isolated from the rootfs.
+/// - **tmpfs at `/dev`, proc, sysfs**: passed through read-only so sandlock's
+///   `/dev` interception and `/proc` virtualization service them; an empty
+///   backing dir would shadow `/dev/null`, `/proc/*`, etc.
+/// - **devpts/mqueue/cgroup**: skipped (no safe namespace-less equivalent).
 fn map_mounts(
     mounts: &[oci_spec::runtime::Mount],
     bundle: &Path,
     rootfs: &Option<PathBuf>,
+    id: &str,
     fs_mount: &mut Vec<(PathBuf, PathBuf)>,
     fs_read: &mut Vec<PathBuf>,
     fs_write: &mut Vec<PathBuf>,
+    scratch_dirs: &mut Vec<PathBuf>,
 ) {
     for mount in mounts {
         let dest = mount.destination();
-
-        // Detect read-only option from mount options.
-        let read_only = mount
-            .options()
-            .as_ref()
-            .map(|opts| opts.iter().any(|o| o == "ro"))
-            .unwrap_or(false);
-
-        // Resolve source — relative paths are relative to the bundle.
-        let source: Option<PathBuf> = mount.source().as_ref().map(|s| {
-            if s.is_absolute() {
-                s.clone()
-            } else {
-                bundle.join(s)
-            }
-        });
-
-        // Skip kernel-provided virtual filesystems.
-        // These don't need Landlock rules and can't be bind-mounted.
         let mount_type = mount.typ().as_deref().unwrap_or("bind");
+
         match mount_type {
-            "proc" | "sysfs" | "devpts" | "tmpfs" | "mqueue" | "cgroup" | "cgroup2" => {
-                continue;
-            }
-            _ => {}
-        }
+            // Kernel interfaces: pass the host's through read-only.  sandlock
+            // virtualizes /proc and intercepts /dev/{null,urandom,random,…}.
+            "proc" => fs_read.push(PathBuf::from("/proc")),
+            "sysfs" => fs_read.push(PathBuf::from("/sys")),
 
-        // Bind mounts: record the mapping and set read/write permissions.
-        if let Some(src) = source {
-            if let Some(ref rootfs_path) = rootfs {
-                // Resolve the destination relative to the chroot.
-                let chroot_dest = rootfs_path.join(dest.strip_prefix("/").unwrap_or(dest));
-                if chroot_dest.exists() || src.exists() {
-                    fs_mount.push((dest.to_path_buf(), src));
-                }
-            } else {
-                if src.exists() {
-                    fs_mount.push((dest.to_path_buf(), src));
+            "tmpfs" => {
+                if dest.to_str() == Some("/dev") {
+                    // The device filesystem — pass through; nodes are served by
+                    // interception, an empty backing dir would hide them.
+                    fs_read.push(PathBuf::from("/dev"));
+                } else {
+                    // Writable scratch (e.g. /tmp, /run, /dev/shm).  Back it with
+                    // a host dir under the state dir so writes are isolated from a
+                    // read-only rootfs and cleaned up with the state dir on delete.
+                    let backing = Path::new(&crate::state::state_dir())
+                        .join(id)
+                        .join("tmpfs")
+                        .join(dest.strip_prefix("/").unwrap_or(dest));
+                    fs_mount.push((dest.to_path_buf(), backing.clone()));
+                    fs_write.push(dest.to_path_buf());
+                    scratch_dirs.push(backing);
                 }
             }
 
-            if read_only {
-                fs_read.push(dest.clone());
-            } else {
-                fs_write.push(dest.clone());
+            // No safe namespace-less equivalent.
+            "devpts" | "mqueue" | "cgroup" | "cgroup2" => {}
+
+            // Bind mounts (and any other type carrying a real source).
+            _ => {
+                let read_only = mount
+                    .options()
+                    .as_ref()
+                    .map(|opts| opts.iter().any(|o| o == "ro"))
+                    .unwrap_or(false);
+                let source: Option<PathBuf> = mount.source().as_ref().map(|s| {
+                    if s.is_absolute() { s.clone() } else { bundle.join(s) }
+                });
+                if let Some(src) = source {
+                    let keep = match rootfs {
+                        Some(rootfs_path) => {
+                            let chroot_dest =
+                                rootfs_path.join(dest.strip_prefix("/").unwrap_or(dest));
+                            chroot_dest.exists() || src.exists()
+                        }
+                        None => src.exists(),
+                    };
+                    if keep {
+                        fs_mount.push((dest.to_path_buf(), src));
+                        if read_only {
+                            fs_read.push(dest.to_path_buf());
+                        } else {
+                            fs_write.push(dest.to_path_buf());
+                        }
+                    }
+                }
             }
         }
     }
@@ -311,7 +341,7 @@ mod tests {
         fs::create_dir_all(bundle.join("rootfs")).unwrap();
 
         let spec = minimal_spec();
-        let policy = OciPolicy::from_spec(&spec, bundle).unwrap();
+        let policy = OciPolicy::from_spec(&spec, bundle, "test").unwrap();
 
         assert!(policy.rootfs.is_some());
         assert!(policy.rootfs.as_ref().unwrap().ends_with("rootfs"));
@@ -325,7 +355,7 @@ mod tests {
         fs::create_dir_all(bundle.join("rootfs")).unwrap();
 
         let spec = minimal_spec();
-        let policy = OciPolicy::from_spec(&spec, bundle).unwrap();
+        let policy = OciPolicy::from_spec(&spec, bundle, "test").unwrap();
 
         assert!(policy.env.contains_key("PATH"));
         assert_eq!(policy.env.get("FOO"), Some(&"bar".to_string()));
@@ -337,7 +367,7 @@ mod tests {
         let bundle = dir.path();
         fs::create_dir_all(bundle.join("rootfs")).unwrap();
 
-        let policy = OciPolicy::from_spec(&minimal_spec(), bundle).unwrap();
+        let policy = OciPolicy::from_spec(&minimal_spec(), bundle, "test").unwrap();
         // No resources set in minimal_spec, so these should be None
         assert!(policy.max_memory.is_none());
         assert!(policy.max_processes.is_none());
@@ -362,7 +392,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let policy = OciPolicy::from_spec(&spec, bundle).unwrap();
+        let policy = OciPolicy::from_spec(&spec, bundle, "test").unwrap();
         assert!(policy.fs_read.contains(&PathBuf::from("/")));
         assert!(!policy.fs_write.contains(&PathBuf::from("/")));
     }
@@ -374,9 +404,47 @@ mod tests {
         fs::create_dir_all(bundle.join("rootfs")).unwrap();
 
         // minimal_spec() sets readonly(false).
-        let policy = OciPolicy::from_spec(&minimal_spec(), bundle).unwrap();
+        let policy = OciPolicy::from_spec(&minimal_spec(), bundle, "test").unwrap();
         assert!(policy.fs_write.contains(&PathBuf::from("/")));
         assert!(!policy.fs_read.contains(&PathBuf::from("/")));
+    }
+
+    #[test]
+    fn tmpfs_scratch_backed_proc_dev_passthrough() {
+        std::env::set_var("SANDLOCK_OCI_STATE_DIR", "/tmp/sandlock-oci-test-mounts");
+        let dir = tempdir().unwrap();
+        let bundle = dir.path();
+        fs::create_dir_all(bundle.join("rootfs")).unwrap();
+
+        let json = serde_json::json!({
+            "ociVersion": "1.0.2",
+            "root": { "path": "rootfs", "readonly": true },
+            "process": { "user": { "uid": 0, "gid": 0 }, "cwd": "/", "args": ["sh"] },
+            "mounts": [
+                { "destination": "/tmp",  "type": "tmpfs", "source": "tmpfs" },
+                { "destination": "/proc", "type": "proc",  "source": "proc" },
+                { "destination": "/dev",  "type": "tmpfs", "source": "tmpfs" }
+            ]
+        });
+        let spec: Spec = serde_json::from_value(json).unwrap();
+
+        let policy = OciPolicy::from_spec(&spec, bundle, "ctr1").unwrap();
+
+        // /tmp is writable scratch: bind-mounted to a backing dir under the
+        // state dir, recorded for creation, and marked writable.
+        assert!(policy
+            .fs_mount
+            .iter()
+            .any(|(d, h)| d == Path::new("/tmp") && h.ends_with("ctr1/tmpfs/tmp")));
+        assert!(policy.scratch_dirs.iter().any(|d| d.ends_with("ctr1/tmpfs/tmp")));
+        assert!(policy.fs_write.contains(&PathBuf::from("/tmp")));
+
+        // /proc and /dev are passed through read-only, not emulated.
+        assert!(policy.fs_read.contains(&PathBuf::from("/proc")));
+        assert!(policy.fs_read.contains(&PathBuf::from("/dev")));
+        assert!(!policy.fs_mount.iter().any(|(d, _)| d == Path::new("/dev")));
+
+        std::env::remove_var("SANDLOCK_OCI_STATE_DIR");
     }
 
     #[test]
@@ -386,7 +454,7 @@ mod tests {
         fs::create_dir_all(bundle.join("rootfs")).unwrap();
 
         let spec = minimal_spec();
-        let policy = OciPolicy::from_spec(&spec, bundle).unwrap();
+        let policy = OciPolicy::from_spec(&spec, bundle, "test").unwrap();
         let sandbox = policy.to_sandbox().unwrap();
 
         assert!(sandbox.chroot.is_some());
@@ -407,7 +475,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let policy = OciPolicy::from_spec(&spec, Path::new("/tmp")).unwrap();
+        let policy = OciPolicy::from_spec(&spec, Path::new("/tmp"), "test").unwrap();
         assert!(policy.rootfs.is_none());
     }
 }

--- a/crates/sandlock-oci/src/policy.rs
+++ b/crates/sandlock-oci/src/policy.rs
@@ -57,7 +57,7 @@ pub struct OciPolicy {
 impl OciPolicy {
     /// Build an OciPolicy from a parsed OCI Spec and its bundle directory.
     pub fn from_spec(spec: &Spec, bundle: &Path, id: &str) -> Result<Self> {
-        let rootfs = rootfs_path(spec, bundle);
+        let rootfs = rootfs_path(spec, bundle)?;
 
         // OCI `root.readonly`: when set, the container rootfs must be read-only,
         // so the whole chroot is granted read access rather than read-write.
@@ -209,20 +209,28 @@ impl OciPolicy {
 }
 
 /// Resolve the rootfs path from the OCI spec.
-/// Returns `None` when the spec has no root, an empty path, or a path that
-/// doesn't exist on disk (allows rootfs-less invocations and tests without a
-/// real bundle).
-fn rootfs_path(spec: &Spec, bundle: &Path) -> Option<PathBuf> {
-    let raw = spec.root().as_ref()
-        .and_then(|r| {
-            let p = r.path().clone();
-            if p.as_os_str().is_empty() { None } else { Some(p) }
-        })?;
-    if raw.is_absolute() {
-        if raw.exists() { Some(raw) } else { None }
+///
+/// Returns `Ok(None)` when the spec declares no root (or an empty path): a
+/// legitimately rootfs-less invocation. Returns an error when a root path *is*
+/// declared but does not resolve to an existing directory, so a broken bundle
+/// fails fast at `create` rather than launching chroot-less and failing
+/// obscurely at execve.
+fn rootfs_path(spec: &Spec, bundle: &Path) -> Result<Option<PathBuf>> {
+    let raw = match spec.root().as_ref().and_then(|r| {
+        let p = r.path().clone();
+        if p.as_os_str().is_empty() { None } else { Some(p) }
+    }) {
+        Some(p) => p,
+        None => return Ok(None),
+    };
+    let resolved = if raw.is_absolute() { raw } else { bundle.join(&raw) };
+    if resolved.exists() {
+        Ok(Some(resolved))
     } else {
-        let joined = bundle.join(&raw);
-        if joined.exists() { Some(joined) } else { None }
+        anyhow::bail!(
+            "rootfs path {:?} declared in config.json does not exist",
+            resolved
+        )
     }
 }
 
@@ -460,9 +468,12 @@ mod tests {
     }
 
     #[test]
-    fn default_stdin_paths_without_rootfs() {
+    fn rootfs_less_spec_yields_no_chroot() {
+        // An explicitly empty root path is a legitimately rootfs-less
+        // invocation: no chroot, confined against host paths only.
         let spec = SpecBuilder::default()
             .version("1.0.2")
+            .root(RootBuilder::default().path("").build().unwrap())
             .process(
                 ProcessBuilder::default()
                     .args(vec!["echo".to_string(), "hello".to_string()])
@@ -474,5 +485,27 @@ mod tests {
 
         let policy = OciPolicy::from_spec(&spec, Path::new("/tmp"), "test").unwrap();
         assert!(policy.rootfs.is_none());
+    }
+
+    #[test]
+    fn declared_but_missing_rootfs_errors() {
+        // A root path that is declared but does not exist must fail fast at
+        // policy build rather than silently launching without a chroot.
+        let spec = SpecBuilder::default()
+            .version("1.0.2")
+            .root(RootBuilder::default().path("rootfs").build().unwrap())
+            .process(
+                ProcessBuilder::default()
+                    .args(vec!["sh".to_string()])
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        let bundle = tempdir().unwrap();
+        // Note: no rootfs dir created under the bundle.
+        let err = OciPolicy::from_spec(&spec, bundle.path(), "test").unwrap_err();
+        assert!(err.to_string().contains("does not exist"));
     }
 }

--- a/crates/sandlock-oci/src/spec.rs
+++ b/crates/sandlock-oci/src/spec.rs
@@ -39,8 +39,8 @@ pub fn load_spec(bundle: &Path) -> Result<Spec> {
 ///   `pids.limit` → `max_processes`.
 /// - **Process**: `process.cwd` → `cwd`, environment forwarded.
 /// - **Namespaces**: Ignored — sandlock avoids namespaces by design.
-pub fn spec_to_policy(spec: &Spec, bundle: &Path) -> Result<OciPolicy> {
-    let policy = OciPolicy::from_spec(spec, bundle)
+pub fn spec_to_policy(spec: &Spec, bundle: &Path, id: &str) -> Result<OciPolicy> {
+    let policy = OciPolicy::from_spec(spec, bundle, id)
         .with_context(|| "failed to map OCI spec to sandlock policy")?;
     Ok(policy)
 }
@@ -89,7 +89,7 @@ mod tests {
         fs::create_dir_all(bundle.join("rootfs")).unwrap();
 
         let spec = minimal_spec();
-        let policy = spec_to_policy(&spec, bundle).unwrap();
+        let policy = spec_to_policy(&spec, bundle, "test").unwrap();
         assert_eq!(policy.cwd.as_deref(), Some(std::path::Path::new("/app")));
     }
 
@@ -100,7 +100,7 @@ mod tests {
         fs::create_dir_all(bundle.join("rootfs")).unwrap();
 
         let spec = minimal_spec();
-        let policy = spec_to_policy(&spec, bundle).unwrap();
+        let policy = spec_to_policy(&spec, bundle, "test").unwrap();
         assert!(policy.env.contains_key("PATH"));
     }
 
@@ -111,7 +111,7 @@ mod tests {
         fs::create_dir_all(bundle.join("rootfs")).unwrap();
 
         let spec = minimal_spec();
-        let policy = spec_to_policy(&spec, bundle).unwrap();
+        let policy = spec_to_policy(&spec, bundle, "test").unwrap();
         assert!(policy.rootfs.is_some());
         assert!(policy.rootfs.as_ref().unwrap().ends_with("rootfs"));
     }

--- a/crates/sandlock-oci/src/state.rs
+++ b/crates/sandlock-oci/src/state.rs
@@ -1,4 +1,4 @@
-//! Persistent state management for OCI container lifecycle.
+//! Persistent state management for the OCI container lifecycle.
 //!
 //! State JSON is stored at `<root>/<id>/state.json`, where `<root>` is the
 //! `--root` directory (when given), `$XDG_RUNTIME_DIR/sandlock-oci` for
@@ -69,13 +69,13 @@ pub fn state_dir() -> String {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Status {
-    /// Transient state while the supervisor is setting up the container.
+    /// Transient state while the supervisor is setting up the sandbox.
     Creating,
-    /// Container has been created (child parked) but not yet started.
+    /// Sandbox has been created (child parked) but not yet started.
     Created,
-    /// Container is currently running.
+    /// Sandbox is currently running.
     Running,
-    /// Container process has exited.
+    /// Sandbox process has exited.
     Stopped,
 }
 
@@ -90,34 +90,34 @@ impl std::fmt::Display for Status {
     }
 }
 
-/// The on-disk state blob for a sandlock-oci container.
+/// The on-disk state blob for a sandlock-oci sandbox.
 ///
 /// Fields match the OCI Runtime State specification.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ContainerState {
+pub struct SandboxState {
     /// OCI spec version.
     #[serde(rename = "ociVersion")]
     pub oci_version: String,
-    /// Container identifier (unique on this host).
+    /// Sandbox identifier (unique on this host).
     pub id: String,
     /// Current lifecycle status.
     pub status: Status,
-    /// PID of the container's init process (0 = not yet started).
+    /// PID of the sandbox's init process (0 = not yet started).
     pub pid: i32,
     /// Absolute path to the bundle directory.
     pub bundle: PathBuf,
-    /// Unix timestamp (seconds) when the container was created.
+    /// Unix timestamp (seconds) when the sandbox was created.
     pub created: u64,
     /// Optional annotations from the OCI spec.
     #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
     pub annotations: std::collections::HashMap<String, String>,
-    /// Exit code or signal that terminated the container.
-    /// `None` while the container is Created or Running.
+    /// Exit code or signal that terminated the sandbox.
+    /// `None` while the sandbox is Created or Running.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exit_info: Option<ExitInfo>,
 }
 
-/// Captures how the container's init process exited.
+/// Captures how the sandbox's init process exited.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExitInfo {
     /// Exit code if the process exited normally.
@@ -126,14 +126,14 @@ pub struct ExitInfo {
     pub signal: Option<i32>,
 }
 
-impl ContainerState {
+impl SandboxState {
     /// Create a new state in the `Created` status.
     pub fn new(id: &str, bundle: &Path, oci_version: &str) -> Self {
         let created = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
-        ContainerState {
+        SandboxState {
             oci_version: oci_version.to_string(),
             id: id.to_string(),
             status: Status::Creating,
@@ -145,7 +145,7 @@ impl ContainerState {
         }
     }
 
-    /// Path to the state directory for this container.
+    /// Path to the state directory for this sandbox.
     pub fn state_dir(&self) -> PathBuf {
         Path::new(&state_dir()).join(&self.id)
     }
@@ -161,7 +161,7 @@ impl ContainerState {
         std::fs::create_dir_all(&dir)
             .with_context(|| format!("create state dir {:?}", dir))?;
         let data = serde_json::to_string_pretty(self)
-            .context("serialize container state")?;
+            .context("serialize sandbox state")?;
         std::fs::write(self.state_file(), data)
             .with_context(|| format!("write state to {:?}", self.state_file()))
     }
@@ -191,7 +191,7 @@ impl ContainerState {
         self.pid = pid;
     }
 
-    /// Mark the container as running.
+    /// Mark the sandbox as running.
     pub fn set_running(&mut self) {
         self.status = Status::Running;
     }
@@ -202,7 +202,7 @@ impl ContainerState {
         self.exit_info = exit_info;
     }
 
-    /// Returns true if the container process is still alive.
+    /// Returns true if the sandbox process is still alive.
     pub fn is_alive(&self) -> bool {
         if self.pid <= 0 {
             return false;
@@ -212,8 +212,8 @@ impl ContainerState {
     }
 }
 
-/// List all container IDs currently tracked in STATE_DIR.
-pub fn list_containers() -> Result<Vec<String>> {
+/// List all sandbox IDs currently tracked in STATE_DIR.
+pub fn list_sandboxes() -> Result<Vec<String>> {
     let dir_str = state_dir();
     let dir = Path::new(&dir_str);
     if !dir.exists() {
@@ -238,8 +238,8 @@ mod tests {
     use super::*;
     use std::env;
 
-    fn _make_state(id: &str) -> ContainerState {
-        ContainerState::new(id, Path::new("/tmp"), "1.0.2")
+    fn _make_state(id: &str) -> SandboxState {
+        SandboxState::new(id, Path::new("/tmp"), "1.0.2")
     }
 
     #[test]
@@ -251,9 +251,9 @@ mod tests {
 
     #[test]
     fn state_roundtrip_json() {
-        let state = ContainerState::new("test-ctr", Path::new("/tmp"), "1.0.2");
+        let state = SandboxState::new("test-ctr", Path::new("/tmp"), "1.0.2");
         let json = serde_json::to_string(&state).unwrap();
-        let loaded: ContainerState = serde_json::from_str(&json).unwrap();
+        let loaded: SandboxState = serde_json::from_str(&json).unwrap();
         assert_eq!(loaded.id, "test-ctr");
         // new() begins in Creating; set_created() transitions to Created.
         assert_eq!(loaded.status, Status::Creating);
@@ -261,7 +261,7 @@ mod tests {
 
     #[test]
     fn is_alive_returns_false_for_zero_pid() {
-        let state = ContainerState::new("dead-ctr", Path::new("/tmp"), "1.0.2");
+        let state = SandboxState::new("dead-ctr", Path::new("/tmp"), "1.0.2");
         assert!(!state.is_alive());
     }
 

--- a/crates/sandlock-oci/src/state.rs
+++ b/crates/sandlock-oci/src/state.rs
@@ -1,21 +1,68 @@
 //! Persistent state management for OCI container lifecycle.
 //!
-//! Implements Phase 2: state JSON stored at `/run/sandlock-oci/<id>/state.json`.
+//! State JSON is stored at `<root>/<id>/state.json`, where `<root>` is the
+//! `--root` directory (when given), `$XDG_RUNTIME_DIR/sandlock-oci` for
+//! unprivileged users, or `/run/sandlock-oci` for root. See [`state_dir`].
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// Default state directory root — matches the OCI runtime spec.
+/// System-wide state directory root, used when running as root.
 ///
-/// Can be overridden at runtime with the `SANDLOCK_OCI_STATE_DIR` environment
-/// variable (useful for integration tests that don't run as root).
+/// Matches the runc/containerd convention. Unprivileged users default to a
+/// per-user runtime directory instead (see [`resolve_state_dir`]), keeping
+/// sandlock usable without root.
 pub const STATE_DIR: &str = "/run/sandlock-oci";
 
-/// Return the effective state directory, respecting the env override.
+/// Process-wide state-dir root, resolved once in `main` via [`init_state_dir`].
+///
+/// Set before any `fork`, so the supervisor child inherits the same value.
+static STATE_DIR_ROOT: OnceLock<String> = OnceLock::new();
+
+/// Resolve and cache the state directory root for this process.
+///
+/// Precedence (highest first):
+/// 1. the explicit `--root` CLI flag (`root_flag`), the OCI-standard knob
+///    that containerd/CRI-O pass,
+/// 2. `$XDG_RUNTIME_DIR/sandlock-oci` for unprivileged users,
+/// 3. `/run/sandlock-oci` for root (or when no per-user runtime dir exists).
+///
+/// Call once, early in `main`, before any state I/O or `fork`.
+pub fn init_state_dir(root_flag: Option<&str>) {
+    let _ = STATE_DIR_ROOT.set(resolve_state_dir(root_flag));
+}
+
+/// Compute the state directory root without caching. See [`init_state_dir`]
+/// for the precedence rules.
+fn resolve_state_dir(root_flag: Option<&str>) -> String {
+    if let Some(root) = root_flag {
+        return root.to_string();
+    }
+    // Unprivileged default: a per-user, user-owned runtime dir, mirroring
+    // rootless runc/crun/podman. This is what keeps sandlock-oci runnable
+    // without root, which is the project's core design goal.
+    if unsafe { libc::geteuid() } != 0 {
+        if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
+            if !xdg.is_empty() {
+                return format!("{}/sandlock-oci", xdg);
+            }
+        }
+    }
+    STATE_DIR.to_string()
+}
+
+/// Return the effective state directory root.
+///
+/// Returns the value cached by [`init_state_dir`] when set; otherwise resolves
+/// the default (library and test callers that never call `init_state_dir`).
 pub fn state_dir() -> String {
-    std::env::var("SANDLOCK_OCI_STATE_DIR").unwrap_or_else(|_| STATE_DIR.to_string())
+    if let Some(dir) = STATE_DIR_ROOT.get() {
+        return dir.clone();
+    }
+    resolve_state_dir(None)
 }
 
 /// OCI container status as defined by the runtime spec.
@@ -250,9 +297,16 @@ mod tests {
     }
 
     #[test]
-    fn state_dir_respects_env_override() {
-        env::set_var("SANDLOCK_OCI_STATE_DIR", "/tmp/sandlock-test-dir");
-        assert_eq!(state_dir(), "/tmp/sandlock-test-dir");
-        env::remove_var("SANDLOCK_OCI_STATE_DIR");
+    fn state_dir_resolution_precedence() {
+        // The --root flag takes precedence over the computed default.
+        assert_eq!(resolve_state_dir(Some("/custom/root")), "/custom/root");
+
+        // Unprivileged users default to a per-user runtime dir; root falls
+        // back to the system-wide STATE_DIR.
+        if unsafe { libc::geteuid() } != 0 {
+            env::set_var("XDG_RUNTIME_DIR", "/run/user/4242");
+            assert_eq!(resolve_state_dir(None), "/run/user/4242/sandlock-oci");
+            env::remove_var("XDG_RUNTIME_DIR");
+        }
     }
 }

--- a/crates/sandlock-oci/src/state.rs
+++ b/crates/sandlock-oci/src/state.rs
@@ -79,28 +79,6 @@ pub struct ExitInfo {
     pub signal: Option<i32>,
 }
 
-impl ExitInfo {
-    /// Create from a raw waitpid status value.
-    pub fn from_status(status: i32) -> Self {
-        if libc::WIFEXITED(status) {
-            ExitInfo {
-                code: Some(unsafe { libc::WEXITSTATUS(status) }),
-                signal: None,
-            }
-        } else if libc::WIFSIGNALED(status) {
-            ExitInfo {
-                code: None,
-                signal: Some(unsafe { libc::WTERMSIG(status) }),
-            }
-        } else {
-            ExitInfo {
-                code: None,
-                signal: None,
-            }
-        }
-    }
-}
-
 impl ContainerState {
     /// Create a new state in the `Created` status.
     pub fn new(id: &str, bundle: &Path, oci_version: &str) -> Self {
@@ -269,20 +247,6 @@ mod tests {
         state.set_stopped(Some(info));
         assert_eq!(state.status, Status::Stopped);
         assert_eq!(state.exit_info.as_ref().unwrap().code, Some(0));
-    }
-
-    #[test]
-    fn exit_info_from_status_exited() {
-        let info = ExitInfo::from_status(0 << 8); // exit code 0
-        assert_eq!(info.code, Some(0));
-        assert!(info.signal.is_none());
-    }
-
-    #[test]
-    fn exit_info_from_status_signaled() {
-        let info = ExitInfo::from_status(libc::SIGKILL); // killed by SIGKILL
-        assert!(info.code.is_none());
-        assert_eq!(info.signal, Some(libc::SIGKILL));
     }
 
     #[test]

--- a/crates/sandlock-oci/src/state.rs
+++ b/crates/sandlock-oci/src/state.rs
@@ -138,7 +138,7 @@ impl ContainerState {
         Ok(())
     }
 
-    /// Record the PID in Created state (SIGSTOP'd child).
+    /// Transition `Creating` -> `Created`, recording the parked child's init PID.
     pub fn set_created(&mut self, pid: i32) {
         self.status = Status::Created;
         self.pid = pid;

--- a/crates/sandlock-oci/src/supervisor.rs
+++ b/crates/sandlock-oci/src/supervisor.rs
@@ -219,22 +219,31 @@ async fn supervisor_main(
                 let _ = stream.write_all(b"\n").await;
             }
             SupervisorCmd::Start => {
-                // OCI `start` — write to the ready pipe so the parked child
-                // proceeds to execve with the full sandlock policy already in place.
-                let reply = match sandbox.start() {
+                // OCI `start` — release the parked child to execve with the
+                // full sandlock policy already in place.
+                match sandbox.start() {
                     Ok(()) => {
                         if let Ok(mut s) = ContainerState::load(id) {
                             s.set_running();
                             s.save().ok();
                         }
-                        SupervisorReply::Ok
+                        let reply = serde_json::to_vec(&SupervisorReply::Ok).unwrap_or_default();
+                        let _ = stream.write_all(&reply).await;
+                        let _ = stream.write_all(b"\n").await;
+                        break LoopExit::Started;
                     }
-                    Err(e) => SupervisorReply::Err { msg: e.to_string() },
-                };
-                let reply_bytes = serde_json::to_vec(&reply).unwrap_or_default();
-                let _ = stream.write_all(&reply_bytes).await;
-                let _ = stream.write_all(b"\n").await;
-                break LoopExit::Started;
+                    Err(e) => {
+                        let reply = serde_json::to_vec(&SupervisorReply::Err { msg: e.to_string() })
+                            .unwrap_or_default();
+                        let _ = stream.write_all(&reply).await;
+                        let _ = stream.write_all(b"\n").await;
+                        // start() failed with the child still parked: do NOT
+                        // wait() (it would block forever on a child that never
+                        // execve's).  Exit via the Shutdown path so the Sandbox
+                        // Drop kills and reaps the parked child.
+                        break LoopExit::Shutdown;
+                    }
+                }
             }
             SupervisorCmd::Shutdown => {
                 // `delete` before `start` — acknowledge and exit.  The sandbox

--- a/crates/sandlock-oci/src/supervisor.rs
+++ b/crates/sandlock-oci/src/supervisor.rs
@@ -93,6 +93,14 @@ pub fn run_supervisor(
         anyhow::bail!("OCI spec error: process.args is empty");
     }
 
+    // Create backing dirs for emulated tmpfs mounts before building the
+    // sandbox so each bind redirect has a target on disk.  They live under the
+    // container state dir and are removed with it on `delete`.
+    for dir in &policy.scratch_dirs {
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("create tmpfs backing dir {:?}", dir))?;
+    }
+
     // Build the Sandbox from the OCI policy — this carries chroot, env, fs
     // rules, resource limits, and network policy into sandlock-core.
     let mut sandbox = policy.to_sandbox().context("build Sandbox from OCI policy")?;

--- a/crates/sandlock-oci/src/supervisor.rs
+++ b/crates/sandlock-oci/src/supervisor.rs
@@ -12,16 +12,16 @@
 //! 4. `sandbox.wait()` collects the exit status and persists it to state.json.
 //!
 //! Communication with the CLI is newline-delimited JSON over a Unix socket in
-//! the container's state directory.
+//! the sandbox's state directory.
 
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::policy::OciPolicy;
-use crate::state::ContainerState;
+use crate::state::SandboxState;
 
-/// Filename of the supervisor control socket inside the container state dir.
+/// Filename of the supervisor control socket inside the sandbox state dir.
 pub const SUPERVISOR_SOCKET: &str = "supervisor.sock";
 
 /// Commands the CLI sends to the Supervisor over the Unix socket.
@@ -33,7 +33,7 @@ pub enum SupervisorCmd {
     /// Query the child PID.
     Ping,
     /// Terminate the supervisor without starting the child (used by `delete`
-    /// when the container was never started).  The sandbox `Drop` kills the
+    /// when the sandbox was never started).  The sandbox `Drop` kills the
     /// parked child.
     Shutdown,
 }
@@ -47,7 +47,7 @@ pub enum SupervisorReply {
     Err { msg: String },
 }
 
-/// Returns the path to the supervisor socket for the given container ID.
+/// Returns the path to the supervisor socket for the given sandbox ID.
 pub fn socket_path(id: &str) -> PathBuf {
     PathBuf::from(crate::state::state_dir())
         .join(id)
@@ -95,7 +95,7 @@ pub fn run_supervisor(
 
     // Create backing dirs for emulated tmpfs mounts before building the
     // sandbox so each bind redirect has a target on disk.  They live under the
-    // container state dir and are removed with it on `delete`.
+    // sandbox state dir and are removed with it on `delete`.
     for dir in &policy.scratch_dirs {
         std::fs::create_dir_all(dir)
             .with_context(|| format!("create tmpfs backing dir {:?}", dir))?;
@@ -180,8 +180,8 @@ async fn supervisor_main(
 
     // Persist Created state with the real child PID.
     {
-        let mut state = ContainerState::load(id).unwrap_or_else(|_| {
-            ContainerState::new(id, Path::new("/"), "1.0.2")
+        let mut state = SandboxState::load(id).unwrap_or_else(|_| {
+            SandboxState::new(id, Path::new("/"), "1.0.2")
         });
         state.set_created(child_pid);
         state.save().ok();
@@ -223,7 +223,7 @@ async fn supervisor_main(
                 // full sandlock policy already in place.
                 match sandbox.start() {
                     Ok(()) => {
-                        if let Ok(mut s) = ContainerState::load(id) {
+                        if let Ok(mut s) = SandboxState::load(id) {
                             s.set_running();
                             s.save().ok();
                         }
@@ -273,7 +273,7 @@ async fn supervisor_main(
         Err(_) => None,
     };
 
-    if let Ok(mut s) = ContainerState::load(id) {
+    if let Ok(mut s) = SandboxState::load(id) {
         s.set_stopped(exit_info);
         s.save().ok();
     }
@@ -287,8 +287,8 @@ mod tests {
 
     #[test]
     fn socket_path_is_under_state_dir() {
-        let p = socket_path("my-container");
-        assert!(p.to_str().unwrap().contains("my-container"));
+        let p = socket_path("my-sandbox");
+        assert!(p.to_str().unwrap().contains("my-sandbox"));
         assert!(p.to_str().unwrap().contains("supervisor.sock"));
     }
 

--- a/crates/sandlock-oci/tests/integration.rs
+++ b/crates/sandlock-oci/tests/integration.rs
@@ -188,3 +188,42 @@ fn oci_delete_nonexistent_is_ok() {
     let out = run_oci(&["delete", "ghost-container-xyz-99"]);
     assert!(out.status.success());
 }
+
+#[test]
+fn oci_create_rejects_duplicate_id() {
+    if !oci_bin().exists() {
+        eprintln!("sandlock-oci binary not built — skipping");
+        return;
+    }
+    // The uniqueness guard fires before any fork, so a pre-existing state.json
+    // under --root is enough to trigger it — no rootfs or Landlock needed.
+    let root = tempdir().unwrap();
+    let id = "dup-id-test";
+    let cdir = root.path().join(id);
+    fs::create_dir_all(&cdir).unwrap();
+    fs::write(
+        cdir.join("state.json"),
+        r#"{"ociVersion":"1.0.2","id":"dup-id-test","status":"created","pid":12345,"bundle":"/tmp","created":0}"#,
+    )
+    .unwrap();
+
+    let out = Command::new(oci_bin())
+        .args([
+            "--root",
+            root.path().to_str().unwrap(),
+            "create",
+            id,
+            "-b",
+            "/tmp",
+        ])
+        .output()
+        .expect("failed to run sandlock-oci");
+
+    assert!(!out.status.success(), "duplicate create should fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("already exists"),
+        "expected 'already exists' error, got: {}",
+        stderr
+    );
+}

--- a/crates/sandlock-oci/tests/integration.rs
+++ b/crates/sandlock-oci/tests/integration.rs
@@ -76,7 +76,7 @@ fn spec_load_and_policy_mapping() {
         .unwrap();
     assert_eq!(spec.version(), "1.0.2");
 
-    let policy = sandlock_oci::spec::spec_to_policy(&spec, dir.path()).unwrap();
+    let policy = sandlock_oci::spec::spec_to_policy(&spec, dir.path(), "test").unwrap();
     // PATH env is forwarded
     assert!(policy.env.contains_key("PATH"));
     // Cwd is forwarded
@@ -122,7 +122,7 @@ fn policy_from_spec_builds_sandbox() {
     create_bundle(dir.path(), &["sh", "-c", "exit 0"]);
 
     let spec = sandlock_oci::spec::load_spec(dir.path()).unwrap();
-    let policy = sandlock_oci::spec::spec_to_policy(&spec, dir.path()).unwrap();
+    let policy = sandlock_oci::spec::spec_to_policy(&spec, dir.path(), "test").unwrap();
 
     // Can convert to sandbox config
     let sandbox = policy.to_sandbox().unwrap();

--- a/crates/sandlock-oci/tests/integration.rs
+++ b/crates/sandlock-oci/tests/integration.rs
@@ -5,28 +5,20 @@
 //!
 //! To run: `cargo test -p sandlock-oci -- --test-threads=1`
 //!
-//! **Note**: these tests require root or a kernel with Landlock v1+ support.
-//! They are skipped automatically when not running as root.
+//! **Note**: the lifecycle commands that fork a sandboxed child need root or a
+//! Landlock-capable kernel, but the smoke tests here only exercise argument
+//! handling and error paths, so they run unprivileged (including in CI).
 
 use std::fs;
 use std::path::Path;
 use std::process::Command;
 use tempfile::tempdir;
 
-/// Build the binary path for sandlock-oci.
-fn oci_bin() -> std::path::PathBuf {
-    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    // Use the workspace target directory.
-    let workspace_root = Path::new(&manifest)
-        .parent() // crates/
-        .unwrap()
-        .parent() // workspace root
-        .unwrap()
-        .to_path_buf();
-    workspace_root
-        .join("target")
-        .join("debug")
-        .join("sandlock-oci")
+/// Path to the sandlock-oci binary under test. Cargo builds it before running
+/// the integration target and exposes its path here, so this resolves to the
+/// correct profile (debug or release) automatically.
+fn oci_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_sandlock-oci")
 }
 
 /// Create a minimal OCI bundle with a rootfs and config.json.
@@ -135,10 +127,6 @@ fn run_oci(args: &[&str]) -> std::process::Output {
 
 #[test]
 fn oci_check_exits_zero() {
-    if !oci_bin().exists() {
-        eprintln!("sandlock-oci binary not built — skipping");
-        return;
-    }
     let out = run_oci(&["check"]);
     assert!(
         out.status.success(),
@@ -149,20 +137,12 @@ fn oci_check_exits_zero() {
 
 #[test]
 fn oci_state_unknown_sandbox_errors() {
-    if !oci_bin().exists() {
-        eprintln!("sandlock-oci binary not built — skipping");
-        return;
-    }
     let out = run_oci(&["state", "this-does-not-exist-xyz-12345"]);
     assert!(!out.status.success(), "expected failure for unknown sandbox");
 }
 
 #[test]
 fn oci_list_no_sandboxes() {
-    if !oci_bin().exists() {
-        eprintln!("sandlock-oci binary not built — skipping");
-        return;
-    }
     // List should succeed even with no state dir.
     let out = run_oci(&["list"]);
     assert!(out.status.success());
@@ -170,20 +150,12 @@ fn oci_list_no_sandboxes() {
 
 #[test]
 fn oci_kill_unknown_sandbox_errors() {
-    if !oci_bin().exists() {
-        eprintln!("sandlock-oci binary not built — skipping");
-        return;
-    }
     let out = run_oci(&["kill", "no-such-sandbox-xyz", "SIGTERM"]);
     assert!(!out.status.success());
 }
 
 #[test]
 fn oci_delete_nonexistent_is_ok() {
-    if !oci_bin().exists() {
-        eprintln!("sandlock-oci binary not built — skipping");
-        return;
-    }
     // Deleting a sandbox that doesn't exist should not fail.
     let out = run_oci(&["delete", "ghost-sandbox-xyz-99"]);
     assert!(out.status.success());
@@ -191,10 +163,6 @@ fn oci_delete_nonexistent_is_ok() {
 
 #[test]
 fn oci_create_rejects_duplicate_id() {
-    if !oci_bin().exists() {
-        eprintln!("sandlock-oci binary not built — skipping");
-        return;
-    }
     // The uniqueness guard fires before any fork, so a pre-existing state.json
     // under --root is enough to trigger it — no rootfs or Landlock needed.
     let root = tempdir().unwrap();

--- a/crates/sandlock-oci/tests/integration.rs
+++ b/crates/sandlock-oci/tests/integration.rs
@@ -88,10 +88,6 @@ fn spec_load_and_policy_mapping() {
 #[test]
 fn state_created_lifecycle() {
     use sandlock_oci::state::{ContainerState, Status};
-    use std::env;
-
-    // Use a temp-friendly state dir for tests
-    env::set_var("SANDLOCK_OCI_STATE_DIR", "/tmp/sandlock-oci-test-state");
 
     let dir = tempdir().unwrap();
     let mut state = ContainerState::new("test-lifecycle", dir.path(), "1.0.2");
@@ -112,8 +108,6 @@ fn state_created_lifecycle() {
     assert_eq!(state.status, Status::Stopped);
     assert!(state.exit_info.is_some());
     assert_eq!(state.exit_info.as_ref().unwrap().code, Some(0));
-
-    env::remove_var("SANDLOCK_OCI_STATE_DIR");
 }
 
 #[test]

--- a/crates/sandlock-oci/tests/integration.rs
+++ b/crates/sandlock-oci/tests/integration.rs
@@ -87,10 +87,10 @@ fn spec_load_and_policy_mapping() {
 
 #[test]
 fn state_created_lifecycle() {
-    use sandlock_oci::state::{ContainerState, Status};
+    use sandlock_oci::state::{SandboxState, Status};
 
     let dir = tempdir().unwrap();
-    let mut state = ContainerState::new("test-lifecycle", dir.path(), "1.0.2");
+    let mut state = SandboxState::new("test-lifecycle", dir.path(), "1.0.2");
     // new() starts in Creating; set_created() advances to Created.
     assert_eq!(state.status, Status::Creating);
 
@@ -148,17 +148,17 @@ fn oci_check_exits_zero() {
 }
 
 #[test]
-fn oci_state_unknown_container_errors() {
+fn oci_state_unknown_sandbox_errors() {
     if !oci_bin().exists() {
         eprintln!("sandlock-oci binary not built — skipping");
         return;
     }
     let out = run_oci(&["state", "this-does-not-exist-xyz-12345"]);
-    assert!(!out.status.success(), "expected failure for unknown container");
+    assert!(!out.status.success(), "expected failure for unknown sandbox");
 }
 
 #[test]
-fn oci_list_no_containers() {
+fn oci_list_no_sandboxes() {
     if !oci_bin().exists() {
         eprintln!("sandlock-oci binary not built — skipping");
         return;
@@ -169,12 +169,12 @@ fn oci_list_no_containers() {
 }
 
 #[test]
-fn oci_kill_unknown_container_errors() {
+fn oci_kill_unknown_sandbox_errors() {
     if !oci_bin().exists() {
         eprintln!("sandlock-oci binary not built — skipping");
         return;
     }
-    let out = run_oci(&["kill", "no-such-container-xyz", "SIGTERM"]);
+    let out = run_oci(&["kill", "no-such-sandbox-xyz", "SIGTERM"]);
     assert!(!out.status.success());
 }
 
@@ -184,8 +184,8 @@ fn oci_delete_nonexistent_is_ok() {
         eprintln!("sandlock-oci binary not built — skipping");
         return;
     }
-    // Deleting a container that doesn't exist should not fail.
-    let out = run_oci(&["delete", "ghost-container-xyz-99"]);
+    // Deleting a sandbox that doesn't exist should not fail.
+    let out = run_oci(&["delete", "ghost-sandbox-xyz-99"]);
     assert!(out.status.success());
 }
 

--- a/crates/sandlock-oci/tests/integration.rs
+++ b/crates/sandlock-oci/tests/integration.rs
@@ -117,22 +117,6 @@ fn state_created_lifecycle() {
 }
 
 #[test]
-fn state_exit_info_from_status() {
-    use libc;
-    use sandlock_oci::state::ExitInfo;
-
-    // Normal exit
-    let info = ExitInfo::from_status(0 << 8);
-    assert_eq!(info.code, Some(0));
-    assert!(info.signal.is_none());
-
-    // Signal kill
-    let info = ExitInfo::from_status(libc::SIGKILL);
-    assert!(info.code.is_none());
-    assert_eq!(info.signal, Some(libc::SIGKILL));
-}
-
-#[test]
 fn policy_from_spec_builds_sandbox() {
     let dir = tempdir().unwrap();
     create_bundle(dir.path(), &["sh", "-c", "exit 0"]);


### PR DESCRIPTION
Follow-ups to #98 (the merged OCI runtime), covering the remaining review
comments from #31 plus a lifecycle bug found while auditing the
create/start API usage.

## Changes

- Remove the dead `--debug` CLI flag (parsed but never read).
- Remove the unused `ExitInfo::from_status` helper (only its own tests
  referenced it); clears the last build warnings.
- Honor `root.readonly`: grant the whole chroot read-only vs. read-write per
  the flag, replacing the hardcoded `/usr,/lib,...` + always-writable `/tmp`
  heuristic. Images with files outside the old fixed list now work.
- Translate OCI mounts by intent in `map_mounts`:
  - writable scratch tmpfs (`/tmp`, `/run`, `/dev/shm`) -> host backing dir
    under the container state dir, bind-mounted read-write (works on a
    read-only root, isolated from the rootfs, removed with the state dir on
    `delete`);
  - `/proc`, `/sys`, and a tmpfs `/dev` -> read passthrough so sandlock's
    procfs virtualization and `/dev` interception serve them (an empty backing
    dir would shadow `/dev/null`, `/proc/*`, etc.);
  - `devpts`/`mqueue`/`cgroup` -> skipped (no safe namespace-less equivalent).
- chdir the supervisor daemon to `/` so it does not pin the caller's cwd.
- Fix a supervisor hang: a failed `start()` no longer falls through to
  `wait()` (which would block forever on the still-parked child and leak the
  supervisor); it now exits via the `Drop`-based cleanup path.
- Doc fix: the `set_created` comment no longer references the removed SIGSTOP
  parking mechanism.

## Testing

- Warning-free build.
- All sandlock-oci tests pass (27 lib + 30 lib+bin + 8 integration).
