### PR TITLE
oci: correct sub-core CPU quota mapping and add cpuset to cpu_cores affinity

### DIFF
--- a/crates/sandlock-oci/src/policy.rs
+++ b/crates/sandlock-oci/src/policy.rs
@@ -136,18 +136,33 @@ impl OciPolicy {
                 if limit > 0 { Some(limit as u32) } else { None }
             });
 
+        // OCI `cpu.quota`/`cpu.period` express a CPU allowance in *cores*
+        // (quota/period can exceed 1.0 for a multi-core cap).  sandlock-core's
+        // `max_cpu` is a coarse global SIGSTOP/SIGCONT wall-clock duty cycle,
+        // not a bandwidth controller: it gates how much wall-clock time the
+        // whole process group may run, as a 1-100 value where 100 means "no
+        // limit".  A >= 1-core allowance can't be expressed as such a value, so
+        // map only a strict sub-core request (quota < period) here; a multi-core
+        // cap belongs on affinity (`cpu_cores`), not on this throttle.  Don't
+        // fake it by clamping to 100, which core reads as unlimited anyway.
         let max_cpu = spec.linux().as_ref()
             .and_then(|l| l.resources().clone())
             .and_then(|res| res.cpu().clone())
             .and_then(|cpu| {
                 let quota = cpu.quota()?;
                 let period = cpu.period()?;
-                if quota > 0 && period > 0 {
-                    let pct = ((quota as f64 / period as f64) * 100.0).min(100.0) as u8;
-                    if pct > 0 { Some(pct) } else { None }
-                } else {
-                    None
+                if quota <= 0 || period == 0 {
+                    return None;
                 }
+                let ratio = quota as f64 / period as f64;
+                if ratio >= 1.0 {
+                    // Multi-core / full-core caps are not enforceable by the
+                    // single-core throttle; don't pretend by emitting 100.
+                    return None;
+                }
+                // Floor to 1% so a tiny but non-zero request isn't truncated to
+                // 0 (which would drop to None == "no limit").
+                Some(((ratio * 100.0) as u8).max(1))
             });
 
         // OCI process.user → run-as identity (uid/gid, both required by the spec).
@@ -399,6 +414,60 @@ mod tests {
         assert!(policy.max_memory.is_none());
         assert!(policy.max_processes.is_none());
         assert!(policy.max_cpu.is_none());
+    }
+
+    /// Build a spec carrying `linux.resources.cpu.{quota,period}`.
+    fn spec_with_cpu(quota: i64, period: u64) -> Spec {
+        let json = serde_json::json!({
+            "ociVersion": "1.0.2",
+            "root": { "path": "rootfs", "readonly": false },
+            "process": { "user": { "uid": 0, "gid": 0 }, "cwd": "/", "args": ["sh"] },
+            "linux": { "resources": { "cpu": { "quota": quota, "period": period } } }
+        });
+        serde_json::from_value(json).unwrap()
+    }
+
+    #[test]
+    fn cpu_sub_core_maps_to_percentage() {
+        let dir = tempdir().unwrap();
+        let bundle = dir.path();
+        fs::create_dir_all(bundle.join("rootfs")).unwrap();
+        // Half a core → 50%.
+        let policy = OciPolicy::from_spec(&spec_with_cpu(50_000, 100_000), bundle, "t").unwrap();
+        assert_eq!(policy.max_cpu, Some(50));
+    }
+
+    #[test]
+    fn cpu_one_full_core_not_mapped_to_max_cpu() {
+        let dir = tempdir().unwrap();
+        let bundle = dir.path();
+        fs::create_dir_all(bundle.join("rootfs")).unwrap();
+        // Exactly one core is not a sub-core request; max_cpu's 1-100 value
+        // can't express it (100 reads as "no limit"), so it doesn't belong on
+        // this throttle. None here; a real cap would go on affinity.
+        let policy = OciPolicy::from_spec(&spec_with_cpu(100_000, 100_000), bundle, "t").unwrap();
+        assert_eq!(policy.max_cpu, None);
+    }
+
+    #[test]
+    fn cpu_multi_core_request_not_clamped_to_100() {
+        let dir = tempdir().unwrap();
+        let bundle = dir.path();
+        fs::create_dir_all(bundle.join("rootfs")).unwrap();
+        // A 2-core (200%) allowance must NOT silently collapse to max_cpu=100;
+        // it can't be expressed as a 1-100 value, so it stays off this knob.
+        let policy = OciPolicy::from_spec(&spec_with_cpu(200_000, 100_000), bundle, "t").unwrap();
+        assert_eq!(policy.max_cpu, None);
+    }
+
+    #[test]
+    fn cpu_tiny_fraction_floors_to_one() {
+        let dir = tempdir().unwrap();
+        let bundle = dir.path();
+        fs::create_dir_all(bundle.join("rootfs")).unwrap();
+        // 0.5% would truncate to 0; floor to 1 so the limit isn't dropped.
+        let policy = OciPolicy::from_spec(&spec_with_cpu(500, 100_000), bundle, "t").unwrap();
+        assert_eq!(policy.max_cpu, Some(1));
     }
 
     #[test]

--- a/crates/sandlock-oci/src/policy.rs
+++ b/crates/sandlock-oci/src/policy.rs
@@ -48,6 +48,12 @@ pub struct OciPolicy {
     /// CPU percentage limit, 1-100 (optional).
     pub max_cpu: Option<u8>,
 
+    /// CPU affinity from OCI `cpu.cpus` (cpuset): the exact cores the sandbox
+    /// may run on, applied via sched_setaffinity in core.  An empty/malformed
+    /// cpuset maps to None (no pinning) rather than a partial set.
+    #[serde(default)]
+    pub cpu_cores: Option<Vec<u32>>,
+
     /// Host directories backing emulated tmpfs mounts.  Created before launch
     /// and removed with the sandbox state dir on `delete`.
     #[serde(default)]
@@ -165,6 +171,16 @@ impl OciPolicy {
                 Some(((ratio * 100.0) as u8).max(1))
             });
 
+        // OCI `cpu.cpus` is a cpuset string ("0-3,7") naming the exact cores
+        // the workload may run on.  It maps directly to core's `cpu_cores`
+        // (sched_setaffinity), an exact, non-approximate mapping, so unlike a
+        // multi-core quota it is genuine enforcement.
+        let cpu_cores = spec.linux().as_ref()
+            .and_then(|l| l.resources().clone())
+            .and_then(|res| res.cpu().clone())
+            .and_then(|cpu| cpu.cpus().clone())
+            .and_then(|cpus| parse_cpuset(&cpus));
+
         // OCI process.user → run-as identity (uid/gid, both required by the spec).
         let run_user = spec.process().as_ref().map(|p| {
             let u = p.user();
@@ -181,6 +197,7 @@ impl OciPolicy {
             max_memory,
             max_processes,
             max_cpu,
+            cpu_cores,
             scratch_dirs,
             run_user,
         })
@@ -230,6 +247,9 @@ impl OciPolicy {
         if let Some(cpu) = self.max_cpu {
             builder = builder.max_cpu(cpu);
         }
+        if let Some(ref cores) = self.cpu_cores {
+            builder = builder.cpu_cores(cores.clone());
+        }
 
         // OCI process.user: hand the requested identity to core unconditionally.
         // Core engages a user namespace only when it differs from the runtime's
@@ -239,6 +259,42 @@ impl OciPolicy {
         }
 
         builder.build_unchecked().map_err(Into::into)
+    }
+}
+
+/// Parse an OCI cpuset string into a sorted, de-duplicated list of CPU indices.
+///
+/// Accepts comma-separated indices and inclusive ranges, e.g. `"0-3,5,7-8"` →
+/// `[0,1,2,3,5,7,8]`.  Whitespace around tokens is ignored.  Returns `None` for
+/// an empty cpuset or on any malformed token (bad number, reversed range), so a
+/// broken cpuset drops to "no pinning" rather than applying a partial affinity.
+fn parse_cpuset(s: &str) -> Option<Vec<u32>> {
+    let mut cores = std::collections::BTreeSet::new();
+    for token in s.split(',') {
+        let token = token.trim();
+        if token.is_empty() {
+            continue;
+        }
+        match token.split_once('-') {
+            Some((a, b)) => {
+                let start: u32 = a.trim().parse().ok()?;
+                let end: u32 = b.trim().parse().ok()?;
+                if end < start {
+                    return None;
+                }
+                for c in start..=end {
+                    cores.insert(c);
+                }
+            }
+            None => {
+                cores.insert(token.parse().ok()?);
+            }
+        }
+    }
+    if cores.is_empty() {
+        None
+    } else {
+        Some(cores.into_iter().collect())
     }
 }
 
@@ -468,6 +524,60 @@ mod tests {
         // 0.5% would truncate to 0; floor to 1 so the limit isn't dropped.
         let policy = OciPolicy::from_spec(&spec_with_cpu(500, 100_000), bundle, "t").unwrap();
         assert_eq!(policy.max_cpu, Some(1));
+    }
+
+    /// Build a spec carrying `linux.resources.cpu.cpus` (cpuset).
+    fn spec_with_cpuset(cpus: &str) -> Spec {
+        let json = serde_json::json!({
+            "ociVersion": "1.0.2",
+            "root": { "path": "rootfs", "readonly": false },
+            "process": { "user": { "uid": 0, "gid": 0 }, "cwd": "/", "args": ["sh"] },
+            "linux": { "resources": { "cpu": { "cpus": cpus } } }
+        });
+        serde_json::from_value(json).unwrap()
+    }
+
+    #[test]
+    fn parse_cpuset_indices_and_ranges() {
+        assert_eq!(parse_cpuset("0-3"), Some(vec![0, 1, 2, 3]));
+        assert_eq!(parse_cpuset("0,2,4"), Some(vec![0, 2, 4]));
+        assert_eq!(parse_cpuset("0-3,7"), Some(vec![0, 1, 2, 3, 7]));
+        assert_eq!(parse_cpuset("3-3"), Some(vec![3]));
+        // Whitespace tolerated; overlaps de-duplicated and sorted.
+        assert_eq!(parse_cpuset(" 1 , 0 , 0-1 "), Some(vec![0, 1]));
+    }
+
+    #[test]
+    fn parse_cpuset_rejects_malformed() {
+        assert_eq!(parse_cpuset(""), None);
+        assert_eq!(parse_cpuset("   "), None);
+        assert_eq!(parse_cpuset("x"), None);
+        assert_eq!(parse_cpuset("1-"), None);
+        assert_eq!(parse_cpuset("3-1"), None); // reversed range
+    }
+
+    #[test]
+    fn cpuset_maps_to_cpu_cores() {
+        let dir = tempdir().unwrap();
+        let bundle = dir.path();
+        fs::create_dir_all(bundle.join("rootfs")).unwrap();
+
+        let policy = OciPolicy::from_spec(&spec_with_cpuset("0-3,7"), bundle, "t").unwrap();
+        assert_eq!(policy.cpu_cores, Some(vec![0, 1, 2, 3, 7]));
+
+        // And it reaches the sandbox as a real affinity list.
+        let sandbox = policy.to_sandbox().unwrap();
+        assert_eq!(sandbox.cpu_cores, Some(vec![0, 1, 2, 3, 7]));
+    }
+
+    #[test]
+    fn no_cpuset_yields_no_cpu_cores() {
+        let dir = tempdir().unwrap();
+        let bundle = dir.path();
+        fs::create_dir_all(bundle.join("rootfs")).unwrap();
+        // minimal_spec sets no cpu.cpus.
+        let policy = OciPolicy::from_spec(&minimal_spec(), bundle, "t").unwrap();
+        assert_eq!(policy.cpu_cores, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Improves OCI CPU resource mapping in `sandlock-oci`, correcting one mapping and adding a missing one. Two focused commits.

### 1. Map only enforceable sub-core CPU quota to `max_cpu` throttle
`cpu.quota`/`cpu.period` was mapped with `((quota/period)*100).min(100.0)`. The `.min(100.0)` silently discarded any `>= 1`-core request, and combined with core's `if cpu_pct < 100` guard a `>= 1`-core quota became `max_cpu = 100`, which core reads as **no limit at all**.

- Sub-core (`quota < period`): map to 1-99%, flooring to 1 so a tiny fraction isn't truncated to 0 (and silently dropped to "no limit").
- `>= 1` core: left unmapped. `max_cpu` is a coarse global `SIGSTOP`/`SIGCONT` wall-clock duty cycle, not a bandwidth controller, and a multi-core allowance can't be expressed as a 1-100 value. A multi-core cap belongs on affinity, not this throttle.

### 2. Map `cpu.cpus` cpuset to `cpu_cores` affinity
OCI `cpu.cpus` (e.g. `"0-3,7"`) was dropped entirely. It maps exactly to core's `cpu_cores` (`sched_setaffinity`), so this is genuine, non-approximate multi-core enforcement, and it is what the field means.

- New `parse_cpuset` helper: comma-separated indices and inclusive ranges, sorted and de-duplicated; malformed/empty input drops to `None` (no partial pinning).
- New `OciPolicy.cpu_cores` field, wired through `from_spec` and `to_sandbox`.

## Testing
9 new unit tests (CPU quota cases + cpuset parsing + end-to-end mapping). Full `sandlock-oci` suite: 37 passed, clean build.

## Out of scope
A pure multi-core **quota** with no `cpu.cpus` present (the approximate pin-to-N-cores hack) is intentionally not implemented, its bandwidth-vs-pinning tradeoff is a separate design decision.
