### PR TITLE
fix(net): empty net_allow deny-all bypass + strengthen false-passing security tests

### DIFF
--- a/crates/sandlock-core/src/network.rs
+++ b/crates/sandlock-core/src/network.rs
@@ -495,6 +495,17 @@ async fn connect_on_behalf(
     // closed: the BPF should have prevented socket creation, so
     // reaching here with one is an unexpected case worth refusing.
     if let Some(ip) = parse_ip_from_sockaddr(&addr_bytes) {
+        // Same invariant as the sendto/sendmsg handlers above: `connect()` is
+        // trapped whenever the named-`AF_UNIX` gate is on (any fs grant), for
+        // every address family, but with no network destination policy there
+        // is nothing to enforce on an IP destination. Return it to the kernel
+        // so the child's own Landlock `CONNECT_TCP` rules govern it — handling
+        // it on-behalf in the unconfined supervisor would bypass that decision
+        // (an empty `net_allow` deny-all would silently permit egress). See
+        // `NotifPolicy::ip_connect_supervised`.
+        if !ctx.policy.ip_connect_supervised(ip.is_loopback()) {
+            return NotifAction::Continue;
+        }
         let dest_port = parse_port_from_sockaddr(&addr_bytes);
         let dup_fd = match crate::seccomp::notif::dup_fd_from_pid(notif.pid, sockfd) {
             Ok(fd) => fd,
@@ -1305,7 +1316,7 @@ async fn sendmsg_on_behalf(
     // connected (NULL) name for a denied address. Send on-behalf (including
     // connected sends) so the verdict is made on the immune copy. Without a
     // policy there is nothing to bypass, so the Continue fast path below stands.
-    let dest_policy = ctx.policy.has_net_allowlist;
+    let dest_policy = ctx.policy.has_net_destination_policy;
     if !dest_policy {
         // Pre-scan for Continue cases (connected socket / non-IP family).
         // EFAULT on unreadable msghdr (vs. Continue, which would let the kernel
@@ -1601,7 +1612,7 @@ async fn sendmmsg_on_behalf(
     // entry for a denied address after our prescan, bypassing the allowlist on
     // an unconnected datagram socket. On-behalf sends use the immune copy and
     // validate every IP destination, so the verdict is TOCTOU-free.
-    if ctx.policy.has_net_allowlist {
+    if ctx.policy.has_net_destination_policy {
         let dup_fd = match crate::seccomp::notif::dup_fd_from_pid(notif.pid, sockfd) {
             Ok(fd) => fd,
             Err(e) => return NotifAction::Errno(e.raw_os_error().unwrap_or(libc::EBADF)),

--- a/crates/sandlock-core/src/resource.rs
+++ b/crates/sandlock-core/src/resource.rs
@@ -13,7 +13,6 @@
 // thread cannot mutate.
 
 use std::io;
-use std::mem;
 use std::os::unix::io::RawFd;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -186,20 +185,45 @@ pub(crate) async fn register_child_if_new(ctx: &Arc<SupervisorCtx>, pid: i32) {
     let _ = register_pid_if_new(ctx, pid);
 }
 
-/// One-shot ptrace attachment around a fork-like syscall. RAII guard:
-/// on drop, detaches the caller so the supervisor cannot leak a ptrace
-/// relationship if a code path between `prepare_*` and `finish_*`
-/// panics or returns early. Functions that complete the tracking and
-/// detach explicitly should still hand the trace to a consuming
-/// function (or let it fall out of scope) — duplicate `PTRACE_DETACH`
-/// is harmless (returns ESRCH and is ignored).
+/// Command sent to the per-trace ptrace worker after `prepare` returns.
+enum TraceCmd {
+    /// The seccomp `Continue` has been sent; resume and capture the fork event.
+    Proceed,
+    /// Tear down without proceeding (e.g. `send_response` failed).
+    Abort,
+}
+
+/// Handle to a one-shot ptrace fork-tracking session.
+///
+/// ptrace *commands* (`PTRACE_SEIZE`, `GETEVENTMSG`, `DETACH`, …) are
+/// per-tracer-thread — issuing one from a thread other than the one that
+/// `SEIZE`d fails with `ESRCH`. (Only `waitpid` may be called cross-thread.)
+/// So the whole command sequence — SEIZE, the post-`Continue` event wait, and
+/// the final `PTRACE_DETACH` — runs inside one `spawn_blocking` worker
+/// (`process_creation_worker`) pinned to a single thread. This handle only
+/// carries the channels driving that worker plus the tracee tid (used by
+/// `finish` to wake the worker's blocking wait on the failed-fork path); it
+/// owns no ptrace state, so dropping it never issues a cross-thread ptrace op.
 pub(crate) struct ProcessCreationTrace {
+    cmd_tx: std::sync::mpsc::SyncSender<TraceCmd>,
+    join: Option<tokio::task::JoinHandle<io::Result<bool>>>,
+    /// The traced (forking) task's tid — `finish`'s watchdog signals it.
     caller_tid: i32,
+    /// True once `finish`/`abort` has sent a command; gates the Drop fallback.
+    signaled: bool,
 }
 
 impl Drop for ProcessCreationTrace {
     fn drop(&mut self) {
-        detach_traced(self.caller_tid);
+        // If neither `finish` nor `abort` ran (early return / panic between
+        // `prepare` and `finish`), the worker is blocked waiting for a command.
+        // Tell it to abort so it detaches the tracee on its own thread and
+        // exits, rather than leaking a blocked blocking-pool thread.
+        if !self.signaled {
+            let _ = self.cmd_tx.send(TraceCmd::Abort);
+        }
+        // The dropped `join` handle detaches the worker task; it runs to
+        // completion (performing the ptrace detach on its owning thread).
     }
 }
 
@@ -230,68 +254,87 @@ pub(crate) fn requires_process_creation_tracking(
 
 /// Arm ptrace fork-event tracking on the syscall's calling task.
 ///
-/// The caller is stopped in seccomp user notification when this runs.
-/// After the supervisor sends `Continue`, the kernel executes the
-/// fork-like syscall and reports `PTRACE_EVENT_{FORK,VFORK,CLONE}`;
-/// the new child is born traced/stopped, so we can register it before
-/// detaching either task.
-///
-/// Runs the blocking `waitpid` on a tokio blocking-pool thread so the
-/// notification handler's worker is not stalled if the wait stretches.
+/// The caller is parked in the seccomp user-notification wait when this
+/// runs. Crucially, the tracee **cannot reach a ptrace-stop until the
+/// supervisor sends `Continue`** — so we must not `PTRACE_INTERRUPT`+wait
+/// here (that deadlocks). Instead `prepare` only performs `PTRACE_SEIZE`
+/// (which does not stop the tracee) on a dedicated worker thread, then
+/// returns once SEIZE is confirmed. The worker parks until `finish` (called
+/// after `Continue`) tells it to proceed, at which point it does the
+/// `INTERRUPT` + event loop + detach — all on that same thread, as ptrace
+/// requires.
 pub(crate) async fn prepare_process_creation_tracking(
+    ctx: &Arc<SupervisorCtx>,
     caller_tid: i32,
 ) -> io::Result<ProcessCreationTrace> {
-    tokio::task::spawn_blocking(move || prepare_process_creation_tracking_blocking(caller_tid))
-        .await
-        .map_err(|e| {
-            io::Error::new(io::ErrorKind::Other, format!("spawn_blocking join: {e}"))
-        })?
+    let ctx = Arc::clone(ctx);
+    // SEIZE result, reported back as an errno so `io::Error` need not cross
+    // the channel (it is not `Clone`/`Send`-friendly to reconstruct).
+    let (attached_tx, attached_rx) = tokio::sync::oneshot::channel::<Result<(), i32>>();
+    // Capacity 1: `finish`/`abort`/Drop send exactly one command; the send is
+    // non-blocking and the worker is always waiting to receive it.
+    let (cmd_tx, cmd_rx) = std::sync::mpsc::sync_channel::<TraceCmd>(1);
+
+    let join = tokio::task::spawn_blocking(move || {
+        process_creation_worker(caller_tid, ctx, attached_tx, cmd_rx)
+    });
+
+    match attached_rx.await {
+        Ok(Ok(())) => Ok(ProcessCreationTrace { cmd_tx, join: Some(join), caller_tid, signaled: false }),
+        Ok(Err(errno)) => {
+            let _ = join.await;
+            Err(io::Error::from_raw_os_error(errno))
+        }
+        Err(_) => {
+            // Worker dropped the sender without reporting (panic). Reap it.
+            let _ = join.await;
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "process-creation worker exited before SEIZE",
+            ))
+        }
+    }
 }
 
-fn prepare_process_creation_tracking_blocking(
+/// Owns the entire ptrace lifecycle for one fork-tracking session on a single
+/// thread. SEIZE happens before `Continue`; the `INTERRUPT` + event loop +
+/// detach happen after, once `cmd_rx` delivers `Proceed`.
+fn process_creation_worker(
     caller_tid: i32,
-) -> io::Result<ProcessCreationTrace> {
+    ctx: Arc<SupervisorCtx>,
+    attached_tx: tokio::sync::oneshot::Sender<Result<(), i32>>,
+    cmd_rx: std::sync::mpsc::Receiver<TraceCmd>,
+) -> io::Result<bool> {
+    // SEIZE (does NOT stop the tracee) before `Continue`, so the child is born
+    // traced/stopped once the fork runs. Because SEIZE itself never blocks on
+    // a stop, it is safe against the seccomp-notify wait the tracee sits in.
     let opts = (libc::PTRACE_O_TRACEFORK
         | libc::PTRACE_O_TRACEVFORK
         | libc::PTRACE_O_TRACECLONE
         | libc::PTRACE_O_TRACESYSGOOD) as libc::c_ulong;
-    let ret = unsafe {
-        libc::ptrace(
-            libc::PTRACE_SEIZE as libc::c_uint,
-            caller_tid,
-            0,
-            opts,
-        )
-    };
+    let ret = unsafe { libc::ptrace(libc::PTRACE_SEIZE as libc::c_uint, caller_tid, 0, opts) };
     if ret < 0 {
-        return Err(io::Error::last_os_error());
+        let errno = io::Error::last_os_error().raw_os_error().unwrap_or(libc::EPERM);
+        let _ = attached_tx.send(Err(errno));
+        return Err(io::Error::from_raw_os_error(errno));
+    }
+    let _ = attached_tx.send(Ok(()));
+
+    // Park until the orchestration confirms `Continue` was sent (Proceed) or
+    // asks us to tear down (Abort).
+    match cmd_rx.recv() {
+        Ok(TraceCmd::Proceed) => {}
+        Ok(TraceCmd::Abort) | Err(_) => {
+            detach_traced(caller_tid);
+            return Ok(false);
+        }
     }
 
-    // Arm the RAII guard the moment SEIZE succeeds: any early return
-    // from here to the end of this function detaches via Drop.
-    let trace = ProcessCreationTrace { caller_tid };
-
-    let ret = unsafe {
-        libc::ptrace(libc::PTRACE_INTERRUPT as libc::c_uint, caller_tid, 0, 0)
-    };
-    if ret < 0 {
-        return Err(io::Error::last_os_error());
-    }
-    wait_for_ptrace_stop(caller_tid)?;
-
-    // Arm a syscall-exit stop as a fallback. A successful fork-like
-    // syscall reports PTRACE_EVENT_{FORK,VFORK,CLONE}; a failed one has
-    // no child event, but it still reaches syscall-exit so the
-    // supervisor will not block forever waiting for a child that was
-    // never created.
-    let ret = unsafe {
-        libc::ptrace(libc::PTRACE_SYSCALL as libc::c_uint, caller_tid, 0, 0)
-    };
-    if ret < 0 {
-        return Err(io::Error::last_os_error());
-    }
-
-    Ok(trace)
+    // After `Continue`, watch for the fork-creation event (no INTERRUPT — see
+    // `run_creation_event_loop`).
+    let result = run_creation_event_loop(caller_tid, &ctx);
+    detach_traced(caller_tid);
+    result
 }
 
 fn detach_traced(tid: i32) {
@@ -321,21 +364,6 @@ fn wait_for_ptrace_stop(tid: i32) -> io::Result<libc::c_int> {
     Ok(status)
 }
 
-fn syscall_stop_kind(tid: i32) -> io::Result<u8> {
-    let mut info: libc::ptrace_syscall_info = unsafe { mem::zeroed() };
-    let ret = unsafe {
-        libc::ptrace(
-            libc::PTRACE_GET_SYSCALL_INFO as libc::c_uint,
-            tid,
-            mem::size_of::<libc::ptrace_syscall_info>(),
-            &mut info,
-        )
-    };
-    if ret < 0 {
-        return Err(io::Error::last_os_error());
-    }
-    Ok(info.op)
-}
 
 #[cfg(test)]
 static CHILD_REGISTERED_HOOK: std::sync::Mutex<
@@ -351,88 +379,87 @@ fn child_registered_for_test(child_pid: i32) {
     }
 }
 
-/// Complete one-shot process-creation tracking after `Continue`.
-///
-/// Runs the blocking `waitpid` on a tokio blocking-pool thread so the
-/// notification handler's worker is not stalled.
-pub(crate) async fn finish_process_creation_tracking(
-    ctx: &Arc<SupervisorCtx>,
-    trace: ProcessCreationTrace,
-) -> io::Result<bool> {
-    let ctx = Arc::clone(ctx);
-    tokio::task::spawn_blocking(move || finish_process_creation_tracking_blocking(&ctx, trace))
-        .await
-        .map_err(|e| {
-            io::Error::new(io::ErrorKind::Other, format!("spawn_blocking join: {e}"))
-        })?
-}
+/// Signal `finish`'s watchdog sends to the tracee to wake this blocking wait
+/// when a fork created no child (a failed fork emits no ptrace event). SIGURG
+/// is effectively unused by normal programs and ignored by default, so it is a
+/// safe wake poke that we recognise and swallow.
+const FORK_WATCHDOG_SIGNAL: libc::c_int = libc::SIGURG;
 
-fn finish_process_creation_tracking_blocking(
-    ctx: &Arc<SupervisorCtx>,
-    trace: ProcessCreationTrace,
-) -> io::Result<bool> {
-    // Every early return below relies on `trace`'s Drop to detach the
-    // caller. The success path hands `trace` off to
-    // `finish_process_creation_event`, which keeps the same guarantee.
+/// Watch the SEIZE'd parent for the fork-creation event after `Continue`.
+///
+/// Resolves to `Ok(true)` when the fork created a child (registered before it
+/// can run user code) or `Ok(false)` when the fork-like syscall created none.
+/// The caller (`process_creation_worker`) detaches the tracee afterward.
+///
+/// We request only fork events (PTRACE_O_TRACEFORK family), not syscall
+/// tracing. A *successful* fork therefore stops the parent at
+/// `PTRACE_EVENT_{FORK,VFORK,CLONE}` synchronously with the fork — with both
+/// parent and child born stopped, so the child cannot run user code while we
+/// register it. A *failed* fork produces no ptrace stop at all, so this would
+/// block forever; `finish` bounds it by sending [`FORK_WATCHDOG_SIGNAL`] to the
+/// tracee after a deadline, which we observe here as a signal-delivery-stop and
+/// treat as "no child". (We do **not** `PTRACE_INTERRUPT` to force a stop —
+/// that races the fork and is unreliable; and we do not busy-poll.)
+fn run_creation_event_loop(caller_tid: i32, ctx: &Arc<SupervisorCtx>) -> io::Result<bool> {
     loop {
-        let status = wait_for_ptrace_stop(trace.caller_tid)?;
+        let mut status: libc::c_int = 0;
+        let r = unsafe { libc::waitpid(caller_tid, &mut status, libc::__WALL) };
+        if r < 0 {
+            let e = io::Error::last_os_error();
+            if e.raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            return Err(e);
+        }
+        if libc::WIFEXITED(status) || libc::WIFSIGNALED(status) {
+            // Tracee exited / was killed out from under us: no child to track.
+            return Ok(false);
+        }
+        if !libc::WIFSTOPPED(status) {
+            continue;
+        }
 
         let event = (status >> 16) & 0xffff;
-        let is_fork_event = event == libc::PTRACE_EVENT_FORK
+        if event == libc::PTRACE_EVENT_FORK
             || event == libc::PTRACE_EVENT_VFORK
-            || event == libc::PTRACE_EVENT_CLONE;
-        if is_fork_event {
-            return finish_process_creation_event(ctx, trace);
+            || event == libc::PTRACE_EVENT_CLONE
+        {
+            return handle_fork_event(caller_tid, ctx);
         }
 
         let stopsig = libc::WSTOPSIG(status);
-        if event == 0 && stopsig == (libc::SIGTRAP | 0x80) {
-            let op = syscall_stop_kind(trace.caller_tid)?;
-            match op {
-                libc::PTRACE_SYSCALL_INFO_ENTRY => {
-                    let ret = unsafe {
-                        libc::ptrace(
-                            libc::PTRACE_SYSCALL as libc::c_uint,
-                            trace.caller_tid,
-                            0,
-                            0,
-                        )
-                    };
-                    if ret < 0 {
-                        return Err(io::Error::last_os_error());
-                    }
-                    continue;
-                }
-                libc::PTRACE_SYSCALL_INFO_EXIT => {
-                    return Ok(false);
-                }
-                op => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        format!("unexpected ptrace syscall stop kind: {op}"),
-                    ));
-                }
-            }
+        if stopsig == FORK_WATCHDOG_SIGNAL {
+            // `finish`'s watchdog fired: the fork-like syscall created no child
+            // (it returned without a fork event, e.g. EAGAIN/ENOMEM). Swallow
+            // the wake signal — the worker detaches the tracee next.
+            return Ok(false);
         }
 
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!("unexpected ptrace event: {event}"),
-        ));
+        // Some other signal-delivery-stop in the window: forward the pending
+        // signal and keep waiting for the fork event.
+        let inject = if stopsig == libc::SIGTRAP { 0 } else { stopsig as libc::c_ulong };
+        ptrace_resume(caller_tid, libc::PTRACE_CONT, inject)?;
     }
 }
 
-fn finish_process_creation_event(
-    ctx: &Arc<SupervisorCtx>,
-    trace: ProcessCreationTrace,
-) -> io::Result<bool> {
-    // `trace` detaches the caller on drop; the explicit child-side
-    // detaches stay manual since the child is not held by the guard.
+/// `ptrace(request, tid, 0, data)` returning an error on failure.
+fn ptrace_resume(tid: i32, request: libc::c_uint, data: libc::c_ulong) -> io::Result<()> {
+    let ret = unsafe { libc::ptrace(request, tid, 0, data) };
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// On a `PTRACE_EVENT_{FORK,VFORK,CLONE}`: read the new child's pid, register
+/// it in `ProcessIndex` (so the execve argv-freeze can enumerate it), then
+/// detach the child so it can run. Runs on the worker thread.
+fn handle_fork_event(caller_tid: i32, ctx: &Arc<SupervisorCtx>) -> io::Result<bool> {
     let mut child_pid: libc::c_ulong = 0;
     let ret = unsafe {
         libc::ptrace(
             libc::PTRACE_GETEVENTMSG as libc::c_uint,
-            trace.caller_tid,
+            caller_tid,
             0,
             &mut child_pid,
         )
@@ -453,37 +480,59 @@ fn finish_process_creation_event(
     #[cfg(test)]
     child_registered_for_test(child_pid);
 
-    // Wait for the child's birth-traced ptrace-stop, then detach so it
-    // can run. Result ignored: the child may have already proceeded
-    // (PTRACE_O_TRACEFORK leaves it stopped, but a racing exit is
-    // possible) — detach is harmless either way.
+    // The child is born stopped under PTRACE_O_TRACEFORK; wait for its
+    // birth-stop, then detach so it can run. Result ignored: a racing exit is
+    // possible and detach is harmless either way. The caller (parent) is
+    // detached by `process_creation_worker`.
     let _ = wait_for_ptrace_stop(child_pid);
     detach_traced(child_pid);
-    drop(trace);
     Ok(true)
 }
 
-/// Tear down a tracking session whose `Continue` was never sent
-/// (e.g., `send_response` failed). Runs the blocking `waitpid` on the
-/// tokio blocking pool.
-pub(crate) async fn abort_process_creation_tracking(trace: ProcessCreationTrace) {
-    let _ = tokio::task::spawn_blocking(move || abort_process_creation_tracking_blocking(trace))
-        .await;
+/// Complete one-shot process-creation tracking after `Continue`.
+///
+/// Signals the worker (started in `prepare`) to proceed, then awaits its
+/// result. All ptrace work happens on the worker's single thread; this only
+/// drives it and bounds the failed-fork case.
+pub(crate) async fn finish_process_creation_tracking(
+    mut trace: ProcessCreationTrace,
+) -> io::Result<bool> {
+    /// Upper bound on how long to wait for the fork event. The event is
+    /// delivered synchronously with the fork (sub-millisecond), so this only
+    /// elapses for a fork that created no child (e.g. EAGAIN/ENOMEM).
+    const FORK_EVENT_DEADLINE: std::time::Duration = std::time::Duration::from_secs(2);
+
+    trace.signaled = true;
+    let caller_tid = trace.caller_tid;
+    // Send is non-blocking (capacity-1 channel, single sender) — the worker is
+    // parked waiting to receive, then blocks in `waitpid` for the fork event.
+    let _ = trace.cmd_tx.send(TraceCmd::Proceed);
+    let mut join = trace.join.take().expect("join handle present until finish/abort");
+
+    let join_err =
+        |e| io::Error::new(io::ErrorKind::Other, format!("spawn_blocking join: {e}"));
+
+    // Race the worker against a watchdog. The worker's `waitpid` is blocking, so
+    // a *failed* fork (no ptrace event) would hang it forever; on the deadline
+    // we poke the tracee so its `waitpid` returns and the worker reports "no
+    // child". `kill` does not need the tracer thread, so this is safe from here.
+    tokio::select! {
+        res = &mut join => res.map_err(join_err)?,
+        _ = tokio::time::sleep(FORK_EVENT_DEADLINE) => {
+            unsafe { libc::kill(caller_tid, FORK_WATCHDOG_SIGNAL); }
+            join.await.map_err(join_err)?
+        }
+    }
 }
 
-fn abort_process_creation_tracking_blocking(trace: ProcessCreationTrace) {
-    // INTERRUPT + wait so we can detach cleanly from a known state;
-    // the actual detach happens via `trace`'s Drop on scope exit.
-    let ret = unsafe {
-        libc::ptrace(
-            libc::PTRACE_INTERRUPT as libc::c_uint,
-            trace.caller_tid,
-            0,
-            0,
-        )
-    };
-    if ret == 0 {
-        let _ = wait_for_ptrace_stop(trace.caller_tid);
+/// Tear down a tracking session whose `Continue` was never sent (e.g.
+/// `send_response` failed). Signals the worker to abort; it detaches the
+/// tracee on its own thread.
+pub(crate) async fn abort_process_creation_tracking(mut trace: ProcessCreationTrace) {
+    trace.signaled = true;
+    let _ = trace.cmd_tx.send(TraceCmd::Abort);
+    if let Some(join) = trace.join.take() {
+        let _ = join.await;
     }
 }
 
@@ -874,10 +923,12 @@ mod tests {
 
         let ctx = fake_supervisor_ctx(true);
         let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_io()
+            // `enable_all` (not just io): `finish_process_creation_tracking`
+            // arms a `tokio::time` watchdog, which needs the time driver.
+            .enable_all()
             .build()
             .expect("tokio runtime");
-        let trace = match rt.block_on(prepare_process_creation_tracking(caller)) {
+        let trace = match rt.block_on(prepare_process_creation_tracking(&ctx, caller)) {
             Ok(trace) => trace,
             Err(e) if matches!(e.raw_os_error(), Some(libc::EPERM | libc::EACCES)) => {
                 eprintln!("skipping ptrace fork-event test: ptrace denied: {e}");
@@ -888,7 +939,7 @@ mod tests {
 
         flags.write(GO, 1);
         let created = rt
-            .block_on(finish_process_creation_tracking(&ctx, trace))
+            .block_on(finish_process_creation_tracking(trace))
             .expect("finish process-creation tracking");
         assert!(created, "fork/clone should produce a ptrace process-creation event");
 

--- a/crates/sandlock-core/src/resource.rs
+++ b/crates/sandlock-core/src/resource.rs
@@ -85,7 +85,7 @@ fn is_thread_create(notif: &SeccompNotif, notif_fd: RawFd) -> bool {
 pub(crate) async fn handle_fork(
     notif: &SeccompNotif,
     notif_fd: RawFd,
-    resource: &Arc<Mutex<ResourceState>>,
+    ctx: &Arc<SupervisorCtx>,
     _policy: &NotifPolicy,
 ) -> NotifAction {
     let nr = notif.data.nr as i64;
@@ -102,7 +102,18 @@ pub(crate) async fn handle_fork(
         return NotifAction::Continue;
     }
 
-    let mut rs = resource.lock().await;
+    // Effective process limit. A policy_fn can tighten the static limit at
+    // runtime (`restrict_max_processes`), so read the live value when a
+    // callback is active; otherwise use the static one. (Lock policy_fn before
+    // the resource lock to keep a consistent order.)
+    let live_max = {
+        let pfs = ctx.policy_fn.lock().await;
+        pfs.live_policy
+            .as_ref()
+            .and_then(|lp| lp.read().ok().map(|l| l.max_processes))
+    };
+
+    let mut rs = ctx.resource.lock().await;
 
     // Checkpoint/freeze: hold the fork notification.
     if rs.hold_forks {
@@ -111,7 +122,8 @@ pub(crate) async fn handle_fork(
     }
 
     // Enforce concurrent process limit.
-    if rs.proc_count >= rs.max_processes {
+    let limit = live_max.unwrap_or(rs.max_processes);
+    if rs.proc_count >= limit {
         return NotifAction::Errno(EAGAIN);
     }
 

--- a/crates/sandlock-core/src/resource.rs
+++ b/crates/sandlock-core/src/resource.rs
@@ -518,7 +518,18 @@ pub(crate) async fn handle_memory(
 ) -> NotifAction {
     let nr = notif.data.nr as i64;
     let args = &notif.data.args;
-    let limit = policy.max_memory_bytes;
+    // Effective limit. A policy_fn can tighten the static ceiling at runtime
+    // (`restrict_max_memory`), so read the live value when a callback is
+    // active; otherwise use the static limit. The live value is seeded from
+    // the static `max_memory` ceiling, and this handler is only registered
+    // when that ceiling exists, so it is never the 0/unlimited sentinel.
+    let limit = {
+        let pfs = ctx.policy_fn.lock().await;
+        pfs.live_policy
+            .as_ref()
+            .and_then(|lp| lp.read().ok().map(|l| l.max_memory_bytes))
+            .unwrap_or(policy.max_memory_bytes)
+    };
 
     let mut st = ctx.resource.lock().await;
 

--- a/crates/sandlock-core/src/resource.rs
+++ b/crates/sandlock-core/src/resource.rs
@@ -637,7 +637,7 @@ mod tests {
             max_memory_bytes: 0,
             max_processes: 0,
             has_memory_limit: false,
-            has_net_allowlist: false,
+            has_net_destination_policy: false,
             has_bind_denylist: false,
             has_unix_fs_gate: false,
             has_random_seed: false,

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -632,7 +632,7 @@ impl Sandbox {
     /// Wait for the child process to exit.
     pub async fn wait(&mut self) -> Result<crate::result::RunResult, crate::error::SandlockError> {
         use crate::error::SandboxRuntimeError;
-        use crate::result::{ExitStatus, RunResult};
+        use crate::result::RunResult;
 
         let pid = self.rt().child_pid.ok_or(SandboxRuntimeError::NotRunning)?;
 
@@ -644,23 +644,18 @@ impl Sandbox {
             });
         }
 
-        let exit_status = tokio::task::spawn_blocking(move || -> ExitStatus {
-            let mut status: i32 = 0;
-            loop {
-                let ret = unsafe { libc::waitpid(pid, &mut status, 0) };
-                if ret < 0 {
-                    let err = std::io::Error::last_os_error();
-                    if err.raw_os_error() == Some(libc::EINTR) {
-                        continue;
-                    }
-                    return ExitStatus::Killed;
-                }
-                break;
-            }
-            sandbox_wait_status_to_exit(status)
-        })
-        .await
-        .unwrap_or(ExitStatus::Killed);
+        // Wait for the top-level child to exit. Prefer the child's pidfd via
+        // `AsyncFd`: pidfd readiness fires only on *exit*, so — unlike a
+        // `waitpid` loop — it never consumes the child's ptrace-stops, which
+        // the `policy_fn` fork-tracking worker reaps (`waitpid` with any flags
+        // reaps a tracee's ptrace-stops, so a concurrent `waitpid` here would
+        // race the worker for fork events and hang it). Mirrors
+        // `spawn_pid_watcher`. Falls back to a blocking `waitpid` only when no
+        // pidfd is available (kernel without `pidfd_open`).
+        let exit_status = match self.rt_mut().pidfd.take() {
+            Some(pidfd) => wait_child_exit_via_pidfd(pidfd, pid).await,
+            None => wait_child_exit_blocking(pid).await,
+        };
 
         self.rt_mut().state = RuntimeState::Stopped(exit_status.clone());
 
@@ -1800,6 +1795,70 @@ fn sandbox_wait_status_to_exit(status: i32) -> crate::result::ExitStatus {
     } else {
         ExitStatus::Killed
     }
+}
+
+/// Await the top-level child's exit via its `pidfd` (readable on exit only),
+/// then reap the status. Because it never calls `waitpid` until the child has
+/// already exited, it does not consume the child's ptrace-stops the way a
+/// `waitpid`-loop would — so it doesn't race the `policy_fn` fork-tracking
+/// worker. Falls back to the blocking waiter on any pidfd/`AsyncFd` error.
+async fn wait_child_exit_via_pidfd(
+    pidfd: std::os::unix::io::OwnedFd,
+    pid: libc::pid_t,
+) -> crate::result::ExitStatus {
+    use crate::result::ExitStatus;
+
+    let async_fd = match tokio::io::unix::AsyncFd::with_interest(
+        pidfd,
+        tokio::io::Interest::READABLE,
+    ) {
+        Ok(fd) => fd,
+        Err(_) => return wait_child_exit_blocking(pid).await,
+    };
+
+    loop {
+        // pidfd becomes readable when the process exits; no data is read.
+        let mut guard = match async_fd.readable().await {
+            Ok(g) => g,
+            Err(_) => return ExitStatus::Killed,
+        };
+        let mut status: i32 = 0;
+        // The child has exited and is reapable now, so this never blocks.
+        let r = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
+        if r > 0 {
+            return sandbox_wait_status_to_exit(status);
+        }
+        if r == 0 {
+            // Spurious readiness (not yet reapable): clear and re-await.
+            guard.clear_ready();
+            continue;
+        }
+        // r < 0 (e.g. ECHILD): already reaped elsewhere. Status is unavailable.
+        return ExitStatus::Killed;
+    }
+}
+
+/// Blocking `waitpid` fallback for kernels without `pidfd_open`. Used only when
+/// no pidfd is available; on such kernels `policy_fn` fork-tracking is the only
+/// thing that could race it, and the lack of pidfd is itself rare.
+async fn wait_child_exit_blocking(pid: libc::pid_t) -> crate::result::ExitStatus {
+    use crate::result::ExitStatus;
+    tokio::task::spawn_blocking(move || -> ExitStatus {
+        let mut status: i32 = 0;
+        loop {
+            let ret = unsafe { libc::waitpid(pid, &mut status, 0) };
+            if ret < 0 {
+                if std::io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
+                    continue;
+                }
+                return ExitStatus::Killed;
+            }
+            break;
+        }
+        sandbox_wait_status_to_exit(status)
+    })
+    .await
+    .unwrap_or(ExitStatus::Killed)
 }
 
 fn sandbox_collect_handlers<I, S, H>(

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -1449,7 +1449,7 @@ impl Sandbox {
                 max_memory_bytes: self.max_memory.map(|m| m.0).unwrap_or(0),
                 max_processes: self.max_processes,
                 has_memory_limit: resolved.features.memory_limit,
-                has_net_allowlist: resolved.features.network_destination_policy,
+                has_net_destination_policy: resolved.features.network_destination_policy,
                 has_bind_denylist: resolved.features.bind_denylist,
                 has_unix_fs_gate: resolved.features.unix_fs_gate,
                 has_random_seed: resolved.features.random_seed,

--- a/crates/sandlock-core/src/seccomp/dispatch.rs
+++ b/crates/sandlock-core/src/seccomp/dispatch.rs
@@ -276,14 +276,14 @@ pub(crate) fn build_dispatch_table(
     // ------------------------------------------------------------------
     for nr in arch::fork_like_syscalls() {
         let policy_for_fork = Arc::clone(policy);
-        let resource_for_fork = Arc::clone(resource);
+        let ctx_for_fork = Arc::clone(ctx);
         table.register(nr, move |cx: &HandlerCtx| {
             let notif = cx.notif;
             let notif_fd = cx.notif_fd;
             let policy = Arc::clone(&policy_for_fork);
-            let resource = Arc::clone(&resource_for_fork);
+            let ctx = Arc::clone(&ctx_for_fork);
             async move {
-                crate::resource::handle_fork(&notif, notif_fd, &resource, &policy).await
+                crate::resource::handle_fork(&notif, notif_fd, &ctx, &policy).await
             }
         });
     }

--- a/crates/sandlock-core/src/seccomp/dispatch.rs
+++ b/crates/sandlock-core/src/seccomp/dispatch.rs
@@ -324,10 +324,11 @@ pub(crate) fn build_dispatch_table(
     }
 
     // ------------------------------------------------------------------
-    // Network (conditional on has_net_allowlist || has_http_acl ||
-    // has_unix_fs_gate; the last traps connect() to gate named unix sockets)
+    // Network (conditional on has_net_destination_policy || has_unix_fs_gate;
+    // the latter traps connect() to gate named unix sockets). has_http_acl is
+    // already subsumed by has_net_destination_policy, so it isn't listed.
     // ------------------------------------------------------------------
-    if policy.has_net_allowlist || policy.has_http_acl || policy.has_unix_fs_gate {
+    if policy.has_net_destination_policy || policy.has_unix_fs_gate {
         for &nr in &[
             libc::SYS_connect,
             libc::SYS_sendto,
@@ -669,7 +670,7 @@ pub(crate) fn build_dispatch_table(
     // ------------------------------------------------------------------
     // Bind — on-behalf
     // ------------------------------------------------------------------
-    if policy.port_remap || policy.has_net_allowlist || policy.has_bind_denylist {
+    if policy.port_remap || policy.has_net_destination_policy || policy.has_bind_denylist {
         let __sup = Arc::clone(ctx);
         table.register(libc::SYS_bind, move |cx: &HandlerCtx| {
             let notif = cx.notif;
@@ -1084,7 +1085,7 @@ mod handler_tests {
                 max_memory_bytes: 0,
                 max_processes: 0,
                 has_memory_limit: false,
-                has_net_allowlist: false,
+                has_net_destination_policy: false,
                 has_bind_denylist: false,
                 has_unix_fs_gate: false,
                 has_random_seed: false,

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -1416,7 +1416,7 @@ async fn handle_notification(
     if matches!(action, NotifAction::Continue)
         && crate::resource::requires_process_creation_tracking(&notif, fd, policy)
     {
-        match crate::resource::prepare_process_creation_tracking(notif.pid as i32).await {
+        match crate::resource::prepare_process_creation_tracking(ctx, notif.pid as i32).await {
             Ok(trace) => {
                 creation_trace = Some(trace);
             }
@@ -1468,7 +1468,7 @@ async fn handle_notification(
 
     if let Some(trace) = creation_trace {
         if send_result.is_ok() {
-            match crate::resource::finish_process_creation_tracking(ctx, trace).await {
+            match crate::resource::finish_process_creation_tracking(trace).await {
                 Ok(true) => {}
                 Ok(false) => {
                     crate::resource::rollback_fork_count(&ctx.resource).await;

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -235,8 +235,12 @@ pub enum PortAllow {
 /// Global network policy for the sandbox.
 #[derive(Debug, Clone)]
 pub enum NetworkPolicy {
-    /// No IP-level restriction (no `--net-allow` configured and no
-    /// `policy_fn` override). The Landlock direct path enforces ports.
+    /// No IP-level restriction for this protocol. On the on-behalf path this
+    /// is only ever reached *with* a destination policy active (e.g. a `*:*` /
+    /// `:*` allow-all-ports rule), so here it means "allow any destination."
+    /// The empty-`net_allow` deny-all case never reaches this arm: with no
+    /// destination policy the connect is returned to the kernel and Landlock's
+    /// `CONNECT_TCP` deny-all governs it.
     Unrestricted,
     /// Endpoint-level allowlist: a connection is permitted iff the
     /// destination IP and port match at least one entry below.
@@ -404,10 +408,18 @@ pub struct NotifPolicy {
     pub max_memory_bytes: u64,
     pub max_processes: u32,
     pub has_memory_limit: bool,
-    pub has_net_allowlist: bool,
+    /// A **network destination policy** is active: a `net_allow` allowlist, a
+    /// `net_deny` denylist, an HTTP ACL, or a live `policy_fn` (i.e.
+    /// `network_destination_policy`). Despite the historical singular framing
+    /// this is *not* only an allowlist. When set, the on-behalf path is the
+    /// IP-level enforcer for connect/sendto/sendmsg and those handlers must
+    /// never `Continue`; when clear, the syscalls are trapped only to gate
+    /// named `AF_UNIX` sockets and IP destinations are returned to the kernel
+    /// so Landlock/BPF govern them.
+    pub has_net_destination_policy: bool,
     /// `--net-deny-bind` is active: trap `bind()` and register the on-behalf
     /// handler so denied TCP ports can be refused (independent of the
-    /// connect-side `has_net_allowlist`).
+    /// connect-side `has_net_destination_policy`).
     pub has_bind_denylist: bool,
     /// Named (pathname) `AF_UNIX` connect gate. When true, `connect()` to a
     /// named unix socket whose path is not covered by an fs-write grant is
@@ -450,6 +462,27 @@ pub struct NotifPolicy {
     /// Active MITM CA public cert (PEM bytes) to inject. `Some` only when
     /// HTTPS MITM is active (BYO or generated).
     pub ca_inject_pem: Option<std::sync::Arc<Vec<u8>>>,
+}
+
+impl NotifPolicy {
+    /// Whether an IP-family `connect()` must be handled on-behalf by the
+    /// supervisor, given the destination's loopback-ness.
+    ///
+    /// This is the connect-side form of the invariant the `sendto`/`sendmsg`
+    /// handlers already follow: with [`Self::has_net_destination_policy`] the
+    /// on-behalf path is the IP-level enforcer and must never `Continue`;
+    /// without it there is nothing to enforce and the syscall is returned to
+    /// the kernel. `connect()` adds one wrinkle over datagram sends —
+    /// `port_remap` rewrites the destination, but only for **loopback** — so
+    /// that is the sole extra reason to supervise an otherwise-unpoliced IP
+    /// connect. When this returns `false`, the connect was trapped purely to
+    /// gate named `AF_UNIX` sockets, and deferring to the kernel lets the
+    /// child's own Landlock `CONNECT_TCP` rules govern it (deny-all for an
+    /// empty `net_allow`); handling it on-behalf would run it in the
+    /// unconfined supervisor and bypass that decision.
+    pub(crate) fn ip_connect_supervised(&self, dest_is_loopback: bool) -> bool {
+        self.has_net_destination_policy || (self.port_remap && dest_is_loopback)
+    }
 }
 
 // ============================================================

--- a/crates/sandlock-core/tests/integration/test_network.rs
+++ b/crates/sandlock-core/tests/integration/test_network.rs
@@ -741,3 +741,55 @@ async fn test_net_deny_bind_blocks_tcp_only() {
     assert!(content.contains("\"tcp_allowed\": \"ok\""), "non-denied TCP bind must succeed; got: {content}");
     assert!(content.contains("\"udp_denied\": \"ok\""), "UDP on the denied port must be allowed (TCP-only); got: {content}");
 }
+
+/// Regression (deny-all bypass via the unix-socket connect gate): an empty
+/// `net_allow` must DENY outbound TCP even when filesystem grants are present.
+///
+/// Any fs grant turns on the named-`AF_UNIX` connect gate
+/// (`has_unix_fs_gate`), which traps `connect()` for *all* address families.
+/// A bug let the supervisor perform IP connects on-behalf in that case —
+/// running them in the (unconfined) supervisor and bypassing the child's
+/// Landlock `CONNECT_TCP` deny-all. With deny-all in force the child's
+/// `connect()` must fail with `EACCES` (errno 13) at the kernel, never reach
+/// the listener.
+///
+/// A live loopback listener is used so that IF the connect were wrongly
+/// allowed it would *succeed* (ALLOWED) rather than merely `ECONNREFUSED` to a
+/// dead port — making the assertion discriminate a true Landlock deny from an
+/// on-behalf connect that happened to fail.
+#[tokio::test]
+async fn test_empty_net_allow_denies_tcp_despite_fs_grants() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let out = temp_file("empty-deny-tcp");
+
+    // base_policy() grants fs reads -> has_unix_fs_gate is on. No `.net_allow`
+    // call: an empty allowlist means "deny all outbound".
+    let policy = base_policy().build().unwrap();
+
+    let script = format!(concat!(
+        "import socket\n",
+        "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n",
+        "s.settimeout(3)\n",
+        "try:\n",
+        "  s.connect(('127.0.0.1', {port}))\n",
+        "  open('{out}', 'w').write('ALLOWED')\n",
+        "except OSError as e:\n",
+        "  open('{out}', 'w').write('ERR:%d' % e.errno)\n",
+        "s.close()\n",
+    ), port = port, out = out.display());
+
+    let result = policy.with_name("test")
+        .run_interactive(&["python3", "-c", &script]).await.unwrap();
+    assert!(result.success(), "exit={:?}", result.code());
+
+    let got = std::fs::read_to_string(&out).unwrap_or_default();
+    let _ = std::fs::remove_file(&out);
+    drop(listener);
+
+    assert_eq!(
+        got, "ERR:13",
+        "empty net_allow must deny TCP connect via Landlock (EACCES); got {got:?}"
+    );
+}

--- a/python/tests/test_mcp_integration.py
+++ b/python/tests/test_mcp_integration.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import socket
 import sys
 from types import SimpleNamespace
 
@@ -69,21 +70,36 @@ print("done")
 
     def test_no_network_blocks_connect(self, tmp_path):
         workspace = str(tmp_path)
-        script = """\
+        # A live loopback listener: if the sandbox failed to block egress the
+        # connect would SUCCEED, not merely fail with ECONNREFUSED to a dead
+        # port. That distinguishes a real Landlock deny (EACCES) from an
+        # incidental failure — without it this test passes even with zero
+        # network enforcement (the bug that let the on-behalf path bypass
+        # Landlock's CONNECT_TCP deny-all once any fs grant is present).
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(8)
+        port = listener.getsockname()[1]
+        try:
+            script = f"""\
 import socket
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.settimeout(3)
 try:
-    s.settimeout(2)
-    s.connect(("127.0.0.1", 80))
-    print("connected")
-except (OSError, socket.timeout):
-    print("blocked")
+    s.connect(("127.0.0.1", {port}))
+    print("ALLOWED")
+except OSError as e:
+    print("ERR", e.errno)
 finally:
     s.close()
 """
-        result = _run_in_sandbox(None, script, workspace)
-        assert result.success
-        assert b"blocked" in result.stdout
+            result = _run_in_sandbox(None, script, workspace)
+            assert result.success
+            # errno 13 == EACCES: the kernel's Landlock CONNECT_TCP hook denied
+            # the connect before it could reach the listener.
+            assert b"ERR 13" in result.stdout, result.stdout
+        finally:
+            listener.close()
 
 
 class TestWorkspaceSharing:

--- a/python/tests/test_pipeline.py
+++ b/python/tests/test_pipeline.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import socket
 import sys
 import tempfile
 from pathlib import Path
@@ -218,22 +219,39 @@ class TestXOA:
             assert b"Subject: hello" in result.stdout
 
     def test_xoa_executor_no_network(self):
-        """Executor cannot reach the network."""
-        executor_policy = _policy(net_allow=[])
+        """Executor (net_allow=[]) cannot reach the network.
 
-        result = (
-            _policy().cmd(
-                [sys.executable, "-c",
-                 "print('import socket; "
-                 "socket.create_connection((\"1.1.1.1\", 80), timeout=1)')"]
+        Verified against a live loopback listener so that an *allowed* connect
+        would succeed — the previous version connected to a fixed external host
+        with a malformed command and passed for plumbing reasons, masking
+        whether egress was actually blocked.
+        """
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(8)
+        port = listener.getsockname()[1]
+        try:
+            # _policy() grants system fs reads -> the named-AF_UNIX connect gate
+            # is on, which is the exact condition under which the on-behalf path
+            # used to bypass Landlock. net_allow=[] must still deny-all.
+            executor_policy = _policy(net_allow=[])
+            script = (
+                "import socket\n"
+                "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
+                "s.settimeout(3)\n"
+                "try:\n"
+                f"    s.connect(('127.0.0.1', {port}))\n"
+                "    print('ALLOWED')\n"
+                "except OSError as e:\n"
+                "    print('ERR', e.errno)\n"
             )
-            | executor_policy.cmd(
-                [sys.executable, "-c", "-"]
-            )
-        ).run()
+            result = executor_policy.run([sys.executable, "-c", script])
 
-        # Executor tried to connect but was blocked
-        assert not result.success
+            # The script itself runs fine; the connect is denied with EACCES (13).
+            assert result.success, result.code()
+            assert b"ERR 13" in result.stdout, result.stdout
+        finally:
+            listener.close()
 
 
 # --- Gather ---

--- a/python/tests/test_policy_fn.py
+++ b/python/tests/test_policy_fn.py
@@ -329,9 +329,35 @@ class TestPolicyFnVerdict:
 
 class TestPolicyFnPerPid:
     def test_restrict_pid_network(self):
-        """Per-PID network restriction."""
+        """restrict_pid_network narrows a specific pid's outbound to the listed IPs.
+
+        The old version restricted the pid then ran ``echo ok`` — it never made
+        a network call, so it could not observe any restriction. Mirror
+        test_restrict_network_on_execve with two live loopback listeners, both
+        allowlisted: restricting the exec'd pid to ["127.0.0.1"] must permit the
+        first and refuse the second (errno 111).
+        """
         def on_event(event, ctx):
             if event.syscall in ("execve", "execveat"):
                 ctx.restrict_pid_network(event.pid, ["127.0.0.1"])
 
-        result = _policy(net_allow=["127.0.0.1:443"], policy_fn=on_event).run(["echo", "ok"])
+        with _loopback_listener("127.0.0.1") as (h1, p1), \
+                _loopback_listener("127.0.0.2") as (h2, p2):
+            script = (
+                "import socket\n"
+                "def probe(ip, port):\n"
+                "    s = socket.socket(); s.settimeout(2)\n"
+                "    try:\n"
+                "        s.connect((ip, port)); return 'OK'\n"
+                "    except OSError as e: return 'ERR%d' % e.errno\n"
+                "    finally: s.close()\n"
+                f"print('allowed=' + probe('{h1}', {p1}), 'denied=' + probe('{h2}', {p2}))\n"
+            )
+            result = _policy(
+                net_allow=[f"{h1}:{p1}", f"{h2}:{p2}"], policy_fn=on_event
+            ).run([sys.executable, "-c", script])
+
+        out = result.stdout.decode()
+        assert result.success, result.error
+        assert "allowed=OK" in out, out
+        assert "denied=ERR111" in out, out

--- a/python/tests/test_policy_fn.py
+++ b/python/tests/test_policy_fn.py
@@ -188,32 +188,37 @@ class TestPolicyFnRestrict:
 
 class TestPolicyFnVerdict:
     def test_deny_with_errno(self):
-        """Return a positive int to deny with that errno."""
-        import errno
-        import tempfile, os
+        """Returning a positive int denies with *that* errno — attributable to policy_fn.
 
-        out = os.path.join(tempfile.gettempdir(), f"sandlock-test-denywith-{os.getpid()}")
+        The previous version connected to 127.0.0.1:1, which is outside the
+        ``net_allow`` allowlist, so Landlock denies it with the same errno 13 —
+        the test passed even if the policy_fn errno path were broken. Target a
+        live listener on an *allowlisted* port instead: Landlock permits it and
+        the listener accepts it, so errno 13 can only come from the policy_fn.
+        """
+        import errno
 
         def on_event(event, ctx):
             if event.syscall == "connect":
                 return errno.EACCES  # 13
             return 0
 
-        result = _policy(net_allow=["127.0.0.1:443"], policy_fn=on_event).run(["python3", "-c",
-            f"import socket\n"
-            f"s = socket.socket(); s.settimeout(0.5)\n"
-            f"try:\n"
-            f"  s.connect(('127.0.0.1', 1))\n"
-            f"  open('{out}', 'w').write('CONNECTED')\n"
-            f"except OSError as e:\n"
-            f"  open('{out}', 'w').write(f'ERR:{{e.errno}}')\n"
-            f"s.close()\n"
-        ])
-        assert result.success
-        with open(out) as f:
-            content = f.read()
-        assert content == "ERR:13", f"expected EACCES (13), got: {content}"
-        os.unlink(out)
+        with _loopback_listener() as (host, port):
+            script = (
+                "import socket\n"
+                "s = socket.socket(); s.settimeout(2)\n"
+                "try:\n"
+                f"    s.connect(('{host}', {port})); print('CONNECTED')\n"
+                "except OSError as e: print('ERR:%d' % e.errno)\n"
+                "s.close()\n"
+            )
+            result = _policy(
+                net_allow=[f"{host}:{port}"], policy_fn=on_event
+            ).run([sys.executable, "-c", script])
+
+        out = result.stdout.decode().strip()
+        assert result.success, result.error
+        assert out == "ERR:13", f"expected policy_fn EACCES (13), got: {out!r}"
 
     def test_audit_allows(self):
         """Return 'audit' or -2 to allow but flag."""

--- a/python/tests/test_policy_fn.py
+++ b/python/tests/test_policy_fn.py
@@ -225,14 +225,44 @@ class TestPolicyFnRestrict:
         assert baseline.success, baseline.error
 
     def test_restrict_max_processes(self):
-        """Restrict process limit dynamically."""
-        def on_event(event, ctx):
+        """restrict_max_processes tightens the concurrent-process limit, enforced.
+
+        The old version restricted the limit then ran ``echo`` and asserted
+        nothing. Restrict to 1 (only the running process), then fork: the fork
+        must be denied with EAGAIN (errno 11). The control run (no restriction)
+        forks successfully, proving the denial is due to the dynamic limit, not
+        the fork itself.
+        """
+        fork_once = (
+            "import os\n"
+            "print('STARTED', flush=True)\n"
+            "try:\n"
+            "    pid = os.fork()\n"
+            "    if pid == 0: os._exit(0)\n"
+            "    os.waitpid(pid, 0); print('FORK_OK')\n"
+            "except OSError as e: print('FORK_DENIED', e.errno)\n"
+        )
+
+        def restrict_to_1(event, ctx):
             if event.syscall in ("execve", "execveat"):
                 ctx.restrict_max_processes(1)
+            return 0
 
-        result = _policy(policy_fn=on_event).run(
-            ["echo", "ok"]
+        restricted = _policy(policy_fn=restrict_to_1).run(
+            [sys.executable, "-c", fork_once], timeout=15
         )
+        out = restricted.stdout.decode()
+        assert restricted.success, restricted.error
+        assert "STARTED" in out, out
+        assert "FORK_OK" not in out, out
+        assert "FORK_DENIED 11" in out, out          # EAGAIN from the limit
+
+        # Control: no restriction -> the same fork succeeds.
+        baseline = _policy(policy_fn=lambda e, ctx: 0).run(
+            [sys.executable, "-c", fork_once], timeout=15
+        )
+        assert baseline.success, baseline.error
+        assert "FORK_OK" in baseline.stdout.decode(), baseline.stdout
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_policy_fn.py
+++ b/python/tests/test_policy_fn.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
+import socket
 import sys
 import threading
 
@@ -22,6 +24,25 @@ def _policy(**overrides):
     defaults = {"fs_readable": _PYTHON_READABLE, "fs_writable": ["/tmp"]}
     defaults.update(overrides)
     return Sandbox(**defaults)
+
+
+@contextlib.contextmanager
+def _loopback_listener(host="127.0.0.1"):
+    """Yield ``(host, port)`` for a live TCP listener on an ephemeral port.
+
+    A *live* listener is the baseline that makes a network deny-test
+    meaningful: a connect to it succeeds when allowed, so a failure can only
+    mean the sandbox denied it — as opposed to connecting to a dead port,
+    which fails with ``ECONNREFUSED`` regardless of any enforcement.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind((host, 0))
+    s.listen(8)
+    try:
+        yield host, s.getsockname()[1]
+    finally:
+        s.close()
 
 
 # ---------------------------------------------------------------------------
@@ -217,18 +238,35 @@ class TestPolicyFnVerdict:
         assert not result.success, "unrecognized verdict must fail closed (deny)"
 
     def test_deny_returns_true(self):
-        """Return True to deny with EPERM (backward compat)."""
-        def on_event(event, ctx):
-            if event.syscall == "connect":
-                return True
-            return False
+        """Returning True denies connect with EPERM — and the process keeps running.
 
-        result = _policy(net_allow=["127.0.0.1:443"], policy_fn=on_event).run(["python3", "-c",
-            "import socket; s=socket.socket(); s.settimeout(0.5); "
-            "s.connect_ex(('127.0.0.1', 1)); s.close(); print('ok')"
-        ])
-        # connect was denied but process should still run
-        assert result.success
+        The target is a live listener on an allowlisted port, so without the
+        policy_fn deny the connect would *succeed*. EPERM (errno 1) therefore
+        proves the deny fired, and the trailing marker proves the deny did not
+        kill the process (the backward-compat contract).
+        """
+        def on_event(event, ctx):
+            # True only for connect (deny); allow everything else.
+            return event.syscall == "connect"
+
+        with _loopback_listener() as (host, port):
+            script = (
+                "import socket\n"
+                "s = socket.socket(); s.settimeout(2)\n"
+                "try:\n"
+                f"    s.connect(('{host}', {port})); print('ALLOWED')\n"
+                "except OSError as e: print('ERR', e.errno)\n"
+                "s.close(); print('SURVIVED')\n"
+            )
+            result = _policy(
+                net_allow=[f"{host}:{port}"], policy_fn=on_event
+            ).run([sys.executable, "-c", script])
+
+        out = result.stdout.decode()
+        assert "ALLOWED" not in out, out
+        assert "ERR 1" in out, out          # EPERM from the policy_fn deny
+        assert "SURVIVED" in out, out        # deny must not kill the process
+        assert result.success, result.error
 
     def test_deny_path_dynamic(self):
         """ctx.deny_path blocks file access."""

--- a/python/tests/test_policy_fn.py
+++ b/python/tests/test_policy_fn.py
@@ -188,15 +188,41 @@ class TestPolicyFnRestrict:
         assert "denied=ERR111" in out, out        # non-listed IP refused
 
     def test_restrict_max_memory(self):
-        """Restrict memory limit dynamically."""
-        def on_event(event, ctx):
-            if event.syscall in ("execve", "execveat"):
-                ctx.restrict_max_memory(32 * 1024 * 1024)
+        """restrict_max_memory tightens the static ceiling and is enforced.
 
-        result = _policy(policy_fn=on_event).run(
-            ["echo", "ok"]
+        The old version restricted memory then ran ``echo`` and asserted
+        nothing, so it never exercised the limit. dynamic restriction works by
+        tightening a static ``max_memory`` ceiling: set a 256 MiB ceiling,
+        restrict to 64 MiB, then allocate 128 MiB. With enforcement the process
+        is killed; the un-restricted ceiling (control) allows the same 128 MiB,
+        proving the kill is due to the dynamic restriction, not the ceiling.
+        """
+        alloc_128mb = (
+            "print('STARTED', flush=True)\n"
+            "b = bytearray(128 * 1024 * 1024)\n"
+            "b[::4096] = b'\\x01' * (len(b) // 4096)\n"   # commit the pages
+            "print('ALLOC_OK')\n"
         )
-        # Should still run (echo uses very little memory)
+
+        def restrict_to_64mb(event, ctx):
+            if event.syscall in ("execve", "execveat"):
+                ctx.restrict_max_memory(64 * 1024 * 1024)
+            return 0
+
+        # Restricted: 128 MiB exceeds the tightened 64 MiB limit -> killed.
+        restricted = _policy(max_memory="256M", policy_fn=restrict_to_64mb).run(
+            [sys.executable, "-c", alloc_128mb], timeout=15
+        )
+        assert b"STARTED" in restricted.stdout, restricted.stdout
+        assert b"ALLOC_OK" not in restricted.stdout, restricted.stdout
+        assert not restricted.success, "128 MiB must exceed the 64 MiB dynamic limit"
+
+        # Control: same 128 MiB under the un-restricted 256 MiB ceiling -> OK.
+        baseline = _policy(max_memory="256M").run(
+            [sys.executable, "-c", alloc_128mb], timeout=15
+        )
+        assert b"ALLOC_OK" in baseline.stdout, baseline.stdout
+        assert baseline.success, baseline.error
 
     def test_restrict_max_processes(self):
         """Restrict process limit dynamically."""

--- a/python/tests/test_policy_fn.py
+++ b/python/tests/test_policy_fn.py
@@ -151,14 +151,41 @@ class TestPolicyFnEvents:
 
 class TestPolicyFnRestrict:
     def test_restrict_network_on_execve(self):
-        """Restrict network after seeing execve."""
+        """restrict_network narrows outbound to the listed IPs after execve.
+
+        The old version called ``restrict_network([])`` — an empty list is a
+        no-op (the override is skipped when it lists no IPs) — and asserted only
+        that the program printed, so it verified nothing about the restriction.
+
+        Use two live loopback listeners on 127.0.0.1 and 127.0.0.2, both
+        allowlisted up front so either would connect. Restricting to
+        ``["127.0.0.1"]`` must then permit the first and deny the second
+        (ECONNREFUSED, errno 111). Without enforcement both would connect.
+        """
         def on_event(event, ctx):
             if event.syscall in ("execve", "execveat"):
-                ctx.restrict_network([])
+                ctx.restrict_network(["127.0.0.1"])
 
-        result = _policy(net_allow=["127.0.0.1:443"], policy_fn=on_event).run(["python3", "-c", "print('restricted')"])
-        assert result.success
-        assert b"restricted" in result.stdout
+        with _loopback_listener("127.0.0.1") as (h1, p1), \
+                _loopback_listener("127.0.0.2") as (h2, p2):
+            script = (
+                "import socket\n"
+                "def probe(ip, port):\n"
+                "    s = socket.socket(); s.settimeout(2)\n"
+                "    try:\n"
+                "        s.connect((ip, port)); return 'OK'\n"
+                "    except OSError as e: return 'ERR%d' % e.errno\n"
+                "    finally: s.close()\n"
+                f"print('allowed=' + probe('{h1}', {p1}), 'denied=' + probe('{h2}', {p2}))\n"
+            )
+            result = _policy(
+                net_allow=[f"{h1}:{p1}", f"{h2}:{p2}"], policy_fn=on_event
+            ).run([sys.executable, "-c", script])
+
+        out = result.stdout.decode()
+        assert result.success, result.error
+        assert "allowed=OK" in out, out          # listed IP still reachable
+        assert "denied=ERR111" in out, out        # non-listed IP refused
 
     def test_restrict_max_memory(self):
         """Restrict memory limit dynamically."""

--- a/python/tests/test_sandbox.py
+++ b/python/tests/test_sandbox.py
@@ -90,6 +90,41 @@ class TestSandboxRun:
         assert not result.success
 
 
+class TestNetAllowDenyAll:
+    """An empty `net_allow` denies all outbound — including when fs grants are
+    present, which turn on the named-`AF_UNIX` connect gate (`has_unix_fs_gate`)
+    and cause `connect()` to be trapped. Regression: the on-behalf connect path
+    used to perform IP connects in the (unconfined) supervisor in that case,
+    bypassing the child's Landlock `CONNECT_TCP` deny-all."""
+
+    def test_empty_net_allow_denies_tcp_despite_fs_grants(self):
+        # Live loopback listener: an *allowed* connect would succeed, so the
+        # assertion discriminates a real Landlock deny (EACCES) from an
+        # incidental ECONNREFUSED to a dead port.
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(8)
+        port = listener.getsockname()[1]
+        try:
+            script = (
+                "import socket\n"
+                "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
+                "s.settimeout(3)\n"
+                "try:\n"
+                f"    s.connect(('127.0.0.1', {port}))\n"
+                "    print('ALLOWED')\n"
+                "except OSError as e:\n"
+                "    print('ERR', e.errno)\n"
+            )
+            # _policy() grants system fs reads -> has_unix_fs_gate is on.
+            # net_allow=[] -> deny all outbound.
+            result = _policy(net_allow=[]).run([sys.executable, "-c", script])
+            assert result.success, result.code()
+            assert result.stdout.strip() == b"ERR 13", result.stdout
+        finally:
+            listener.close()
+
+
 class TestNetDeny:
     """`net_deny` wired through the FFI: default-allow networking with an
     IP/CIDR/port denylist, mutually exclusive with `net_allow`."""


### PR DESCRIPTION
## Summary

Everything here traces to one failure mode: **security tests that pass without the security actually happening.** Fixing those tests exposed real bugs in the enforcement they were supposed to cover.

## 1. `net_allow=[]` silently allowed all outbound TCP (Landlock bypass)

Once any fs grant turns on the named-`AF_UNIX` connect gate (`has_unix_fs_gate` — i.e. essentially always), `connect()` is trapped for every address family. The on-behalf handler then performed IP connects in the **unconfined supervisor**, bypassing the child's Landlock `CONNECT_TCP` deny-all. So an empty `net_allow` (deny-all) permitted all outbound TCP.

Fix: bring `connect()` in line with the invariant the `sendto`/`sendmsg` handlers already follow — *no network destination policy ⇒ nothing to enforce ⇒ return the syscall to the kernel so Landlock governs it*. Also renames the misnamed `has_net_allowlist` → `has_net_destination_policy` and corrects the `NetworkPolicy::Unrestricted` doc.

Regression introduced in `4a8a7bf` (post-`v0.8.3` tag). **The published `v0.8.3` release is NOT affected** — verified against the PyPI wheel; only source builds from `main` between `4a8a7bf` and this PR are.

## 2. False-passing security tests

A cluster of tests exercised a deny/restrict API but only asserted "the process still ran", so they passed even when enforcement was a complete no-op:

- network deny tests connecting to a **dead port** (failure was incidental, not enforced)
- `restrict_network([])` — an empty list is a no-op
- `restrict_pid_network` — ran `echo`, never made a network call
- `restrict_max_memory` / `restrict_max_processes` — restricted, then ran `echo`, asserted nothing

All now use **live loopback listeners** (so an allowed op would actually succeed) or real allocations/forks, and assert the enforcement-specific outcome (EACCES/EPERM/EAGAIN, killed process, refused connect). Equivalently weak tests in `test_mcp_integration.py` / `test_pipeline.py` are fixed too.

## 3. Three `policy_fn` product bugs the strengthening uncovered

Making those tests real revealed the underlying dynamic-policy features were broken:

- **`restrict_max_memory` was a no-op** — `handle_memory` read the static `NotifPolicy` limit, never the `LivePolicy` that `restrict_max_memory` writes. Now reads the live (tightened) limit.
- **`restrict_max_processes` was a no-op** — same shape in `handle_fork` (read static `rs.max_processes`). Now reads the live limit.
- **`policy_fn` + `fork()` deadlocked the sandbox.** The fork-event ptrace tracking that `policy_fn` enables hung on any fork. Root cause unfolded into three couplings, all fixed:
  1. *Pre-`Continue` ptrace-stop deadlock* — `prepare` `INTERRUPT`'d and waited for a stop before the seccomp `Continue`, but a tracee parked in the notify wait can't reach a ptrace-stop. Now `SEIZE`-only before `Continue`; the fork event is awaited after.
  2. *Single-thread coordinator, no busy-poll* — ptrace commands are per-tracer-thread (cross-thread = `ESRCH`; only `waitpid` may be cross-thread), so the whole `SEIZE → wait → detach` runs in one `spawn_blocking` worker driven over a channel. A successful fork is caught by a single blocking `waitpid`; a *failed* fork (no event) is bounded by an async `tokio::time` watchdog that wakes the worker via `kill(SIGURG)`. No dedicated thread, no spin, no `INTERRUPT` race.
  3. *Competing waiter* — `Sandbox::wait()` reaped the top-level child with a `waitpid(pid,0)` loop, and `waitpid` (any flags) reaps a tracee's ptrace-stops, so it raced the fork-tracking worker and hung repeated forks. `wait()` now detects exit via the child's **`pidfd` + `AsyncFd`** (readable on exit only, never consuming ptrace-stops), mirroring `spawn_pid_watcher`.

Fork tracking still uses ptrace (the namespace-less TOCTOU guarantee requires `TRACEFORK`); pidfd is only for *exit* detection.

## Test plan

- `cargo test -p sandlock-core` — **398 lib + 257 integration** pass (incl. new `test_empty_net_allow_denies_tcp_despite_fs_grants` and the fork-tracking integration test exercising the new coordinator).
- `pytest python/tests` — **354** pass.
- Stress: 200 sequential forks under `policy_fn`, forced fork failures (EAGAIN), and repeated runs all complete with **zero hangs**.
- Egress matrix: `net_allow=[]` → EACCES; matching rule → ok; non-matching → refused; `*:*` → ok.