### PR TITLE
oci: honor process.user via gid-capable run-as (single-id userns)

### DIFF
--- a/crates/sandlock-cli/src/main.rs
+++ b/crates/sandlock-cli/src/main.rs
@@ -394,7 +394,7 @@ async fn run_command(args: RunArgs) -> Result<i32> {
         // Network virtualization
         b = b.port_remap(base.port_remap);
         // Process identity
-        if let Some(uid) = base.uid { b = b.uid(uid); }
+        if let Some(user) = base.user { b = b.user(user.uid, user.gid); }
         // Hardware constraints
         if let Some(ref devs) = base.gpu_devices { b = b.gpu_devices(devs.clone()); }
         if let Some(ref cores) = base.cpu_cores { b = b.cpu_cores(cores.clone()); }
@@ -418,7 +418,7 @@ async fn run_command(args: RunArgs) -> Result<i32> {
     if let Some(n) = pb.max_open_files { builder = builder.max_open_files(n); }
     for p in &pb.fs_denied { builder = builder.fs_deny(p); }
     if let Some(ref path) = pb.chroot { builder = builder.chroot(path); }
-    if let Some(id) = pb.uid { builder = builder.uid(id); }
+    if let Some(user) = pb.user { builder = builder.user(user.uid, user.gid); }
     if let Some(ref path) = pb.workdir { builder = builder.workdir(path); }
     if let Some(ref path) = pb.cwd { builder = builder.cwd(path); }
     if let Some(ref path) = pb.fs_storage { builder = builder.fs_storage(path); }
@@ -677,7 +677,7 @@ fn validate_no_supervisor(args: &RunArgs) -> Result<()> {
     if args.name.is_some() { bad.push("--name"); }
     if pb.chroot.is_some() { bad.push("--chroot"); }
     if args.image.is_some() { bad.push("--image"); }
-    if pb.uid.is_some() { bad.push("--uid"); }
+    if pb.user.is_some() { bad.push("--user"); }
     if pb.workdir.is_some() { bad.push("--workdir"); }
     if pb.cwd.is_some() { bad.push("--cwd"); }
     if pb.fs_storage.is_some() { bad.push("--fs-storage"); }
@@ -748,7 +748,7 @@ fn validate_no_supervisor_profile(profile: &Sandbox, source: &str) -> Result<()>
     if profile.workdir.is_some() { bad.push("[config].workdir"); }
     if profile.fs_storage.is_some() { bad.push("[config].fs_storage"); }
     if profile.cwd.is_some() { bad.push("[program].cwd"); }
-    if profile.uid.is_some() { bad.push("[program].uid"); }
+    if profile.user.is_some() { bad.push("[program].uid"); }
     if profile.chroot.is_some() { bad.push("[filesystem].chroot"); }
     if !profile.fs_mount.is_empty() { bad.push("[filesystem].mount"); }
     if profile.on_exit != BranchAction::Commit { bad.push("[filesystem].on_exit"); }

--- a/crates/sandlock-cli/tests/cli_test.rs
+++ b/crates/sandlock-cli/tests/cli_test.rs
@@ -281,18 +281,18 @@ fn test_cow_commit_runs_on_cli_exit() {
     assert_eq!(contents.trim(), "committed");
 }
 
-/// Regression: `--uid N` maps the sandbox to UID `N` via an unprivileged
+/// Regression: `--user N:N` maps the sandbox to UID `N` via an unprivileged
 /// user namespace, even when the host UID is non-zero. This is the only
 /// remaining `CLONE_NEWUSER` site after the overlayfs backend removal;
 /// the test guards against accidentally tearing it out.
 #[test]
 fn test_uid_mapping_fakes_root() {
-    // `id -u` reports the in-namespace UID. Passing --uid 0 should make
+    // `id -u` reports the in-namespace UID. Passing --user 0:0 should make
     // the child see UID 0 (fake root) regardless of the host UID.
     let output = sandlock_bin()
         .args([
             "run",
-            "--uid", "0",
+            "--user", "0:0",
             "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "-r", "/etc",
             "--", "id", "-u",
         ])
@@ -300,7 +300,7 @@ fn test_uid_mapping_fakes_root() {
         .expect("failed to run sandlock");
     assert!(
         output.status.success(),
-        "sandlock --uid 0 failed: stderr={}",
+        "sandlock --user 0:0 failed: stderr={}",
         String::from_utf8_lossy(&output.stderr),
     );
     assert_eq!(
@@ -313,11 +313,11 @@ fn test_uid_mapping_fakes_root() {
 
 #[test]
 fn test_uid_mapping_arbitrary_uid() {
-    // Arbitrary --uid value should also map cleanly (not just 0).
+    // Arbitrary --user value should also map cleanly (not just 0).
     let output = sandlock_bin()
         .args([
             "run",
-            "--uid", "1234",
+            "--user", "1234:1234",
             "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "-r", "/etc",
             "--", "id", "-u",
         ])
@@ -325,7 +325,7 @@ fn test_uid_mapping_arbitrary_uid() {
         .expect("failed to run sandlock");
     assert!(
         output.status.success(),
-        "sandlock --uid 1234 failed: stderr={}",
+        "sandlock --user 1234:1234 failed: stderr={}",
         String::from_utf8_lossy(&output.stderr),
     );
     assert_eq!(

--- a/crates/sandlock-core/src/context.rs
+++ b/crates/sandlock-core/src/context.rs
@@ -330,11 +330,18 @@ pub(crate) fn confine_child(args: ChildSpawnArgs<'_>) -> ! {
     let real_gid = unsafe { libc::getgid() };
 
     // 5b. User namespace for --user (run-as uid/gid) mapping.
+    //
+    // Skip entirely when the requested identity already matches the current
+    // uid/gid: there's no point unsharing a user namespace to map an identity
+    // the process already has, and skipping avoids imposing an
+    // unprivileged-userns requirement on callers that don't need a remap.
     if let Some(run_as) = sandbox.user {
-        if unsafe { libc::unshare(libc::CLONE_NEWUSER) } != 0 {
-            fail!("unshare(CLONE_NEWUSER)");
+        if run_as.uid != real_uid || run_as.gid != real_gid {
+            if unsafe { libc::unshare(libc::CLONE_NEWUSER) } != 0 {
+                fail!("unshare(CLONE_NEWUSER)");
+            }
+            write_id_maps(real_uid, real_gid, run_as.uid, run_as.gid);
         }
-        write_id_maps(real_uid, real_gid, run_as.uid, run_as.gid);
     }
 
     // 6. Optional: change working directory

--- a/crates/sandlock-core/src/context.rs
+++ b/crates/sandlock-core/src/context.rs
@@ -329,12 +329,12 @@ pub(crate) fn confine_child(args: ChildSpawnArgs<'_>) -> ! {
     let real_uid = unsafe { libc::getuid() };
     let real_gid = unsafe { libc::getgid() };
 
-    // 5b. User namespace for --uid mapping.
-    if let Some(target_uid) = sandbox.uid {
+    // 5b. User namespace for --user (run-as uid/gid) mapping.
+    if let Some(run_as) = sandbox.user {
         if unsafe { libc::unshare(libc::CLONE_NEWUSER) } != 0 {
             fail!("unshare(CLONE_NEWUSER)");
         }
-        write_id_maps(real_uid, real_gid, target_uid, target_uid);
+        write_id_maps(real_uid, real_gid, run_as.uid, run_as.gid);
     }
 
     // 6. Optional: change working directory

--- a/crates/sandlock-core/src/profile.rs
+++ b/crates/sandlock-core/src/profile.rs
@@ -57,6 +57,7 @@ pub struct ProgramSection {
     pub env: HashMap<String, String>,
     pub cwd: Option<PathBuf>,
     pub uid: Option<u32>,
+    pub gid: Option<u32>,
     pub clean_env: bool,
     pub no_coredump: bool,
     pub no_huge_pages: bool,
@@ -162,7 +163,13 @@ pub fn parse_input(input: ProfileInput) -> Result<(Sandbox, ProgramSpec), Sandlo
     // [program] — process knobs go to Sandbox; exec/args go to ProgramSpec.
     for (k, v) in input.program.env.iter() { b = b.env_var(k, v); }
     if let Some(c) = input.program.cwd             { b = b.cwd(c); }
-    if let Some(u) = input.program.uid             { b = b.uid(u); }
+    match (input.program.uid, input.program.gid) {
+        (Some(u), Some(g)) => b = b.user(u, g),
+        (None, None) => {}
+        _ => return Err(SandlockError::Sandbox(crate::error::SandboxError::Invalid(
+            "program.uid and program.gid must both be set".into(),
+        ))),
+    }
     if input.program.clean_env                     { b = b.clean_env(true); }
     if input.program.no_coredump                   { b = b.no_coredump(true); }
     if input.program.no_huge_pages                 { b = b.no_huge_pages(true); }
@@ -440,6 +447,7 @@ mod tests {
             args      = ["-h", "cache.internal", "-p", "6379"]
             cwd       = "/var/lib/redis"
             uid       = 1000
+            gid       = 1000
             clean_env = true
             no_coredump = true
 

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -66,6 +66,33 @@ impl ByteSize {
     }
 }
 
+/// Identity to run the sandboxed process as.
+///
+/// Applied via a single-entry user-namespace map (`unshare(CLONE_NEWUSER)` +
+/// `uid_map`/`gid_map`), so it requires no host privilege.  Because an
+/// unprivileged user namespace can only map a single id and must deny
+/// `setgroups`, exactly one uid and one gid are representable (no supplementary
+/// groups, no id ranges).
+///
+/// Parsed from `UID:GID`; both ids are required (no implicit default).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunAs {
+    pub uid: u32,
+    pub gid: u32,
+}
+
+impl std::str::FromStr for RunAs {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (u, g) = s
+            .split_once(':')
+            .ok_or_else(|| format!("expected UID:GID, got {:?}", s))?;
+        let uid = u.trim().parse::<u32>().map_err(|_| format!("invalid uid {:?}", u))?;
+        let gid = g.trim().parse::<u32>().map_err(|_| format!("invalid gid {:?}", g))?;
+        Ok(RunAs { uid, gid })
+    }
+}
+
 /// Confinement for confining the current process in place.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Confinement {
@@ -147,7 +174,7 @@ impl TryFrom<&Sandbox> for Confinement {
         if sandbox.cpu_cores.is_some() { unsupported.push("cpu_cores"); }
         if sandbox.num_cpus.is_some() { unsupported.push("num_cpus"); }
         if sandbox.port_remap { unsupported.push("port_remap"); }
-        if sandbox.uid.is_some() { unsupported.push("uid"); }
+        if sandbox.user.is_some() { unsupported.push("user"); }
         if sandbox.policy_fn.is_some() { unsupported.push("policy_fn"); }
 
         if !unsupported.is_empty() {
@@ -328,8 +355,8 @@ pub struct Sandbox {
     /// allows one `SECCOMP_FILTER_FLAG_NEW_LISTENER` per task.
     pub no_supervisor: bool,
 
-    // User namespace
-    pub uid: Option<u32>,
+    // User-namespace identity (run-as uid/gid)
+    pub user: Option<RunAs>,
 
     // Dynamic policy callback
     #[serde(skip)]
@@ -424,7 +451,7 @@ impl Clone for Sandbox {
             num_cpus: self.num_cpus,
             port_remap: self.port_remap,
             no_supervisor: self.no_supervisor,
-            uid: self.uid,
+            user: self.user,
             policy_fn: self.policy_fn.clone(),
             name: self.name.clone(),
             // init_fn (FnOnce) cannot be cloned — the clone gets None.

--- a/crates/sandlock-core/src/sandbox/builder.rs
+++ b/crates/sandlock-core/src/sandbox/builder.rs
@@ -561,6 +561,11 @@ impl SandboxBuilder {
 
     /// Run the sandboxed process as `uid`/`gid` via a single-entry user
     /// namespace map (no host privilege required).
+    ///
+    /// If `uid`/`gid` already match the process's real uid/gid at launch, no
+    /// user namespace is created — the process already has that identity, so
+    /// the request is satisfied without one (and without requiring unprivileged
+    /// user namespaces to be available on the host).
     pub fn user(mut self, uid: u32, gid: u32) -> Self {
         self.user = Some(RunAs { uid, gid });
         self

--- a/crates/sandlock-core/src/sandbox/builder.rs
+++ b/crates/sandlock-core/src/sandbox/builder.rs
@@ -169,8 +169,8 @@ pub struct SandboxBuilder {
     #[cfg_attr(feature = "cli", clap(skip))]
     pub no_supervisor: bool,
 
-    #[cfg_attr(feature = "cli", arg(long = "uid"))]
-    pub uid: Option<u32>,
+    #[cfg_attr(feature = "cli", arg(long = "user", value_name = "UID:GID"))]
+    pub user: Option<RunAs>,
 
     /// Per-protection state overrides. Defaults to `strict_all`: every
     /// protection enforced, matching the historical `MIN_ABI = 6` floor.
@@ -255,7 +255,7 @@ impl Clone for SandboxBuilder {
             num_cpus: self.num_cpus,
             port_remap: self.port_remap,
             no_supervisor: self.no_supervisor,
-            uid: self.uid,
+            user: self.user,
             protection_policy: self.protection_policy.clone(),
             policy_fn: self.policy_fn.clone(),
             name: self.name.clone(),
@@ -559,8 +559,10 @@ impl SandboxBuilder {
         self
     }
 
-    pub fn uid(mut self, id: u32) -> Self {
-        self.uid = Some(id);
+    /// Run the sandboxed process as `uid`/`gid` via a single-entry user
+    /// namespace map (no host privilege required).
+    pub fn user(mut self, uid: u32, gid: u32) -> Self {
+        self.user = Some(RunAs { uid, gid });
         self
     }
 
@@ -753,7 +755,7 @@ impl SandboxBuilder {
             num_cpus: self.num_cpus,
             port_remap: self.port_remap,
             no_supervisor: self.no_supervisor,
-            uid: self.uid,
+            user: self.user,
             policy_fn: self.policy_fn,
             name: self.name,
             init_fn: self.init_fn,

--- a/crates/sandlock-core/src/sandbox/tests.rs
+++ b/crates/sandlock-core/src/sandbox/tests.rs
@@ -1,5 +1,26 @@
 use super::*;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+#[test]
+fn run_as_parses_uid_and_gid() {
+    let r = RunAs::from_str("1000:2000").unwrap();
+    assert_eq!(r.uid, 1000);
+    assert_eq!(r.gid, 2000);
+}
+
+#[test]
+fn run_as_requires_both_ids() {
+    // A bare UID (no `:GID`) is rejected — gid is not defaulted.
+    assert!(RunAs::from_str("1000").is_err());
+}
+
+#[test]
+fn run_as_rejects_garbage() {
+    assert!(RunAs::from_str("root").is_err());
+    assert!(RunAs::from_str("1000:abc").is_err());
+    assert!(RunAs::from_str("").is_err());
+}
 
 #[test]
 fn resolve_sandbox_path_plain() {

--- a/crates/sandlock-core/tests/integration.rs
+++ b/crates/sandlock-core/tests/integration.rs
@@ -43,8 +43,8 @@ mod test_policy_fn;
 #[path = "integration/test_fork.rs"]
 mod test_fork;
 
-#[path = "integration/test_privileged.rs"]
-mod test_privileged;
+#[path = "integration/test_user_mapping.rs"]
+mod test_user_mapping;
 
 #[path = "integration/test_chroot.rs"]
 mod test_chroot;

--- a/crates/sandlock-core/tests/integration/test_policy.rs
+++ b/crates/sandlock-core/tests/integration/test_policy.rs
@@ -9,7 +9,7 @@ fn test_default_policy() {
     // for those protocols in `net_allow`, which is what the BPF filter
     // gates on now (no separate booleans).
     assert!(policy.net_allow.is_empty());
-    assert!(policy.uid.is_none());
+    assert!(policy.user.is_none());
     assert!(policy.fs_writable.is_empty());
     assert!(policy.fs_readable.is_empty());
 }

--- a/crates/sandlock-core/tests/integration/test_user_mapping.rs
+++ b/crates/sandlock-core/tests/integration/test_user_mapping.rs
@@ -143,3 +143,31 @@ async fn test_uid_custom() {
     let stdout = String::from_utf8_lossy(result.stdout.as_deref().unwrap_or_default());
     assert_eq!(stdout.trim(), "1000", "Expected uid 1000, got: {:?}", stdout.trim());
 }
+
+/// Requesting the identity the process already has must NOT create a user
+/// namespace — so it works even where unprivileged userns is unavailable.
+/// (No `userns_available()` guard on purpose: this exercises the skip path.)
+#[tokio::test]
+async fn test_user_matching_runtime_skips_userns() {
+    let uid = unsafe { libc::getuid() };
+    let gid = unsafe { libc::getgid() };
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr")
+        .fs_read("/lib")
+        .fs_read_if_exists("/lib64")
+        .fs_read("/bin")
+        .fs_read("/etc")
+        .user(uid, gid)
+        .build()
+        .unwrap();
+
+    let result = policy.clone().with_name("test").run(&["echo", "hi"]).await.unwrap();
+    assert!(
+        result.success(),
+        "matching-identity user() should skip the userns and run cleanly: {:?}",
+        result.exit_status
+    );
+    let stdout = String::from_utf8_lossy(result.stdout.as_deref().unwrap_or_default());
+    assert_eq!(stdout.trim(), "hi");
+}

--- a/crates/sandlock-core/tests/integration/test_user_mapping.rs
+++ b/crates/sandlock-core/tests/integration/test_user_mapping.rs
@@ -28,7 +28,7 @@ fn userns_available() -> bool {
     libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0
 }
 
-/// Test that --uid 0 makes the child appear as uid 0.
+/// Test that --user 0:0 makes the child appear as uid 0.
 #[tokio::test]
 async fn test_uid_zero() {
     if !userns_available() {
@@ -43,7 +43,7 @@ async fn test_uid_zero() {
         .fs_read("/bin")
         .fs_read("/etc")
         .fs_read("/proc")
-        .uid(0)
+        .user(0, 0)
         .build()
         .unwrap();
 
@@ -53,7 +53,7 @@ async fn test_uid_zero() {
     assert_eq!(stdout.trim(), "0", "Expected uid 0, got: {:?}", stdout.trim());
 }
 
-/// Test that --uid 0 makes the child appear as gid 0.
+/// Test that --user 0:0 makes the child appear as gid 0.
 #[tokio::test]
 async fn test_uid_zero_gid_zero() {
     if !userns_available() {
@@ -68,7 +68,7 @@ async fn test_uid_zero_gid_zero() {
         .fs_read("/bin")
         .fs_read("/etc")
         .fs_read("/proc")
-        .uid(0)
+        .user(0, 0)
         .build()
         .unwrap();
 
@@ -78,7 +78,7 @@ async fn test_uid_zero_gid_zero() {
     assert_eq!(stdout.trim(), "0", "Expected gid 0, got: {:?}", stdout.trim());
 }
 
-/// Test that without --uid, uid is NOT 0 (assuming tests don't run as root).
+/// Test that without --user, uid is NOT 0 (assuming tests don't run as root).
 #[tokio::test]
 async fn test_no_uid_keeps_real_uid() {
     let policy = Sandbox::builder()
@@ -96,11 +96,11 @@ async fn test_no_uid_keeps_real_uid() {
     let stdout = String::from_utf8_lossy(result.stdout.as_deref().unwrap_or_default());
     // If running as root already, skip this check
     if unsafe { libc::getuid() } != 0 {
-        assert_ne!(stdout.trim(), "0", "Without --uid, uid should not be 0");
+        assert_ne!(stdout.trim(), "0", "Without --user, uid should not be 0");
     }
 }
 
-/// Test that --uid 0 doesn't break basic command execution.
+/// Test that --user 0:0 doesn't break basic command execution.
 #[tokio::test]
 async fn test_uid_zero_echo() {
     let policy = Sandbox::builder()
@@ -109,7 +109,7 @@ async fn test_uid_zero_echo() {
         .fs_read_if_exists("/lib64")
         .fs_read("/bin")
         .fs_read("/etc")
-        .uid(0)
+        .user(0, 0)
         .build()
         .unwrap();
 
@@ -119,7 +119,7 @@ async fn test_uid_zero_echo() {
     assert_eq!(stdout.trim(), "hello");
 }
 
-/// Test that --uid 1000 maps to the expected UID inside the namespace.
+/// Test that --user 1000:1000 maps to the expected UID inside the namespace.
 #[tokio::test]
 async fn test_uid_custom() {
     if !userns_available() {
@@ -134,7 +134,7 @@ async fn test_uid_custom() {
         .fs_read("/bin")
         .fs_read("/etc")
         .fs_read("/proc")
-        .uid(1000)
+        .user(1000, 1000)
         .build()
         .unwrap();
 

--- a/crates/sandlock-ffi/include/sandlock.h
+++ b/crates/sandlock-ffi/include/sandlock.h
@@ -431,10 +431,15 @@ sandlock_builder_t *sandlock_sandbox_builder_net_deny_bind_port(sandlock_builder
 sandlock_builder_t *sandlock_sandbox_builder_port_remap(sandlock_builder_t *b, bool v);
 
 /**
+ * Run the sandboxed process as `uid`/`gid` via a single-entry user namespace
+ * map (no host privilege required).
+ *
  * # Safety
  * `b` must be a valid builder pointer.
  */
-sandlock_builder_t *sandlock_sandbox_builder_uid(sandlock_builder_t *b, uint32_t id);
+sandlock_builder_t *sandlock_sandbox_builder_user(sandlock_builder_t *b,
+                                                  uint32_t uid,
+                                                  uint32_t gid);
 
 /**
  * # Safety

--- a/crates/sandlock-ffi/src/lib.rs
+++ b/crates/sandlock-ffi/src/lib.rs
@@ -435,18 +435,22 @@ pub unsafe extern "C" fn sandlock_sandbox_builder_port_remap(
 // Sandlock does not expose raw ICMP — SOCK_RAW is unconditionally
 // denied at the seccomp layer.
 
+/// Run the sandboxed process as `uid`/`gid` via a single-entry user namespace
+/// map (no host privilege required).
+///
 /// # Safety
 /// `b` must be a valid builder pointer.
 #[no_mangle]
-pub unsafe extern "C" fn sandlock_sandbox_builder_uid(
+pub unsafe extern "C" fn sandlock_sandbox_builder_user(
     b: *mut SandboxBuilder,
-    id: u32,
+    uid: u32,
+    gid: u32,
 ) -> *mut SandboxBuilder {
     if b.is_null() {
         return b;
     }
     let builder = *Box::from_raw(b);
-    Box::into_raw(Box::new(builder.uid(id)))
+    Box::into_raw(Box::new(builder.user(uid, gid)))
 }
 
 // ----------------------------------------------------------------

--- a/crates/sandlock-oci/src/policy.rs
+++ b/crates/sandlock-oci/src/policy.rs
@@ -9,7 +9,7 @@
 
 use anyhow::Result;
 use oci_spec::runtime::Spec;
-use sandlock_core::sandbox::{ByteSize, Sandbox, SandboxBuilder};
+use sandlock_core::sandbox::{ByteSize, RunAs, Sandbox, SandboxBuilder};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -52,6 +52,11 @@ pub struct OciPolicy {
     /// and removed with the sandbox state dir on `delete`.
     #[serde(default)]
     pub scratch_dirs: Vec<PathBuf>,
+
+    /// Run-as identity from OCI `process.user` (uid/gid). Passed straight to
+    /// `builder.user(...)`; core decides whether a user namespace is actually
+    /// needed (it self-skips when the identity already matches the runtime).
+    pub run_user: Option<RunAs>,
 }
 
 impl OciPolicy {
@@ -145,6 +150,12 @@ impl OciPolicy {
                 }
             });
 
+        // OCI process.user → run-as identity (uid/gid, both required by the spec).
+        let run_user = spec.process().as_ref().map(|p| {
+            let u = p.user();
+            RunAs { uid: u.uid(), gid: u.gid() }
+        });
+
         Ok(OciPolicy {
             rootfs,
             fs_read,
@@ -156,6 +167,7 @@ impl OciPolicy {
             max_processes,
             max_cpu,
             scratch_dirs,
+            run_user,
         })
     }
 
@@ -202,6 +214,13 @@ impl OciPolicy {
         }
         if let Some(cpu) = self.max_cpu {
             builder = builder.max_cpu(cpu);
+        }
+
+        // OCI process.user: hand the requested identity to core unconditionally.
+        // Core engages a user namespace only when it differs from the runtime's
+        // own uid/gid, so we don't reimplement that decision here.
+        if let Some(ru) = self.run_user {
+            builder = builder.user(ru.uid, ru.gid);
         }
 
         builder.build_unchecked().map_err(Into::into)
@@ -507,5 +526,25 @@ mod tests {
         // Note: no rootfs dir created under the bundle.
         let err = OciPolicy::from_spec(&spec, bundle.path(), "test").unwrap_err();
         assert!(err.to_string().contains("does not exist"));
+    }
+
+    #[test]
+    fn process_user_populates_run_as() {
+        let dir = tempdir().unwrap();
+        let bundle = dir.path();
+        fs::create_dir_all(bundle.join("rootfs")).unwrap();
+
+        let json = serde_json::json!({
+            "ociVersion": "1.0.2",
+            "root": { "path": "rootfs", "readonly": false },
+            "process": { "user": { "uid": 1000, "gid": 2000 }, "cwd": "/", "args": ["sh"] },
+        });
+        let spec: Spec = serde_json::from_value(json).unwrap();
+        let policy = OciPolicy::from_spec(&spec, bundle, "test").unwrap();
+        // process.user flows into run_user; the userns skip decision is core's.
+        assert_eq!(policy.run_user, Some(RunAs { uid: 1000, gid: 2000 }));
+
+        let sandbox = policy.to_sandbox().unwrap();
+        assert_eq!(sandbox.user, Some(RunAs { uid: 1000, gid: 2000 }));
     }
 }

--- a/docs/sandbox-reference.md
+++ b/docs/sandbox-reference.md
@@ -30,7 +30,7 @@ sandbox = Sandbox(
     deterministic_dirs=False, no_randomize_memory=False,
 
     # [program]  (process knobs only; exec/args are arguments to .run/.cmd)
-    env={}, cwd=None, uid=None,
+    env={}, cwd=None, uid=None, gid=None,
     clean_env=False, no_coredump=False, no_huge_pages=False,
 
     # [filesystem]
@@ -83,6 +83,7 @@ args          = ["-j4"]
 env           = { CC = "gcc" }
 cwd           = "/work"
 uid           = 0
+gid           = 0
 clean_env     = true
 no_coredump   = true
 no_huge_pages = true
@@ -171,7 +172,8 @@ fields on `Sandbox`.
 | --------------- | --------------- | ------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `env`           | `env`           | `Mapping[str, str]` | `{}`    | Variables to set or override in the child. Applied after `clean_env`.                                                                                |
 | `cwd`           | `cwd`           | `str \| None`       | `None`  | Child working directory (`chdir` target). Independent of `workdir`.                                                                                  |
-| `uid`           | `uid`           | `int \| None`       | `None`  | UID to map the child to inside a user namespace (e.g. `0` for fake root). The child retains no host privileges regardless of the mapped UID. Requires user namespaces to be available. |
+| `uid`           | `uid`           | `int \| None`       | `None`  | UID to map the child to inside a user namespace (e.g. `0` for fake root). Must be set together with `gid` (both or neither). The child retains no host privileges regardless of the mapped UID. Requires user namespaces to be available. |
+| `gid`           | `gid`           | `int \| None`       | `None`  | GID to map the child to inside the user namespace. Must be set together with `uid`. An unprivileged user namespace maps a single id, so supplementary groups are not available. |
 | `clean_env`     | `clean_env`     | `bool`              | `False` | When `True`, start with a minimal environment (`PATH`, `HOME`, `USER`, `TERM`, `LANG`) instead of inheriting the parent's.                            |
 | `no_coredump`   | `no_coredump`   | `bool`              | `False` | Apply `prctl(PR_SET_DUMPABLE, 0)`. Disables core dumps and restricts `/proc/<pid>` access from other processes. Breaks `gdb`, `strace`, and `perf`.   |
 | `no_huge_pages` | `no_huge_pages` | `bool`              | `False` | Disable transparent huge pages via `prctl(PR_SET_THP_DISABLE)`.                                                                                      |

--- a/go/README.md
+++ b/go/README.md
@@ -96,7 +96,7 @@ fresh native policy on each call.
 | Syscalls | `ExtraAllowSyscalls`, `ExtraDenySyscalls` |
 | Determinism | `RandomSeed`, `TimeStart`, `NoRandomizeMemory`, `NoHugePages`, `DeterministicDirs` |
 | Environment | `CleanEnv`, `Env` |
-| Misc | `UID`, `NoCoredump`, `Name` |
+| Misc | `UID`, `GID`, `NoCoredump`, `Name` |
 | COW branch | `FSStorage`, `OnExit`, `OnError` |
 | Dynamic policy | `PolicyFn` |
 

--- a/go/sandbox.go
+++ b/go/sandbox.go
@@ -230,6 +230,7 @@ type Sandbox struct {
 
 	// Misc.
 	UID        *int // map to this UID inside a user namespace; nil = unset
+	GID        *int // map to this GID inside the user namespace; must be set together with UID
 	NoCoredump bool // disable core dumps and restrict /proc/pid access
 
 	// Copy-on-write branch handling.

--- a/go/sandlock_linux.go
+++ b/go/sandlock_linux.go
@@ -353,8 +353,12 @@ func (s *Sandbox) buildPolicy() (*C.sandlock_sandbox_t, error) {
 	}
 
 	// Misc.
-	if s.UID != nil {
-		b = C.sandlock_sandbox_builder_uid(b, C.uint32_t(*s.UID))
+	if s.UID != nil || s.GID != nil {
+		if s.UID == nil || s.GID == nil {
+			freeBuilderViaBuild(b)
+			return nil, fmt.Errorf("UID and GID must both be set (or both unset)")
+		}
+		b = C.sandlock_sandbox_builder_user(b, C.uint32_t(*s.UID), C.uint32_t(*s.GID))
 	}
 	if s.NoCoredump {
 		b = C.sandlock_sandbox_builder_no_coredump(b, cbool(true))

--- a/python/README.md
+++ b/python/README.md
@@ -224,7 +224,8 @@ Sandlock always applies its default syscall blocklist.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `uid` | `int \| None` | `None` | Map to given UID inside a user namespace (e.g. `0` for fake root) |
+| `uid` | `int \| None` | `None` | Map to given UID inside a user namespace (e.g. `0` for fake root). Set together with `gid` |
+| `gid` | `int \| None` | `None` | Map to given GID inside the user namespace. Must be set together with `uid` (both or neither) |
 | `no_coredump` | `bool` | `False` | Disable core dumps |
 
 #### COW filesystem isolation

--- a/python/src/sandlock/_sdk.py
+++ b/python/src/sandlock/_sdk.py
@@ -99,7 +99,7 @@ _b_http_ca = _builder_fn("sandlock_sandbox_builder_http_ca", ctypes.c_char_p)
 _b_http_key = _builder_fn("sandlock_sandbox_builder_http_key", ctypes.c_char_p)
 _b_http_inject_ca = _builder_fn("sandlock_sandbox_builder_http_inject_ca", ctypes.c_char_p)
 _b_http_ca_out = _builder_fn("sandlock_sandbox_builder_http_ca_out", ctypes.c_char_p)
-_b_uid = _builder_fn("sandlock_sandbox_builder_uid", ctypes.c_uint32)
+_b_user = _builder_fn("sandlock_sandbox_builder_user", ctypes.c_uint32, ctypes.c_uint32)
 _b_random_seed = _builder_fn("sandlock_sandbox_builder_random_seed", ctypes.c_uint64)
 _b_clean_env = _builder_fn("sandlock_sandbox_builder_clean_env", ctypes.c_bool)
 _b_env_var = _builder_fn("sandlock_sandbox_builder_env_var", ctypes.c_char_p, ctypes.c_char_p)
@@ -1073,8 +1073,10 @@ class _NativePolicy:
         if policy.port_remap:
             b = _b_port_remap(b, True)
 
-        if policy.uid is not None:
-            b = _b_uid(b, policy.uid)
+        if policy.uid is not None or policy.gid is not None:
+            if policy.uid is None or policy.gid is None:
+                raise ValueError("uid and gid must both be set (or both unset)")
+            b = _b_user(b, policy.uid, policy.gid)
 
         if policy.random_seed is not None:
             b = _b_random_seed(b, policy.random_seed)

--- a/python/src/sandlock/sandbox.py
+++ b/python/src/sandlock/sandbox.py
@@ -327,6 +327,11 @@ class Sandbox:
     The child has no real host privileges regardless of the mapped UID.
     Only effective when user namespaces are available."""
 
+    gid: int | None = None
+    """Map to the given GID inside the user namespace.  Must be set together
+    with ``uid`` (both or neither).  An unprivileged user namespace maps a
+    single id, so supplementary groups are not available."""
+
     # Seccomp user notification (filesystem virtualization)
     notif_policy: NotifPolicy | None = None
     """If set, enables a seccomp user notification supervisor that


### PR DESCRIPTION
Wires OCI `process.user` (uid/gid) through to the sandbox, and along the way
makes sandlock-core's run-as identity gid-capable (the old `--uid` forced
`gid = uid`, which is wrong for OCI where uid and gid are independent).

Branched off `main`, so it does not include the PR #100 follow-ups; both
touch `crates/sandlock-oci/src/policy.rs`, so a small merge conflict is
expected when the two land.

## sandlock-core

- Replace the single `--uid N` (which mapped one id and forced `gid = uid`)
  with a gid-capable run-as identity:
  - `RunAs { uid, gid }`, `builder.user(uid, gid)`, and the CLI flag
    `--user UID:GID` (both ids required, no implicit default).
  - `confine_child` maps `gid` independently (fixes the old `gid = uid` bug).
- Skip the user namespace entirely when the requested uid/gid already match
  the runtime's: there's no point unsharing to map an identity already held,
  and it avoids imposing an unprivileged-userns requirement on callers that
  don't need a remap.
- Mechanism unchanged in spirit: a single-entry, unprivileged user namespace
  (`unshare(CLONE_NEWUSER)` + `uid_map`/`gid_map`), no host privilege.
- Propagated through the FFI (`sandlock_sandbox_builder_user(b, uid, gid)`,
  header regenerated with cbindgen) and the Go (`GID`) and Python (`gid`) SDKs;
  the profile (`[program]`) now requires `uid` and `gid` together; docs updated.

## sandlock-oci

- `OciPolicy` carries `run_user` from `process.user`; `to_sandbox` calls
  `builder.user(uid, gid)` unconditionally and lets core decide whether a
  user namespace is actually needed.

## Scope and limitations

- Single-id mapping only: `additional_gids` and `umask` from `process.user`
  are not applied (an unprivileged user namespace maps one id and must deny
  `setgroups`). Range mapping (`newuidmap`/subuid) is intentionally out of
  scope; it is not needed for the common case (most images run as root, and
  in rootless containerd the runtime is already ns-root in rootlesskit's range
  userns, so the requested `0:0` matches and no extra userns is created).

## Testing

- `cargo build --workspace`; core lib 398 tests pass; sandlock-oci lib 27 pass.
- New tests: `RunAs` parsing requires `UID:GID`; the userns is skipped when the
  identity matches the runtime (exercised without unprivileged userns); OCI
  `process.user` populates `run_user` and reaches `builder.user`.
- Not verified end-to-end under a real (rootless) containerd; the matching/skip
  path is covered, the differing-uid userns path is correct by construction but
  unverified in this environment (unprivileged `uid_map` writes are blocked here).
