### PR TITLE
Checkpoint/restore for sandlock sandboxes (transparent ptrace-injection)

### DIFF
--- a/crates/sandlock-core/src/checkpoint/capture.rs
+++ b/crates/sandlock-core/src/checkpoint/capture.rs
@@ -7,7 +7,7 @@ use crate::error::{SandlockError, SandboxRuntimeError};
 // ptrace helpers -- PTRACE_SEIZE (doesn't auto-SIGSTOP like ATTACH)
 // ---------------------------------------------------------------------------
 
-fn ptrace_seize(pid: i32) -> io::Result<()> {
+pub(crate) fn ptrace_seize(pid: i32) -> io::Result<()> {
     let ret = unsafe {
         libc::ptrace(libc::PTRACE_SEIZE as libc::c_uint, pid, 0, 0)
     };
@@ -29,7 +29,7 @@ fn ptrace_seize(pid: i32) -> io::Result<()> {
     Ok(())
 }
 
-fn ptrace_detach(pid: i32) -> io::Result<()> {
+pub(crate) fn ptrace_detach(pid: i32) -> io::Result<()> {
     let ret = unsafe { libc::ptrace(libc::PTRACE_DETACH, pid, 0, 0) };
     if ret < 0 {
         return Err(io::Error::last_os_error());
@@ -37,7 +37,7 @@ fn ptrace_detach(pid: i32) -> io::Result<()> {
     Ok(())
 }
 
-fn ptrace_getregs(pid: i32) -> io::Result<Vec<u64>> {
+pub(crate) fn ptrace_getregs(pid: i32) -> io::Result<Vec<u64>> {
     #[cfg(target_arch = "x86_64")]
     {
         // user_regs_struct is 27 u64 fields on x86_64 (216 bytes)

--- a/crates/sandlock-core/src/checkpoint/capture.rs
+++ b/crates/sandlock-core/src/checkpoint/capture.rs
@@ -137,7 +137,7 @@ fn ptrace_getregset_bytes(pid: i32, set: libc::c_int, max: usize) -> io::Result<
     if ret < 0 {
         return Err(io::Error::last_os_error());
     }
-    buf.truncate(iov.iov_len);
+    buf.truncate(iov.iov_len.min(buf.len()));
     Ok(buf)
 }
 
@@ -409,7 +409,7 @@ mod tests {
 
     #[test]
     fn ptrace_getfpregs_captures_nonempty_state() {
-        let mut child = std::process::Command::new("sleep").arg("30").spawn().unwrap();
+        let mut child = Command::new("sleep").arg("30").spawn().unwrap();
         let pid = child.id() as i32;
         let res = (|| -> io::Result<Vec<u8>> {
             ptrace_seize(pid)?;

--- a/crates/sandlock-core/src/checkpoint/capture.rs
+++ b/crates/sandlock-core/src/checkpoint/capture.rs
@@ -1,72 +1,10 @@
-use serde::{Serialize, Deserialize};
+use std::io;
+use super::{Checkpoint, ProcessState, MemorySegment, MemoryMap, FdInfo};
 use crate::sandbox::Sandbox;
 use crate::error::{SandlockError, SandboxRuntimeError};
-use std::io;
-use std::path::{Path, PathBuf};
-
-/// A frozen snapshot of sandbox state.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Checkpoint {
-    pub name: String,
-    pub policy: Sandbox,
-    pub process_state: ProcessState,
-    pub fd_table: Vec<FdInfo>,
-    pub cow_snapshot: Option<PathBuf>,
-    pub app_state: Option<Vec<u8>>,
-}
-
-/// Captured process state via ptrace (registers) + process_vm_readv (memory) + /proc (metadata).
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ProcessState {
-    pub pid: i32,
-    pub cwd: String,
-    pub exe: String,
-    pub regs: Vec<u64>,
-    pub memory_maps: Vec<MemoryMap>,
-    pub memory_data: Vec<MemorySegment>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct MemorySegment {
-    pub start: u64,
-    pub data: Vec<u8>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct MemoryMap {
-    pub start: u64,
-    pub end: u64,
-    pub perms: String,
-    pub offset: u64,
-    pub path: Option<String>,
-}
-
-impl MemoryMap {
-    pub fn writable(&self) -> bool {
-        self.perms.starts_with("rw")
-    }
-
-    pub fn private(&self) -> bool {
-        self.perms.contains('p')
-    }
-
-    pub fn is_special(&self) -> bool {
-        self.path.as_ref().map_or(false, |p| {
-            p.starts_with("[vdso]") || p.starts_with("[vvar]") || p.starts_with("[vsyscall]")
-        })
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct FdInfo {
-    pub fd: i32,
-    pub path: String,
-    pub flags: i32,
-    pub offset: u64,
-}
 
 // ---------------------------------------------------------------------------
-// ptrace helpers — PTRACE_SEIZE (doesn't auto-SIGSTOP like ATTACH)
+// ptrace helpers -- PTRACE_SEIZE (doesn't auto-SIGSTOP like ATTACH)
 // ---------------------------------------------------------------------------
 
 fn ptrace_seize(pid: i32) -> io::Result<()> {
@@ -221,7 +159,7 @@ fn parse_proc_maps(pid: i32) -> io::Result<Vec<MemoryMap>> {
 }
 
 // ---------------------------------------------------------------------------
-// Memory capture — process_vm_readv (scatter-gather, no file I/O)
+// Memory capture -- process_vm_readv (scatter-gather, no file I/O)
 // ---------------------------------------------------------------------------
 
 fn capture_memory(pid: i32, maps: &[MemoryMap]) -> io::Result<Vec<MemorySegment>> {
@@ -326,7 +264,7 @@ fn parse_fdinfo(pid: i32, fd: i32) -> io::Result<(i32, u64)> {
 /// Capture a checkpoint from a running, stopped sandbox.
 /// The sandbox must already be frozen (SIGSTOP'd and fork-held).
 pub(crate) fn capture(pid: i32, policy: &Sandbox) -> Result<Checkpoint, SandlockError> {
-    // Seize via ptrace (PTRACE_SEIZE + PTRACE_INTERRUPT — doesn't auto-SIGSTOP)
+    // Seize via ptrace (PTRACE_SEIZE + PTRACE_INTERRUPT -- doesn't auto-SIGSTOP)
     ptrace_seize(pid).map_err(|e| {
         SandlockError::Runtime(SandboxRuntimeError::Child(format!("ptrace seize: {}", e)))
     })?;
@@ -376,277 +314,6 @@ pub(crate) fn capture(pid: i32, policy: &Sandbox) -> Result<Checkpoint, Sandlock
         cow_snapshot: None,
         app_state: None,
     })
-}
-
-// ---------------------------------------------------------------------------
-// Save / Load — directory-based format
-// ---------------------------------------------------------------------------
-//
-// Layout:
-//   <dir>/
-//   ├── meta.json            # name, cow_snapshot
-//   ├── policy.dat           # bincode-serialized Sandbox
-//   ├── app_state.bin        # optional raw app state
-//   └── process/
-//       ├── info.json        # pid, cwd, exe
-//       ├── fds.json         # file descriptor table
-//       ├── memory_map.json  # region metadata
-//       ├── threads/
-//       │   └── 0.bin        # raw register bytes (main thread)
-//       └── memory/
-//           └── <index>.bin  # raw memory contents per segment
-
-fn io_err(e: impl std::fmt::Display) -> SandlockError {
-    SandlockError::Runtime(SandboxRuntimeError::Child(e.to_string()))
-}
-
-fn write_json<T: Serialize>(path: &Path, val: &T) -> Result<(), SandlockError> {
-    let json = serde_json::to_string_pretty(val).map_err(io_err)?;
-    std::fs::write(path, json).map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))
-}
-
-fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T, SandlockError> {
-    let data = std::fs::read_to_string(path)
-        .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
-    serde_json::from_str(&data).map_err(io_err)
-}
-
-/// JSON schema for meta.json.
-#[derive(Serialize, Deserialize)]
-struct MetaJson {
-    name: String,
-    cow_snapshot: Option<String>,
-}
-
-/// JSON schema for process/info.json.
-#[derive(Serialize, Deserialize)]
-struct InfoJson {
-    pid: i32,
-    cwd: String,
-    exe: String,
-}
-
-/// JSON schema for each entry in process/fds.json.
-#[derive(Serialize, Deserialize)]
-struct FdJson {
-    fd: i32,
-    path: String,
-    flags: i32,
-    offset: u64,
-}
-
-/// JSON schema for each entry in process/memory_map.json.
-#[derive(Serialize, Deserialize)]
-struct MemoryMapJson {
-    start: u64,
-    end: u64,
-    perms: String,
-    offset: u64,
-    path: Option<String>,
-}
-
-impl Checkpoint {
-    /// Persist this checkpoint to a directory.
-    ///
-    /// Writes atomically: creates `<dir>.tmp`, populates it, then renames.
-    pub fn save(&self, dir: &Path) -> Result<(), SandlockError> {
-        let tmp = dir.with_extension("tmp");
-        if tmp.exists() {
-            std::fs::remove_dir_all(&tmp)
-                .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
-        }
-        std::fs::create_dir_all(&tmp)
-            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
-
-        let res = self.save_inner(&tmp);
-        if res.is_err() {
-            let _ = std::fs::remove_dir_all(&tmp);
-            return res;
-        }
-
-        // Atomic rename into place
-        if dir.exists() {
-            std::fs::remove_dir_all(dir)
-                .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
-        }
-        std::fs::rename(&tmp, dir)
-            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
-
-        Ok(())
-    }
-
-    fn save_inner(&self, dir: &Path) -> Result<(), SandlockError> {
-        // meta.json
-        write_json(&dir.join("meta.json"), &MetaJson {
-            name: self.name.clone(),
-            cow_snapshot: self.cow_snapshot.as_ref().map(|p| p.display().to_string()),
-        })?;
-
-        // policy.dat (bincode — complex struct, not human-readable anyway)
-        let policy_bytes = bincode::serialize(&self.policy).map_err(io_err)?;
-        std::fs::write(dir.join("policy.dat"), &policy_bytes)
-            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
-
-        // app_state.bin
-        if let Some(ref state) = self.app_state {
-            std::fs::write(dir.join("app_state.bin"), state)
-                .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
-        }
-
-        // process/
-        let proc_dir = dir.join("process");
-        std::fs::create_dir(&proc_dir)
-            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
-
-        // process/info.json
-        write_json(&proc_dir.join("info.json"), &InfoJson {
-            pid: self.process_state.pid,
-            cwd: self.process_state.cwd.clone(),
-            exe: self.process_state.exe.clone(),
-        })?;
-
-        // process/fds.json
-        let fds: Vec<FdJson> = self.fd_table.iter().map(|f| FdJson {
-            fd: f.fd,
-            path: f.path.clone(),
-            flags: f.flags,
-            offset: f.offset,
-        }).collect();
-        write_json(&proc_dir.join("fds.json"), &fds)?;
-
-        // process/memory_map.json — only captured segments (1:1 with memory/*.bin)
-        // Build map entries for each captured segment by matching start address
-        let maps: Vec<MemoryMapJson> = self.process_state.memory_data.iter().map(|seg| {
-            // Find the corresponding full map entry
-            let map = self.process_state.memory_maps.iter()
-                .find(|m| m.start == seg.start);
-            match map {
-                Some(m) => MemoryMapJson {
-                    start: m.start,
-                    end: m.end,
-                    perms: m.perms.clone(),
-                    offset: m.offset,
-                    path: m.path.clone(),
-                },
-                None => MemoryMapJson {
-                    start: seg.start,
-                    end: seg.start + seg.data.len() as u64,
-                    perms: "rw-p".to_string(),
-                    offset: 0,
-                    path: None,
-                },
-            }
-        }).collect();
-        write_json(&proc_dir.join("memory_map.json"), &maps)?;
-
-        // process/threads/0.bin — main thread register state
-        let threads_dir = proc_dir.join("threads");
-        std::fs::create_dir(&threads_dir)
-            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
-        let reg_bytes: Vec<u8> = self.process_state.regs.iter()
-            .flat_map(|r| r.to_le_bytes())
-            .collect();
-        std::fs::write(threads_dir.join("0.bin"), &reg_bytes)
-            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
-
-        // process/memory/<index>.bin — 1:1 with memory_map.json entries
-        let mem_dir = proc_dir.join("memory");
-        std::fs::create_dir(&mem_dir)
-            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
-        for (i, seg) in self.process_state.memory_data.iter().enumerate() {
-            std::fs::write(mem_dir.join(format!("{}.bin", i)), &seg.data)
-                .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
-        }
-
-        Ok(())
-    }
-
-    /// Load a checkpoint from a directory.
-    pub fn load(dir: &Path) -> Result<Self, SandlockError> {
-        if !dir.is_dir() {
-            return Err(SandlockError::Runtime(SandboxRuntimeError::Child(
-                format!("Checkpoint not found: {}", dir.display()),
-            )));
-        }
-
-        // meta.json
-        let meta: MetaJson = read_json(&dir.join("meta.json"))?;
-
-        // policy.dat
-        let policy_bytes = std::fs::read(dir.join("policy.dat"))
-            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
-        let policy: Sandbox = bincode::deserialize(&policy_bytes).map_err(io_err)?;
-
-        // app_state.bin
-        let app_state_path = dir.join("app_state.bin");
-        let app_state = if app_state_path.exists() {
-            Some(std::fs::read(&app_state_path)
-                .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?)
-        } else {
-            None
-        };
-
-        // process/
-        let proc_dir = dir.join("process");
-
-        // process/info.json
-        let info: InfoJson = read_json(&proc_dir.join("info.json"))?;
-
-        // process/fds.json
-        let fds_json: Vec<FdJson> = read_json(&proc_dir.join("fds.json"))?;
-        let fd_table: Vec<FdInfo> = fds_json.into_iter().map(|f| FdInfo {
-            fd: f.fd,
-            path: f.path,
-            flags: f.flags,
-            offset: f.offset,
-        }).collect();
-
-        // process/memory_map.json — 1:1 with memory/<i>.bin
-        let maps_json: Vec<MemoryMapJson> = read_json(&proc_dir.join("memory_map.json"))?;
-        let memory_maps: Vec<MemoryMap> = maps_json.iter().map(|m| MemoryMap {
-            start: m.start,
-            end: m.end,
-            perms: m.perms.clone(),
-            offset: m.offset,
-            path: m.path.clone(),
-        }).collect();
-
-        // process/threads/0.bin
-        let reg_bytes = std::fs::read(proc_dir.join("threads").join("0.bin"))
-            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
-        let regs: Vec<u64> = reg_bytes.chunks_exact(8)
-            .map(|chunk| u64::from_le_bytes(chunk.try_into().unwrap()))
-            .collect();
-
-        // process/memory/<i>.bin — 1:1 with memory_map.json
-        let mem_dir = proc_dir.join("memory");
-        let mut memory_data = Vec::new();
-        for (i, map) in maps_json.iter().enumerate() {
-            let seg_path = mem_dir.join(format!("{}.bin", i));
-            let data = std::fs::read(&seg_path)
-                .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
-            memory_data.push(MemorySegment {
-                start: map.start,
-                data,
-            });
-        }
-
-        Ok(Checkpoint {
-            name: meta.name,
-            policy,
-            process_state: ProcessState {
-                pid: info.pid,
-                cwd: info.cwd,
-                exe: info.exe,
-                regs,
-                memory_maps,
-                memory_data,
-            },
-            fd_table,
-            cow_snapshot: meta.cow_snapshot.map(PathBuf::from),
-            app_state,
-        })
-    }
 }
 
 #[cfg(test)]
@@ -706,7 +373,7 @@ mod tests {
     /// Full capture -> save -> load roundtrip against a live child. `capture()`
     /// only ptraces and reads `/proc`, so this exercises the architecture-specific
     /// register arm plus the on-disk save/load format end to end WITHOUT a sandbox
-    /// launch (no Landlock) — the coverage the sandbox-launch integration test
+    /// launch (no Landlock) -- the coverage the sandbox-launch integration test
     /// cannot provide on kernels below the required Landlock ABI.
     #[test]
     fn capture_save_load_roundtrips() {

--- a/crates/sandlock-core/src/checkpoint/capture.rs
+++ b/crates/sandlock-core/src/checkpoint/capture.rs
@@ -153,7 +153,7 @@ fn ptrace_getfpregs(pid: i32) -> io::Result<Vec<u8>> {
 // /proc parsing
 // ---------------------------------------------------------------------------
 
-fn parse_proc_maps(pid: i32) -> io::Result<Vec<MemoryMap>> {
+pub(crate) fn parse_proc_maps(pid: i32) -> io::Result<Vec<MemoryMap>> {
     let content = std::fs::read_to_string(format!("/proc/{}/maps", pid))?;
     let mut maps = Vec::new();
     for line in content.lines() {

--- a/crates/sandlock-core/src/checkpoint/capture.rs
+++ b/crates/sandlock-core/src/checkpoint/capture.rs
@@ -117,6 +117,39 @@ fn ptrace_getregs(pid: i32) -> io::Result<Vec<u64>> {
 }
 
 // ---------------------------------------------------------------------------
+// FPU/extended register capture via PTRACE_GETREGSET
+// ---------------------------------------------------------------------------
+
+fn ptrace_getregset_bytes(pid: i32, set: libc::c_int, max: usize) -> io::Result<Vec<u8>> {
+    let mut buf = vec![0u8; max];
+    let mut iov = libc::iovec {
+        iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+        iov_len: buf.len(),
+    };
+    let ret = unsafe {
+        libc::ptrace(
+            libc::PTRACE_GETREGSET,
+            pid,
+            set as usize as *mut libc::c_void,
+            &mut iov as *mut libc::iovec as *mut libc::c_void,
+        )
+    };
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    buf.truncate(iov.iov_len);
+    Ok(buf)
+}
+
+fn ptrace_getfpregs(pid: i32) -> io::Result<Vec<u8>> {
+    // NT_PRFPREG = 2; NT_X86_XSTATE = 0x202. 8 KiB upper-bounds AVX-512 xstate.
+    #[cfg(target_arch = "x86_64")]
+    { ptrace_getregset_bytes(pid, 0x202, 8192).or_else(|_| ptrace_getregset_bytes(pid, 2, 512)) }
+    #[cfg(not(target_arch = "x86_64"))]
+    { ptrace_getregset_bytes(pid, 2, 4096) }
+}
+
+// ---------------------------------------------------------------------------
 // /proc parsing
 // ---------------------------------------------------------------------------
 
@@ -274,6 +307,9 @@ pub(crate) fn capture(pid: i32, policy: &Sandbox) -> Result<Checkpoint, Sandlock
         SandlockError::Runtime(SandboxRuntimeError::Child(format!("ptrace getregs: {}", e)))
     })?;
 
+    // Capture FPU/extended register state
+    let fpregs = ptrace_getfpregs(pid).unwrap_or_default();
+
     // Capture memory maps
     let maps =
         parse_proc_maps(pid).map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
@@ -307,6 +343,7 @@ pub(crate) fn capture(pid: i32, policy: &Sandbox) -> Result<Checkpoint, Sandlock
             cwd,
             exe,
             regs,
+            fpregs,
             memory_maps: maps,
             memory_data,
         },
@@ -368,6 +405,22 @@ mod tests {
             target_arch = "riscv64"
         ))]
         assert!(pc != 0, "captured program counter should be non-zero, got {:#x}", pc);
+    }
+
+    #[test]
+    fn ptrace_getfpregs_captures_nonempty_state() {
+        let mut child = std::process::Command::new("sleep").arg("30").spawn().unwrap();
+        let pid = child.id() as i32;
+        let res = (|| -> io::Result<Vec<u8>> {
+            ptrace_seize(pid)?;
+            let fp = ptrace_getfpregs(pid)?;
+            ptrace_detach(pid)?;
+            Ok(fp)
+        })();
+        let _ = child.kill();
+        let _ = child.wait();
+        let fp = res.expect("fpreg capture should succeed");
+        assert!(!fp.is_empty(), "captured FP/extended register blob should be non-empty");
     }
 
     /// Full capture -> save -> load roundtrip against a live child. `capture()`

--- a/crates/sandlock-core/src/checkpoint/capture.rs
+++ b/crates/sandlock-core/src/checkpoint/capture.rs
@@ -455,6 +455,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
 
         assert_eq!(loaded.process_state.regs, cp.process_state.regs, "regs roundtrip");
+        assert_eq!(loaded.process_state.fpregs, cp.process_state.fpregs, "fpregs roundtrip");
         assert_eq!(
             loaded.process_state.memory_data.len(),
             cp.process_state.memory_data.len(),

--- a/crates/sandlock-core/src/checkpoint/image.rs
+++ b/crates/sandlock-core/src/checkpoint/image.rs
@@ -1,0 +1,276 @@
+use serde::{Serialize, Deserialize};
+use std::path::{Path, PathBuf};
+use super::{Checkpoint, ProcessState, MemorySegment, MemoryMap, FdInfo};
+use crate::error::{SandlockError, SandboxRuntimeError};
+use crate::sandbox::Sandbox;
+
+// ---------------------------------------------------------------------------
+// Save / Load -- directory-based format
+// ---------------------------------------------------------------------------
+//
+// Layout:
+//   <dir>/
+//   ├── meta.json            # name, cow_snapshot
+//   ├── policy.dat           # bincode-serialized Sandbox
+//   ├── app_state.bin        # optional raw app state
+//   └── process/
+//       ├── info.json        # pid, cwd, exe
+//       ├── fds.json         # file descriptor table
+//       ├── memory_map.json  # region metadata
+//       ├── threads/
+//       │   └── 0.bin        # raw register bytes (main thread)
+//       └── memory/
+//           └── <index>.bin  # raw memory contents per segment
+
+fn io_err(e: impl std::fmt::Display) -> SandlockError {
+    SandlockError::Runtime(SandboxRuntimeError::Child(e.to_string()))
+}
+
+fn write_json<T: Serialize>(path: &Path, val: &T) -> Result<(), SandlockError> {
+    let json = serde_json::to_string_pretty(val).map_err(io_err)?;
+    std::fs::write(path, json).map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T, SandlockError> {
+    let data = std::fs::read_to_string(path)
+        .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
+    serde_json::from_str(&data).map_err(io_err)
+}
+
+/// JSON schema for meta.json.
+#[derive(Serialize, Deserialize)]
+struct MetaJson {
+    name: String,
+    cow_snapshot: Option<String>,
+}
+
+/// JSON schema for process/info.json.
+#[derive(Serialize, Deserialize)]
+struct InfoJson {
+    pid: i32,
+    cwd: String,
+    exe: String,
+}
+
+/// JSON schema for each entry in process/fds.json.
+#[derive(Serialize, Deserialize)]
+struct FdJson {
+    fd: i32,
+    path: String,
+    flags: i32,
+    offset: u64,
+}
+
+/// JSON schema for each entry in process/memory_map.json.
+#[derive(Serialize, Deserialize)]
+struct MemoryMapJson {
+    start: u64,
+    end: u64,
+    perms: String,
+    offset: u64,
+    path: Option<String>,
+}
+
+impl Checkpoint {
+    /// Persist this checkpoint to a directory.
+    ///
+    /// Writes atomically: creates `<dir>.tmp`, populates it, then renames.
+    pub fn save(&self, dir: &Path) -> Result<(), SandlockError> {
+        let tmp = dir.with_extension("tmp");
+        if tmp.exists() {
+            std::fs::remove_dir_all(&tmp)
+                .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
+        }
+        std::fs::create_dir_all(&tmp)
+            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
+
+        let res = self.save_inner(&tmp);
+        if res.is_err() {
+            let _ = std::fs::remove_dir_all(&tmp);
+            return res;
+        }
+
+        // Atomic rename into place
+        if dir.exists() {
+            std::fs::remove_dir_all(dir)
+                .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
+        }
+        std::fs::rename(&tmp, dir)
+            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
+
+        Ok(())
+    }
+
+    fn save_inner(&self, dir: &Path) -> Result<(), SandlockError> {
+        // meta.json
+        write_json(&dir.join("meta.json"), &MetaJson {
+            name: self.name.clone(),
+            cow_snapshot: self.cow_snapshot.as_ref().map(|p| p.display().to_string()),
+        })?;
+
+        // policy.dat (bincode -- complex struct, not human-readable anyway)
+        let policy_bytes = bincode::serialize(&self.policy).map_err(io_err)?;
+        std::fs::write(dir.join("policy.dat"), &policy_bytes)
+            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
+
+        // app_state.bin
+        if let Some(ref state) = self.app_state {
+            std::fs::write(dir.join("app_state.bin"), state)
+                .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
+        }
+
+        // process/
+        let proc_dir = dir.join("process");
+        std::fs::create_dir(&proc_dir)
+            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
+
+        // process/info.json
+        write_json(&proc_dir.join("info.json"), &InfoJson {
+            pid: self.process_state.pid,
+            cwd: self.process_state.cwd.clone(),
+            exe: self.process_state.exe.clone(),
+        })?;
+
+        // process/fds.json
+        let fds: Vec<FdJson> = self.fd_table.iter().map(|f| FdJson {
+            fd: f.fd,
+            path: f.path.clone(),
+            flags: f.flags,
+            offset: f.offset,
+        }).collect();
+        write_json(&proc_dir.join("fds.json"), &fds)?;
+
+        // process/memory_map.json -- only captured segments (1:1 with memory/*.bin)
+        // Build map entries for each captured segment by matching start address
+        let maps: Vec<MemoryMapJson> = self.process_state.memory_data.iter().map(|seg| {
+            // Find the corresponding full map entry
+            let map = self.process_state.memory_maps.iter()
+                .find(|m| m.start == seg.start);
+            match map {
+                Some(m) => MemoryMapJson {
+                    start: m.start,
+                    end: m.end,
+                    perms: m.perms.clone(),
+                    offset: m.offset,
+                    path: m.path.clone(),
+                },
+                None => MemoryMapJson {
+                    start: seg.start,
+                    end: seg.start + seg.data.len() as u64,
+                    perms: "rw-p".to_string(),
+                    offset: 0,
+                    path: None,
+                },
+            }
+        }).collect();
+        write_json(&proc_dir.join("memory_map.json"), &maps)?;
+
+        // process/threads/0.bin -- main thread register state
+        let threads_dir = proc_dir.join("threads");
+        std::fs::create_dir(&threads_dir)
+            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
+        let reg_bytes: Vec<u8> = self.process_state.regs.iter()
+            .flat_map(|r| r.to_le_bytes())
+            .collect();
+        std::fs::write(threads_dir.join("0.bin"), &reg_bytes)
+            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
+
+        // process/memory/<index>.bin -- 1:1 with memory_map.json entries
+        let mem_dir = proc_dir.join("memory");
+        std::fs::create_dir(&mem_dir)
+            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
+        for (i, seg) in self.process_state.memory_data.iter().enumerate() {
+            std::fs::write(mem_dir.join(format!("{}.bin", i)), &seg.data)
+                .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
+        }
+
+        Ok(())
+    }
+
+    /// Load a checkpoint from a directory.
+    pub fn load(dir: &Path) -> Result<Self, SandlockError> {
+        if !dir.is_dir() {
+            return Err(SandlockError::Runtime(SandboxRuntimeError::Child(
+                format!("Checkpoint not found: {}", dir.display()),
+            )));
+        }
+
+        // meta.json
+        let meta: MetaJson = read_json(&dir.join("meta.json"))?;
+
+        // policy.dat
+        let policy_bytes = std::fs::read(dir.join("policy.dat"))
+            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
+        let policy: Sandbox = bincode::deserialize(&policy_bytes).map_err(io_err)?;
+
+        // app_state.bin
+        let app_state_path = dir.join("app_state.bin");
+        let app_state = if app_state_path.exists() {
+            Some(std::fs::read(&app_state_path)
+                .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?)
+        } else {
+            None
+        };
+
+        // process/
+        let proc_dir = dir.join("process");
+
+        // process/info.json
+        let info: InfoJson = read_json(&proc_dir.join("info.json"))?;
+
+        // process/fds.json
+        let fds_json: Vec<FdJson> = read_json(&proc_dir.join("fds.json"))?;
+        let fd_table: Vec<FdInfo> = fds_json.into_iter().map(|f| FdInfo {
+            fd: f.fd,
+            path: f.path,
+            flags: f.flags,
+            offset: f.offset,
+        }).collect();
+
+        // process/memory_map.json -- 1:1 with memory/<i>.bin
+        let maps_json: Vec<MemoryMapJson> = read_json(&proc_dir.join("memory_map.json"))?;
+        let memory_maps: Vec<MemoryMap> = maps_json.iter().map(|m| MemoryMap {
+            start: m.start,
+            end: m.end,
+            perms: m.perms.clone(),
+            offset: m.offset,
+            path: m.path.clone(),
+        }).collect();
+
+        // process/threads/0.bin
+        let reg_bytes = std::fs::read(proc_dir.join("threads").join("0.bin"))
+            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
+        let regs: Vec<u64> = reg_bytes.chunks_exact(8)
+            .map(|chunk| u64::from_le_bytes(chunk.try_into().unwrap()))
+            .collect();
+
+        // process/memory/<i>.bin -- 1:1 with memory_map.json
+        let mem_dir = proc_dir.join("memory");
+        let mut memory_data = Vec::new();
+        for (i, map) in maps_json.iter().enumerate() {
+            let seg_path = mem_dir.join(format!("{}.bin", i));
+            let data = std::fs::read(&seg_path)
+                .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
+            memory_data.push(MemorySegment {
+                start: map.start,
+                data,
+            });
+        }
+
+        Ok(Checkpoint {
+            name: meta.name,
+            policy,
+            process_state: ProcessState {
+                pid: info.pid,
+                cwd: info.cwd,
+                exe: info.exe,
+                regs,
+                memory_maps,
+                memory_data,
+            },
+            fd_table,
+            cow_snapshot: meta.cow_snapshot.map(PathBuf::from),
+            app_state,
+        })
+    }
+}

--- a/crates/sandlock-core/src/checkpoint/image.rs
+++ b/crates/sandlock-core/src/checkpoint/image.rs
@@ -166,6 +166,7 @@ impl Checkpoint {
         write_json(&proc_dir.join("memory_map.json"), &maps)?;
 
         // process/threads/0.bin -- main thread register state
+        // NOTE: process_state.fpregs is not yet written here; persistence is added in the next change.
         let threads_dir = proc_dir.join("threads");
         std::fs::create_dir(&threads_dir)
             .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
@@ -265,6 +266,7 @@ impl Checkpoint {
                 cwd: info.cwd,
                 exe: info.exe,
                 regs,
+                // fpregs persistence is added in the next change; load defaults to empty for now.
                 fpregs: Vec::new(),
                 memory_maps,
                 memory_data,

--- a/crates/sandlock-core/src/checkpoint/image.rs
+++ b/crates/sandlock-core/src/checkpoint/image.rs
@@ -265,6 +265,7 @@ impl Checkpoint {
                 cwd: info.cwd,
                 exe: info.exe,
                 regs,
+                fpregs: Vec::new(),
                 memory_maps,
                 memory_data,
             },

--- a/crates/sandlock-core/src/checkpoint/image.rs
+++ b/crates/sandlock-core/src/checkpoint/image.rs
@@ -44,6 +44,7 @@ fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T, SandlockErr
 struct MetaJson {
     name: String,
     cow_snapshot: Option<String>,
+    #[serde(default)]
     version: u32,
 }
 
@@ -257,7 +258,7 @@ impl Checkpoint {
         let regs: Vec<u64> = reg_bytes.chunks_exact(8)
             .map(|chunk| u64::from_le_bytes(chunk.try_into().unwrap()))
             .collect();
-        // process/threads/fpregs.bin -- absent in older images, default to empty
+        // Read FP/extended registers; tolerate absence defensively.
         let fpregs = std::fs::read(threads_dir.join("fpregs.bin")).unwrap_or_default();
 
         // process/memory/<i>.bin -- 1:1 with memory_map.json
@@ -306,6 +307,7 @@ mod tests {
             br#"{"name":"x","cow_snapshot":null,"version":999}"#).unwrap();
         let res = Checkpoint::load(&dir);
         let _ = std::fs::remove_dir_all(&dir);
-        assert!(res.is_err(), "loading an unknown image version must fail");
+        let msg = res.unwrap_err().to_string();
+        assert!(msg.contains("version"), "error should mention version, got: {msg}");
     }
 }

--- a/crates/sandlock-core/src/checkpoint/image.rs
+++ b/crates/sandlock-core/src/checkpoint/image.rs
@@ -22,6 +22,8 @@ use crate::sandbox::Sandbox;
 //       └── memory/
 //           └── <index>.bin  # raw memory contents per segment
 
+const IMAGE_VERSION: u32 = 1;
+
 fn io_err(e: impl std::fmt::Display) -> SandlockError {
     SandlockError::Runtime(SandboxRuntimeError::Child(e.to_string()))
 }
@@ -42,6 +44,7 @@ fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T, SandlockErr
 struct MetaJson {
     name: String,
     cow_snapshot: Option<String>,
+    version: u32,
 }
 
 /// JSON schema for process/info.json.
@@ -106,6 +109,7 @@ impl Checkpoint {
         write_json(&dir.join("meta.json"), &MetaJson {
             name: self.name.clone(),
             cow_snapshot: self.cow_snapshot.as_ref().map(|p| p.display().to_string()),
+            version: IMAGE_VERSION,
         })?;
 
         // policy.dat (bincode -- complex struct, not human-readable anyway)
@@ -166,7 +170,6 @@ impl Checkpoint {
         write_json(&proc_dir.join("memory_map.json"), &maps)?;
 
         // process/threads/0.bin -- main thread register state
-        // NOTE: process_state.fpregs is not yet written here; persistence is added in the next change.
         let threads_dir = proc_dir.join("threads");
         std::fs::create_dir(&threads_dir)
             .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
@@ -174,6 +177,9 @@ impl Checkpoint {
             .flat_map(|r| r.to_le_bytes())
             .collect();
         std::fs::write(threads_dir.join("0.bin"), &reg_bytes)
+            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
+        // process/threads/fpregs.bin -- FPU/extended register state
+        std::fs::write(threads_dir.join("fpregs.bin"), &self.process_state.fpregs)
             .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
 
         // process/memory/<index>.bin -- 1:1 with memory_map.json entries
@@ -198,6 +204,12 @@ impl Checkpoint {
 
         // meta.json
         let meta: MetaJson = read_json(&dir.join("meta.json"))?;
+        if meta.version != IMAGE_VERSION {
+            return Err(SandlockError::Runtime(SandboxRuntimeError::Child(
+                format!("unsupported checkpoint image version {} (expected {})",
+                    meta.version, IMAGE_VERSION),
+            )));
+        }
 
         // policy.dat
         let policy_bytes = std::fs::read(dir.join("policy.dat"))
@@ -239,11 +251,14 @@ impl Checkpoint {
         }).collect();
 
         // process/threads/0.bin
-        let reg_bytes = std::fs::read(proc_dir.join("threads").join("0.bin"))
+        let threads_dir = proc_dir.join("threads");
+        let reg_bytes = std::fs::read(threads_dir.join("0.bin"))
             .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
         let regs: Vec<u64> = reg_bytes.chunks_exact(8)
             .map(|chunk| u64::from_le_bytes(chunk.try_into().unwrap()))
             .collect();
+        // process/threads/fpregs.bin -- absent in older images, default to empty
+        let fpregs = std::fs::read(threads_dir.join("fpregs.bin")).unwrap_or_default();
 
         // process/memory/<i>.bin -- 1:1 with memory_map.json
         let mem_dir = proc_dir.join("memory");
@@ -266,8 +281,7 @@ impl Checkpoint {
                 cwd: info.cwd,
                 exe: info.exe,
                 regs,
-                // fpregs persistence is added in the next change; load defaults to empty for now.
-                fpregs: Vec::new(),
+                fpregs,
                 memory_maps,
                 memory_data,
             },
@@ -275,5 +289,23 @@ impl Checkpoint {
             cow_snapshot: meta.cow_snapshot.map(PathBuf::from),
             app_state,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Checkpoint;
+
+    #[test]
+    fn image_rejects_wrong_version() {
+        let dir = std::env::temp_dir().join(format!("sandlock-ver-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("process/threads")).unwrap();
+        std::fs::create_dir_all(dir.join("process/memory")).unwrap();
+        std::fs::write(dir.join("meta.json"),
+            br#"{"name":"x","cow_snapshot":null,"version":999}"#).unwrap();
+        let res = Checkpoint::load(&dir);
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(res.is_err(), "loading an unknown image version must fail");
     }
 }

--- a/crates/sandlock-core/src/checkpoint/image.rs
+++ b/crates/sandlock-core/src/checkpoint/image.rs
@@ -16,13 +16,19 @@ use crate::sandbox::Sandbox;
 //   └── process/
 //       ├── info.json        # pid, cwd, exe
 //       ├── fds.json         # file descriptor table
-//       ├── memory_map.json  # region metadata
+//       ├── memory_map.json  # FULL region metadata (every mapping)
 //       ├── threads/
 //       │   └── 0.bin        # raw register bytes (main thread)
 //       └── memory/
-//           └── <index>.bin  # raw memory contents per segment
+//           └── <start_hex>.bin  # captured bytes for a region, keyed by its
+//                                # start address (only regions with data)
+//
+// `memory_map.json` lists *every* mapping (not just captured ones) so that
+// restore can `RemapFromFile` the file-backed regions (e.g. the executable
+// text) that were never captured into `memory/`. Each `memory/<start_hex>.bin`
+// is re-associated with its map entry by matching start address.
 
-const IMAGE_VERSION: u32 = 1;
+const IMAGE_VERSION: u32 = 2;
 
 fn io_err(e: impl std::fmt::Display) -> SandlockError {
     SandlockError::Runtime(SandboxRuntimeError::Child(e.to_string()))
@@ -145,28 +151,15 @@ impl Checkpoint {
         }).collect();
         write_json(&proc_dir.join("fds.json"), &fds)?;
 
-        // process/memory_map.json -- only captured segments (1:1 with memory/*.bin)
-        // Build map entries for each captured segment by matching start address
-        let maps: Vec<MemoryMapJson> = self.process_state.memory_data.iter().map(|seg| {
-            // Find the corresponding full map entry
-            let map = self.process_state.memory_maps.iter()
-                .find(|m| m.start == seg.start);
-            match map {
-                Some(m) => MemoryMapJson {
-                    start: m.start,
-                    end: m.end,
-                    perms: m.perms.clone(),
-                    offset: m.offset,
-                    path: m.path.clone(),
-                },
-                None => MemoryMapJson {
-                    start: seg.start,
-                    end: seg.start + seg.data.len() as u64,
-                    perms: "rw-p".to_string(),
-                    offset: 0,
-                    path: None,
-                },
-            }
+        // process/memory_map.json -- FULL region metadata (every mapping), so
+        // restore can RemapFromFile the file-backed regions (e.g. the
+        // executable text) that were never captured into memory_data.
+        let maps: Vec<MemoryMapJson> = self.process_state.memory_maps.iter().map(|m| MemoryMapJson {
+            start: m.start,
+            end: m.end,
+            perms: m.perms.clone(),
+            offset: m.offset,
+            path: m.path.clone(),
         }).collect();
         write_json(&proc_dir.join("memory_map.json"), &maps)?;
 
@@ -183,12 +176,14 @@ impl Checkpoint {
         std::fs::write(threads_dir.join("fpregs.bin"), &self.process_state.fpregs)
             .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
 
-        // process/memory/<index>.bin -- 1:1 with memory_map.json entries
+        // process/memory/<start_hex>.bin -- captured segment bytes, keyed by
+        // start address so load can re-associate each blob with its (full) map
+        // entry regardless of how many uncaptured maps sit between them.
         let mem_dir = proc_dir.join("memory");
         std::fs::create_dir(&mem_dir)
             .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
-        for (i, seg) in self.process_state.memory_data.iter().enumerate() {
-            std::fs::write(mem_dir.join(format!("{}.bin", i)), &seg.data)
+        for seg in self.process_state.memory_data.iter() {
+            std::fs::write(mem_dir.join(format!("{:x}.bin", seg.start)), &seg.data)
                 .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
         }
 
@@ -241,7 +236,7 @@ impl Checkpoint {
             offset: f.offset,
         }).collect();
 
-        // process/memory_map.json -- 1:1 with memory/<i>.bin
+        // process/memory_map.json -- FULL region list (every mapping).
         let maps_json: Vec<MemoryMapJson> = read_json(&proc_dir.join("memory_map.json"))?;
         let memory_maps: Vec<MemoryMap> = maps_json.iter().map(|m| MemoryMap {
             start: m.start,
@@ -261,17 +256,22 @@ impl Checkpoint {
         // Read FP/extended registers; tolerate absence defensively.
         let fpregs = std::fs::read(threads_dir.join("fpregs.bin")).unwrap_or_default();
 
-        // process/memory/<i>.bin -- 1:1 with memory_map.json
+        // process/memory/<start_hex>.bin -- captured segments only, matched to
+        // their map entry by start address. Maps without a blob (file-backed
+        // regions like the executable text) carry no data and are restored via
+        // RemapFromFile during resume.
         let mem_dir = proc_dir.join("memory");
         let mut memory_data = Vec::new();
-        for (i, map) in maps_json.iter().enumerate() {
-            let seg_path = mem_dir.join(format!("{}.bin", i));
-            let data = std::fs::read(&seg_path)
-                .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
-            memory_data.push(MemorySegment {
-                start: map.start,
-                data,
-            });
+        for map in &maps_json {
+            let seg_path = mem_dir.join(format!("{:x}.bin", map.start));
+            if seg_path.exists() {
+                let data = std::fs::read(&seg_path)
+                    .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Io(e)))?;
+                memory_data.push(MemorySegment {
+                    start: map.start,
+                    data,
+                });
+            }
         }
 
         Ok(Checkpoint {

--- a/crates/sandlock-core/src/checkpoint/inject.rs
+++ b/crates/sandlock-core/src/checkpoint/inject.rs
@@ -1,0 +1,197 @@
+use std::io;
+
+#[cfg(target_arch = "x86_64")]
+use std::os::raw::c_void;
+
+// ---------------------------------------------------------------------------
+// Raw ptrace helpers
+// ---------------------------------------------------------------------------
+
+/// PTRACE_PEEKTEXT reads the word at `addr` and returns it as the ptrace
+/// return value. A legitimately-read word may be 0xFFFF...FF, which is
+/// indistinguishable from the -1 error sentinel by value alone, so the
+/// errno-cleared-first convention is mandatory: clear errno, peek, then on a
+/// -1 return check errno to decide whether it was a real error.
+#[cfg(target_arch = "x86_64")]
+fn ptrace_peektext(pid: i32, addr: u64) -> io::Result<u64> {
+    unsafe {
+        *libc::__errno_location() = 0;
+        let word = libc::ptrace(
+            libc::PTRACE_PEEKTEXT,
+            pid,
+            addr as *mut c_void,
+            std::ptr::null_mut::<c_void>(),
+        );
+        if word == -1 {
+            let errno = *libc::__errno_location();
+            if errno != 0 {
+                return Err(io::Error::from_raw_os_error(errno));
+            }
+        }
+        Ok(word as u64)
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+fn ptrace_poketext(pid: i32, addr: u64, data: u64) -> io::Result<()> {
+    let ret = unsafe {
+        libc::ptrace(
+            libc::PTRACE_POKETEXT,
+            pid,
+            addr as *mut c_void,
+            data as *mut c_void,
+        )
+    };
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(target_arch = "x86_64")]
+fn ptrace_getregs(pid: i32) -> io::Result<libc::user_regs_struct> {
+    let mut regs: libc::user_regs_struct = unsafe { std::mem::zeroed() };
+    let ret = unsafe {
+        libc::ptrace(
+            libc::PTRACE_GETREGS,
+            pid,
+            std::ptr::null_mut::<c_void>(),
+            &mut regs as *mut libc::user_regs_struct as *mut c_void,
+        )
+    };
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(regs)
+}
+
+#[cfg(target_arch = "x86_64")]
+fn ptrace_setregs(pid: i32, regs: &libc::user_regs_struct) -> io::Result<()> {
+    let ret = unsafe {
+        libc::ptrace(
+            libc::PTRACE_SETREGS,
+            pid,
+            std::ptr::null_mut::<c_void>(),
+            regs as *const libc::user_regs_struct as *mut c_void,
+        )
+    };
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(target_arch = "x86_64")]
+fn ptrace_singlestep(pid: i32) -> io::Result<()> {
+    let ret = unsafe {
+        libc::ptrace(
+            libc::PTRACE_SINGLESTEP,
+            pid,
+            std::ptr::null_mut::<c_void>(),
+            std::ptr::null_mut::<c_void>(),
+        )
+    };
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Execute one syscall in a ptrace-stopped child via register/text injection,
+/// returning the raw syscall result (negative = -errno). The child must already
+/// be ptrace-stopped at a valid executable rip. After return, the child's
+/// registers and the text at rip are restored to their pre-call state, so this
+/// may be called repeatedly. x86_64 only.
+// used by the restore path (added in a later change)
+#[allow(dead_code)]
+#[cfg(target_arch = "x86_64")]
+pub(crate) fn inject_syscall(pid: i32, nr: u64, args: [u64; 6]) -> io::Result<i64> {
+    // Save the pristine registers and the original instruction word at rip so
+    // the child can be returned to its exact pre-call state afterwards.
+    let saved_regs = ptrace_getregs(pid)?;
+    let rip = saved_regs.rip;
+    let orig_word = ptrace_peektext(pid, rip)?;
+
+    // Plant the `syscall` instruction (0f 05) into the low two bytes of the
+    // word at rip, leaving the rest of the word intact.
+    let planted = (orig_word & !0xffffu64) | 0x050fu64;
+
+    // Run the call inside a closure so that, regardless of where a middle step
+    // fails, we always attempt to restore the text word and registers before
+    // returning. A half-modified child is worse than a clean error.
+    let result = (|| -> io::Result<i64> {
+        ptrace_poketext(pid, rip, planted)?;
+
+        let mut regs = saved_regs;
+        regs.rax = nr;
+        regs.rdi = args[0];
+        regs.rsi = args[1];
+        regs.rdx = args[2];
+        regs.r10 = args[3];
+        regs.r8 = args[4];
+        regs.r9 = args[5];
+        regs.rip = rip; // execute the planted `syscall`
+        ptrace_setregs(pid, &regs)?;
+
+        ptrace_singlestep(pid)?;
+        let mut status: i32 = 0;
+        let w = unsafe { libc::waitpid(pid, &mut status, 0) };
+        if w < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let after = ptrace_getregs(pid)?;
+        Ok(after.rax as i64)
+    })();
+
+    // Best-effort restore: original instruction word, then the saved registers
+    // (so rip and everything else match the pre-call state). Run both even on
+    // the error path; surface a restore failure only if the call itself
+    // succeeded.
+    let restore_word = ptrace_poketext(pid, rip, orig_word);
+    let restore_regs = ptrace_setregs(pid, &saved_regs);
+
+    let ret = result?;
+    restore_word?;
+    restore_regs?;
+    Ok(ret)
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+#[allow(dead_code)]
+pub(crate) fn inject_syscall(_pid: i32, _nr: u64, _args: [u64; 6]) -> io::Result<i64> {
+    Err(io::Error::new(io::ErrorKind::Unsupported,
+        "syscall injection is only implemented on x86_64"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn inject_getpid_returns_child_pid() {
+        use std::os::unix::process::CommandExt;
+        let mut child = unsafe {
+            std::process::Command::new("sleep").arg("30")
+                .pre_exec(|| {
+                    // Become traceable; stop at execve so the tracer (parent) gets control.
+                    libc::ptrace(libc::PTRACE_TRACEME, 0, 0, 0);
+                    Ok(())
+                })
+                .spawn().unwrap()
+        };
+        let pid = child.id() as i32;
+        // Wait for the execve-stop (SIGTRAP).
+        let mut st = 0i32;
+        unsafe { libc::waitpid(pid, &mut st, 0); }
+
+        // getpid == 39 on x86_64.
+        let ret = inject_syscall(pid, 39, [0; 6]).expect("inject getpid");
+
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert_eq!(ret as i32, pid, "injected getpid should return the child's pid");
+    }
+}

--- a/crates/sandlock-core/src/checkpoint/inject.rs
+++ b/crates/sandlock-core/src/checkpoint/inject.rs
@@ -293,9 +293,8 @@ pub(crate) fn inject_syscall_at(_pid: i32, _gadget: u64, _nr: u64, _args: [u64; 
 /// `process_vm_writev`. The target page must be writable. Mirrors the private
 /// `write_child_mem_vm` helper in `seccomp::notif` (copied locally because that
 /// one is private and TOCTOU-bound to a live notification).
-// used by the restore path (added in a later change)
-#[allow(dead_code)]
-fn write_child_mem(pid: i32, addr: u64, bytes: &[u8]) -> io::Result<()> {
+// used by the restore path (resume::restore_into) and setup_trampoline
+pub(crate) fn write_child_mem(pid: i32, addr: u64, bytes: &[u8]) -> io::Result<()> {
     let local_iov = libc::iovec {
         iov_base: bytes.as_ptr() as *mut libc::c_void,
         iov_len: bytes.len(),
@@ -334,21 +333,28 @@ pub(crate) fn setup_trampoline(pid: i32, maps: &[MemoryMap]) -> io::Result<u64> 
         .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "no free page for restore trampoline"))?;
 
     // mmap(addr, 4096, PROT_READ|PROT_WRITE|PROT_EXEC,
-    //      MAP_PRIVATE|MAP_ANONYMOUS|MAP_FIXED_NOREPLACE, -1, 0). nr = 9 on x86_64.
-    // MAP_FIXED_NOREPLACE returns -EEXIST if the address is already occupied,
-    // so the post-call check below is a genuine safety net rather than a
-    // tautology (MAP_FIXED always returns the requested address on success).
+    //      MAP_PRIVATE|MAP_ANONYMOUS|MAP_FIXED, -1, 0). nr = 9 on x86_64.
+    //
+    // MAP_FIXED (not MAP_FIXED_NOREPLACE) is deliberate: in a real restore the
+    // stub's address space differs from the checkpoint, so the trampoline hole
+    // (a gap in the TARGET/checkpoint layout) is typically still occupied by
+    // disposable inherited mappings in the stub, which we MUST clobber to plant
+    // the gadget. Safety against clobbering a RESTORED region is guaranteed by
+    // the caller passing the CHECKPOINT's `memory_maps` here, so the hole does
+    // not exist in the target and no restored region ever maps over it -- NOT by
+    // NOREPLACE. The post-call check stays meaningful because MAP_FIXED returns
+    // the requested address on success and a negative errno on failure (e.g. a
+    // W^X denial of a writable+executable mapping).
     let prot = (libc::PROT_READ | libc::PROT_WRITE | libc::PROT_EXEC) as u64;
-    let flags = (libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_FIXED_NOREPLACE) as u64;
+    let flags = (libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_FIXED) as u64;
     let ret = inject_syscall(pid, 9, [addr, 4096, prot, flags, (-1i64) as u64, 0])?;
 
-    // MAP_FIXED_NOREPLACE returns the requested address on success; a negative
-    // value (-EEXIST, -ENOMEM, ...) means the mapping failed, most likely
-    // because the address is already occupied.
+    // MAP_FIXED returns the requested address on success; a negative value
+    // (-EPERM from a W^X denial, -ENOMEM, ...) means the mapping failed.
     if ret < 0 || (ret as u64) != addr {
         return Err(io::Error::new(
             io::ErrorKind::Other,
-            format!("trampoline mmap at {addr:#x} failed or address occupied (ret={ret:#x})"),
+            format!("trampoline mmap at {addr:#x} failed (ret={ret:#x})"),
         ));
     }
 

--- a/crates/sandlock-core/src/checkpoint/inject.rs
+++ b/crates/sandlock-core/src/checkpoint/inject.rs
@@ -319,11 +319,13 @@ pub(crate) fn write_child_mem(pid: i32, addr: u64, bytes: &[u8]) -> io::Result<(
 }
 
 /// Bootstrap a permanent `syscall` trampoline in a free hole of the stopped
-/// child's address space. Finds an unused page, maps it `MAP_FIXED_NOREPLACE`
+/// child's address space. Finds an unused page, maps it `MAP_FIXED`
 /// as read/write/exec anonymous memory using the temporary plant-at-rip injector,
 /// writes a `syscall` instruction into it, and returns the page address. All
 /// later injections can run through this fixed gadget without ever clobbering
 /// the page that holds it (it lives in a gap the restored process never uses).
+/// MAP_FIXED (not MAP_FIXED_NOREPLACE) is used deliberately to clobber any
+/// disposable inherited stub mappings that occupy the chosen hole.
 /// x86_64 only.
 // used by the restore path (added in a later change)
 #[allow(dead_code)]

--- a/crates/sandlock-core/src/checkpoint/inject.rs
+++ b/crates/sandlock-core/src/checkpoint/inject.rs
@@ -140,6 +140,16 @@ pub(crate) fn inject_syscall(pid: i32, nr: u64, args: [u64; 6]) -> io::Result<i6
             return Err(io::Error::last_os_error());
         }
 
+        // WIFSTOPPED: low byte == 0x7f. WSTOPSIG: (status >> 8) & 0xff.
+        let stopped = (status & 0xff) == 0x7f;
+        let stopsig = (status >> 8) & 0xff;
+        if !stopped || stopsig != libc::SIGTRAP {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("injected syscall did not complete: status={status:#x}"),
+            ));
+        }
+
         let after = ptrace_getregs(pid)?;
         Ok(after.rax as i64)
     })();

--- a/crates/sandlock-core/src/checkpoint/inject.rs
+++ b/crates/sandlock-core/src/checkpoint/inject.rs
@@ -1,5 +1,7 @@
 use std::io;
 
+use crate::checkpoint::MemoryMap;
+
 #[cfg(target_arch = "x86_64")]
 use std::os::raw::c_void;
 
@@ -174,6 +176,192 @@ pub(crate) fn inject_syscall(_pid: i32, _nr: u64, _args: [u64; 6]) -> io::Result
         "syscall injection is only implemented on x86_64"))
 }
 
+/// Find a page-aligned (4096) userspace address that is not covered by any map
+/// in `maps`, suitable for a one-page trampoline. Collects the `[start, end)`
+/// ranges, sorts them by start, and returns the first gap of at least one page
+/// within the sane userspace window `[0x1_0000, 0x7fff_0000_0000)`. Returns
+/// `None` when no such gap exists. Pure function: no child process needed.
+// used by the restore path (added in a later change)
+#[allow(dead_code)]
+pub(crate) fn find_free_page(maps: &[MemoryMap]) -> Option<u64> {
+    const PAGE: u64 = 4096;
+    const WINDOW_LO: u64 = 0x1_0000;
+    const WINDOW_HI: u64 = 0x7fff_0000_0000;
+
+    let mut ranges: Vec<(u64, u64)> = maps.iter().map(|m| (m.start, m.end)).collect();
+    ranges.sort_by_key(|r| r.0);
+
+    // Walk the window left to right, advancing a cursor past every map that
+    // overlaps the region we are still considering. The first time the cursor
+    // has at least one page of clearance before the next map, that is our gap.
+    let mut cursor = WINDOW_LO;
+    for (start, end) in &ranges {
+        // Skip maps that end before the cursor; they cannot bound the gap.
+        if *end <= cursor {
+            continue;
+        }
+        // A map starting at or before the cursor just pushes the cursor forward.
+        if *start <= cursor {
+            cursor = *end;
+            if cursor >= WINDOW_HI {
+                return None;
+            }
+            continue;
+        }
+        // There is open space in [cursor, start). Is it at least one page and
+        // inside the window?
+        if start.saturating_sub(cursor) >= PAGE && cursor + PAGE <= WINDOW_HI {
+            return Some(cursor);
+        }
+        // Gap too small; jump past this map and keep looking.
+        cursor = *end;
+        if cursor >= WINDOW_HI {
+            return None;
+        }
+    }
+
+    // Trailing space after the last map up to the window top.
+    if cursor + PAGE <= WINDOW_HI {
+        Some(cursor)
+    } else {
+        None
+    }
+}
+
+/// Execute one syscall in a ptrace-stopped child through a permanent `syscall`
+/// gadget that already exists at `gadget`. Unlike `inject_syscall`, this plants
+/// no text and restores no text: it only saves the registers, points rip at the
+/// gadget, single-steps, reads the result, and restores the saved registers.
+/// This lets the caller drive injections that would otherwise clobber the page
+/// holding a temporary gadget. x86_64 only.
+// used by the restore path (added in a later change)
+#[allow(dead_code)]
+#[cfg(target_arch = "x86_64")]
+pub(crate) fn inject_syscall_at(pid: i32, gadget: u64, nr: u64, args: [u64; 6]) -> io::Result<i64> {
+    let saved_regs = ptrace_getregs(pid)?;
+
+    let result = (|| -> io::Result<i64> {
+        let mut regs = saved_regs;
+        regs.rax = nr;
+        regs.rdi = args[0];
+        regs.rsi = args[1];
+        regs.rdx = args[2];
+        regs.r10 = args[3];
+        regs.r8 = args[4];
+        regs.r9 = args[5];
+        regs.rip = gadget; // execute the permanent `syscall`
+        ptrace_setregs(pid, &regs)?;
+
+        ptrace_singlestep(pid)?;
+        let mut status: i32 = 0;
+        let w = unsafe { libc::waitpid(pid, &mut status, 0) };
+        if w < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // WIFSTOPPED: low byte == 0x7f. WSTOPSIG: (status >> 8) & 0xff.
+        let stopped = (status & 0xff) == 0x7f;
+        let stopsig = (status >> 8) & 0xff;
+        if !stopped || stopsig != libc::SIGTRAP {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("injected syscall did not complete: status={status:#x}"),
+            ));
+        }
+
+        let after = ptrace_getregs(pid)?;
+        Ok(after.rax as i64)
+    })();
+
+    // Restore the saved registers (rip included) even on the error path; surface
+    // a restore failure only if the call itself succeeded.
+    let restore_regs = ptrace_setregs(pid, &saved_regs);
+
+    let ret = result?;
+    restore_regs?;
+    Ok(ret)
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+#[allow(dead_code)]
+pub(crate) fn inject_syscall_at(_pid: i32, _gadget: u64, _nr: u64, _args: [u64; 6]) -> io::Result<i64> {
+    Err(io::Error::new(io::ErrorKind::Unsupported,
+        "syscall injection is only implemented on x86_64"))
+}
+
+/// Write `bytes` into the stopped child at `addr` via a single
+/// `process_vm_writev`. The target page must be writable. Mirrors the private
+/// `write_child_mem_vm` helper in `seccomp::notif` (copied locally because that
+/// one is private and TOCTOU-bound to a live notification).
+// used by the restore path (added in a later change)
+#[allow(dead_code)]
+fn write_child_mem(pid: i32, addr: u64, bytes: &[u8]) -> io::Result<()> {
+    let local_iov = libc::iovec {
+        iov_base: bytes.as_ptr() as *mut libc::c_void,
+        iov_len: bytes.len(),
+    };
+    let remote_iov = libc::iovec {
+        iov_base: addr as *mut libc::c_void,
+        iov_len: bytes.len(),
+    };
+    let ret = unsafe {
+        libc::process_vm_writev(pid, &local_iov, 1, &remote_iov, 1, 0)
+    };
+    if ret < 0 {
+        Err(io::Error::last_os_error())
+    } else if (ret as usize) < bytes.len() {
+        Err(io::Error::new(
+            io::ErrorKind::WriteZero,
+            format!("short write: {} of {} bytes", ret, bytes.len()),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+/// Bootstrap a permanent `syscall` trampoline in a free hole of the stopped
+/// child's address space. Finds an unused page, maps it `MAP_FIXED` as
+/// read/write/exec anonymous memory using the temporary plant-at-rip injector,
+/// writes a `syscall` instruction into it, and returns the page address. All
+/// later injections can run through this fixed gadget without ever clobbering
+/// the page that holds it (it lives in a gap the restored process never uses).
+/// x86_64 only.
+// used by the restore path (added in a later change)
+#[allow(dead_code)]
+#[cfg(target_arch = "x86_64")]
+pub(crate) fn setup_trampoline(pid: i32, maps: &[MemoryMap]) -> io::Result<u64> {
+    let addr = find_free_page(maps)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "no free page for restore trampoline"))?;
+
+    // mmap(addr, 4096, PROT_READ|PROT_WRITE|PROT_EXEC,
+    //      MAP_PRIVATE|MAP_ANONYMOUS|MAP_FIXED, -1, 0). nr = 9 on x86_64.
+    let prot = (libc::PROT_READ | libc::PROT_WRITE | libc::PROT_EXEC) as u64;
+    let flags = (libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_FIXED) as u64;
+    let ret = inject_syscall(pid, 9, [addr, 4096, prot, flags, (-1i64) as u64, 0])?;
+
+    // MAP_FIXED returns the requested address on success; anything else (in
+    // particular a negative -errno) means the mapping did not land where we need
+    // the trampoline to live.
+    if ret < 0 || (ret as u64) != addr {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("trampoline mmap returned {ret:#x}, expected {addr:#x}"),
+        ));
+    }
+
+    // Plant the permanent `syscall` instruction (0f 05) into the new page.
+    write_child_mem(pid, addr, &[0x0f, 0x05])?;
+
+    Ok(addr)
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+#[allow(dead_code)]
+pub(crate) fn setup_trampoline(_pid: i32, _maps: &[MemoryMap]) -> io::Result<u64> {
+    Err(io::Error::new(io::ErrorKind::Unsupported,
+        "trampoline setup is only implemented on x86_64"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -203,5 +391,68 @@ mod tests {
         let _ = child.wait();
 
         assert_eq!(ret as i32, pid, "injected getpid should return the child's pid");
+    }
+
+    #[test]
+    fn find_free_page_finds_gap_between_maps() {
+        // Two maps with a one-megabyte gap between them. The first map starts at
+        // the window low bound so there is no leading gap to find; the only gap
+        // starts at 0x20_0000 (end of the first map) and runs to 0x30_0000.
+        let maps = vec![
+            MemoryMap {
+                start: 0x1_0000,
+                end: 0x20_0000,
+                perms: "r-xp".into(),
+                offset: 0,
+                path: None,
+            },
+            MemoryMap {
+                start: 0x30_0000,
+                end: 0x40_0000,
+                perms: "rw-p".into(),
+                offset: 0,
+                path: None,
+            },
+        ];
+        let addr = find_free_page(&maps).expect("a gap should be found");
+        assert_eq!(addr % 4096, 0, "result must be page aligned");
+        assert!(
+            addr >= 0x20_0000 && addr + 4096 <= 0x30_0000,
+            "result {addr:#x} should sit inside the gap"
+        );
+    }
+
+    #[test]
+    fn find_free_page_none_when_packed() {
+        // A single map spanning the entire search window leaves no room.
+        let maps = vec![MemoryMap {
+            start: 0x1_0000,
+            end: 0x7fff_0000_0000,
+            perms: "rw-p".into(),
+            offset: 0,
+            path: None,
+        }];
+        assert!(find_free_page(&maps).is_none(), "packed window has no gap");
+    }
+
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn trampoline_executes_getpid() {
+        use std::os::unix::process::CommandExt;
+        let mut child = unsafe {
+            std::process::Command::new("sleep").arg("30")
+                .pre_exec(|| { libc::ptrace(libc::PTRACE_TRACEME, 0, 0, 0); Ok(()) })
+                .spawn().unwrap()
+        };
+        let pid = child.id() as i32;
+        let mut st = 0i32;
+        unsafe { libc::waitpid(pid, &mut st, 0); }
+
+        let maps = crate::checkpoint::capture::parse_proc_maps(pid).expect("read child maps");
+        let tramp = setup_trampoline(pid, &maps).expect("setup trampoline");
+        let ret = inject_syscall_at(pid, tramp, 39, [0; 6]).expect("getpid via trampoline");
+
+        let _ = child.kill(); let _ = child.wait();
+        assert_eq!(ret as i32, pid, "getpid via trampoline should return child pid");
     }
 }

--- a/crates/sandlock-core/src/checkpoint/inject.rs
+++ b/crates/sandlock-core/src/checkpoint/inject.rs
@@ -320,8 +320,8 @@ fn write_child_mem(pid: i32, addr: u64, bytes: &[u8]) -> io::Result<()> {
 }
 
 /// Bootstrap a permanent `syscall` trampoline in a free hole of the stopped
-/// child's address space. Finds an unused page, maps it `MAP_FIXED` as
-/// read/write/exec anonymous memory using the temporary plant-at-rip injector,
+/// child's address space. Finds an unused page, maps it `MAP_FIXED_NOREPLACE`
+/// as read/write/exec anonymous memory using the temporary plant-at-rip injector,
 /// writes a `syscall` instruction into it, and returns the page address. All
 /// later injections can run through this fixed gadget without ever clobbering
 /// the page that holds it (it lives in a gap the restored process never uses).
@@ -334,18 +334,21 @@ pub(crate) fn setup_trampoline(pid: i32, maps: &[MemoryMap]) -> io::Result<u64> 
         .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "no free page for restore trampoline"))?;
 
     // mmap(addr, 4096, PROT_READ|PROT_WRITE|PROT_EXEC,
-    //      MAP_PRIVATE|MAP_ANONYMOUS|MAP_FIXED, -1, 0). nr = 9 on x86_64.
+    //      MAP_PRIVATE|MAP_ANONYMOUS|MAP_FIXED_NOREPLACE, -1, 0). nr = 9 on x86_64.
+    // MAP_FIXED_NOREPLACE returns -EEXIST if the address is already occupied,
+    // so the post-call check below is a genuine safety net rather than a
+    // tautology (MAP_FIXED always returns the requested address on success).
     let prot = (libc::PROT_READ | libc::PROT_WRITE | libc::PROT_EXEC) as u64;
-    let flags = (libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_FIXED) as u64;
+    let flags = (libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_FIXED_NOREPLACE) as u64;
     let ret = inject_syscall(pid, 9, [addr, 4096, prot, flags, (-1i64) as u64, 0])?;
 
-    // MAP_FIXED returns the requested address on success; anything else (in
-    // particular a negative -errno) means the mapping did not land where we need
-    // the trampoline to live.
+    // MAP_FIXED_NOREPLACE returns the requested address on success; a negative
+    // value (-EEXIST, -ENOMEM, ...) means the mapping failed, most likely
+    // because the address is already occupied.
     if ret < 0 || (ret as u64) != addr {
         return Err(io::Error::new(
             io::ErrorKind::Other,
-            format!("trampoline mmap returned {ret:#x}, expected {addr:#x}"),
+            format!("trampoline mmap at {addr:#x} failed or address occupied (ret={ret:#x})"),
         ));
     }
 

--- a/crates/sandlock-core/src/checkpoint/mod.rs
+++ b/crates/sandlock-core/src/checkpoint/mod.rs
@@ -4,6 +4,7 @@ use crate::sandbox::Sandbox;
 
 mod capture;
 mod image;
+mod regs;
 
 pub(crate) use capture::capture;
 

--- a/crates/sandlock-core/src/checkpoint/mod.rs
+++ b/crates/sandlock-core/src/checkpoint/mod.rs
@@ -1,0 +1,69 @@
+use serde::{Serialize, Deserialize};
+use std::path::PathBuf;
+use crate::sandbox::Sandbox;
+
+mod capture;
+mod image;
+
+pub(crate) use capture::capture;
+
+/// A frozen snapshot of sandbox state.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Checkpoint {
+    pub name: String,
+    pub policy: Sandbox,
+    pub process_state: ProcessState,
+    pub fd_table: Vec<FdInfo>,
+    pub cow_snapshot: Option<PathBuf>,
+    pub app_state: Option<Vec<u8>>,
+}
+
+/// Captured process state via ptrace (registers) + process_vm_readv (memory) + /proc (metadata).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProcessState {
+    pub pid: i32,
+    pub cwd: String,
+    pub exe: String,
+    pub regs: Vec<u64>,
+    pub memory_maps: Vec<MemoryMap>,
+    pub memory_data: Vec<MemorySegment>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MemorySegment {
+    pub start: u64,
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MemoryMap {
+    pub start: u64,
+    pub end: u64,
+    pub perms: String,
+    pub offset: u64,
+    pub path: Option<String>,
+}
+
+impl MemoryMap {
+    pub fn writable(&self) -> bool {
+        self.perms.starts_with("rw")
+    }
+
+    pub fn private(&self) -> bool {
+        self.perms.contains('p')
+    }
+
+    pub fn is_special(&self) -> bool {
+        self.path.as_ref().map_or(false, |p| {
+            p.starts_with("[vdso]") || p.starts_with("[vvar]") || p.starts_with("[vsyscall]")
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FdInfo {
+    pub fd: i32,
+    pub path: String,
+    pub flags: i32,
+    pub offset: u64,
+}

--- a/crates/sandlock-core/src/checkpoint/mod.rs
+++ b/crates/sandlock-core/src/checkpoint/mod.rs
@@ -63,7 +63,7 @@ impl MemoryMap {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FdInfo {
     pub fd: i32,
     pub path: String,

--- a/crates/sandlock-core/src/checkpoint/mod.rs
+++ b/crates/sandlock-core/src/checkpoint/mod.rs
@@ -2,16 +2,16 @@ use serde::{Serialize, Deserialize};
 use std::path::PathBuf;
 use crate::sandbox::Sandbox;
 
-mod capture;
+pub(crate) mod capture;
 mod image;
 mod inject;
 mod regs;
-mod resume;
+pub(crate) mod resume;
 
 pub(crate) use capture::capture;
 
 /// A frozen snapshot of sandbox state.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Checkpoint {
     pub name: String,
     pub policy: Sandbox,
@@ -22,7 +22,7 @@ pub struct Checkpoint {
 }
 
 /// Captured process state via ptrace (registers) + process_vm_readv (memory) + /proc (metadata).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProcessState {
     pub pid: i32,
     pub cwd: String,
@@ -33,13 +33,13 @@ pub struct ProcessState {
     pub memory_data: Vec<MemorySegment>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemorySegment {
     pub start: u64,
     pub data: Vec<u8>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryMap {
     pub start: u64,
     pub end: u64,

--- a/crates/sandlock-core/src/checkpoint/mod.rs
+++ b/crates/sandlock-core/src/checkpoint/mod.rs
@@ -4,6 +4,7 @@ use crate::sandbox::Sandbox;
 
 mod capture;
 mod image;
+mod inject;
 mod regs;
 mod resume;
 

--- a/crates/sandlock-core/src/checkpoint/mod.rs
+++ b/crates/sandlock-core/src/checkpoint/mod.rs
@@ -5,6 +5,7 @@ use crate::sandbox::Sandbox;
 mod capture;
 mod image;
 mod regs;
+mod resume;
 
 pub(crate) use capture::capture;
 

--- a/crates/sandlock-core/src/checkpoint/mod.rs
+++ b/crates/sandlock-core/src/checkpoint/mod.rs
@@ -25,6 +25,7 @@ pub struct ProcessState {
     pub cwd: String,
     pub exe: String,
     pub regs: Vec<u64>,
+    pub fpregs: Vec<u8>,
     pub memory_maps: Vec<MemoryMap>,
     pub memory_data: Vec<MemorySegment>,
 }

--- a/crates/sandlock-core/src/checkpoint/regs.rs
+++ b/crates/sandlock-core/src/checkpoint/regs.rs
@@ -1,0 +1,72 @@
+use std::io;
+
+fn setregset(pid: i32, set: libc::c_int, bytes: &[u8]) -> io::Result<()> {
+    let mut buf = bytes.to_vec();
+    let mut iov = libc::iovec {
+        iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+        iov_len: buf.len(),
+    };
+    let ret = unsafe {
+        libc::ptrace(
+            libc::PTRACE_SETREGSET,
+            pid,
+            set as usize as *mut libc::c_void,
+            &mut iov as *mut libc::iovec as *mut libc::c_void,
+        )
+    };
+    if ret < 0 { return Err(io::Error::last_os_error()); }
+    Ok(())
+}
+
+/// Set the general-purpose register file. `regs` is the Vec<u64> produced by
+/// capture::ptrace_getregs (architecture-specific width).
+pub(crate) fn set_gp_regs(pid: i32, regs: &[u64]) -> io::Result<()> {
+    const NT_PRSTATUS: libc::c_int = 1;
+    let bytes: Vec<u8> = regs.iter().flat_map(|r| r.to_le_bytes()).collect();
+    setregset(pid, NT_PRSTATUS, &bytes)
+}
+
+/// Set the FP/extended register file from the raw blob captured by
+/// capture::ptrace_getfpregs. No-op if the blob is empty.
+// used by the restore path (added in a later change)
+#[allow(dead_code)]
+pub(crate) fn set_fp_regs(pid: i32, blob: &[u8]) -> io::Result<()> {
+    if blob.is_empty() { return Ok(()); }
+    #[cfg(target_arch = "x86_64")]
+    { setregset(pid, 0x202, blob).or_else(|_| setregset(pid, 2, blob)) }
+    #[cfg(not(target_arch = "x86_64"))]
+    { setregset(pid, 2, blob) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn setregset_roundtrips_gp_registers() {
+        use std::os::unix::process::CommandExt;
+        // Donor: capture a register file from a live child.
+        let mut donor = std::process::Command::new("sleep").arg("30").spawn().unwrap();
+        let dpid = donor.id() as i32;
+        super::super::capture::ptrace_seize(dpid).unwrap();
+        let regs = super::super::capture::ptrace_getregs(dpid).unwrap();
+        super::super::capture::ptrace_detach(dpid).unwrap();
+        let _ = donor.kill(); let _ = donor.wait();
+
+        // Target: a child that stops itself for tracing (TRACEME, stops at execve).
+        let mut target = unsafe {
+            std::process::Command::new("sleep").arg("30")
+                .pre_exec(|| { libc::ptrace(libc::PTRACE_TRACEME, 0, 0, 0); Ok(()) })
+                .spawn().unwrap()
+        };
+        let tpid = target.id() as i32;
+        let mut st = 0i32;
+        unsafe { libc::waitpid(tpid, &mut st, 0); } // stop at execve
+
+        set_gp_regs(tpid, &regs).unwrap();
+        let read_back = super::super::capture::ptrace_getregs(tpid).unwrap();
+        let _ = target.kill(); let _ = target.wait();
+
+        assert_eq!(read_back, regs, "GP register file must round-trip through SETREGSET");
+    }
+}

--- a/crates/sandlock-core/src/checkpoint/regs.rs
+++ b/crates/sandlock-core/src/checkpoint/regs.rs
@@ -1,10 +1,9 @@
 use std::io;
 
 fn setregset(pid: i32, set: libc::c_int, bytes: &[u8]) -> io::Result<()> {
-    let mut buf = bytes.to_vec();
     let mut iov = libc::iovec {
-        iov_base: buf.as_mut_ptr() as *mut libc::c_void,
-        iov_len: buf.len(),
+        iov_base: bytes.as_ptr() as *mut libc::c_void,
+        iov_len: bytes.len(),
     };
     let ret = unsafe {
         libc::ptrace(
@@ -20,6 +19,8 @@ fn setregset(pid: i32, set: libc::c_int, bytes: &[u8]) -> io::Result<()> {
 
 /// Set the general-purpose register file. `regs` is the Vec<u64> produced by
 /// capture::ptrace_getregs (architecture-specific width).
+// used by the restore path (added in a later change)
+#[allow(dead_code)]
 pub(crate) fn set_gp_regs(pid: i32, regs: &[u64]) -> io::Result<()> {
     const NT_PRSTATUS: libc::c_int = 1;
     let bytes: Vec<u8> = regs.iter().flat_map(|r| r.to_le_bytes()).collect();

--- a/crates/sandlock-core/src/checkpoint/resume.rs
+++ b/crates/sandlock-core/src/checkpoint/resume.rs
@@ -90,6 +90,10 @@ fn prot_from_perms(perms: &str) -> libc::c_int {
 /// Limitation: file-backed regions are restored `MAP_PRIVATE` from the on-disk
 /// file, so a checkpointed `MAP_SHARED` mapping is restored as private
 /// (documented M1 limitation).
+/// Limitation: transparent restore currently works for vDSO-free programs.
+/// libc/glibc programs that call vDSO functions (e.g. `clock_gettime`) crash
+/// on resume because the vDSO is not yet relocated/restored (known limitation,
+/// next milestone).
 #[cfg(target_arch = "x86_64")]
 pub(crate) fn restore_into(
     pid: i32,
@@ -283,13 +287,21 @@ pub(crate) fn restore_into(
     // sentinel (e.g. -514) in rax and fault. Apply the fixup ourselves so the
     // syscall re-executes cleanly with its arguments still in registers (this is
     // what CRIU does). x86_64 user_regs_struct layout: rax=10, orig_rax=15, rip=16.
+    //
+    // Real restart sentinels: -512 ERESTARTSYS, -513 ERESTARTNOINTR,
+    // -514 ERESTARTNOHAND, -516 ERESTART_RESTARTBLOCK. -515 (ENOIOCTLCMD) is
+    // NOT a restart code and must not be matched. For ERESTART_RESTARTBLOCK
+    // (-516) we re-run orig_rax rather than the kernel restart_syscall path
+    // (restart_block is not captured), so timeout-bearing syscalls restart with
+    // their full original timeout rather than remaining time -- accepted
+    // approximation for fresh-process restore.
     const RAX: usize = 10;
     const ORIG_RAX: usize = 15;
     const RIP: usize = 16;
     let mut regs = cp.process_state.regs.clone();
     if let (Some(&rax), Some(&orig_rax)) = (regs.get(RAX), regs.get(ORIG_RAX)) {
-        // ERESTART_RESTARTBLOCK..=ERESTARTSYS == -516..=-512.
-        if (-516..=-512).contains(&(rax as i64)) {
+        let rax_signed = rax as i64;
+        if matches!(rax_signed, -512 | -513 | -514 | -516) {
             regs[RAX] = orig_rax;
             regs[RIP] = regs[RIP].wrapping_sub(2);
         }
@@ -487,15 +499,18 @@ mod tests {
         let read_regs = read_regs.expect("read stub regs");
         // `restore_into` restores registers verbatim EXCEPT it re-arms an
         // interrupted, restartable syscall: when the checkpoint's rax holds a
-        // restart sentinel (-516..=-512), it reloads rax with orig_rax and
-        // rewinds rip by 2 onto the `syscall` instruction so the call re-executes
-        // cleanly on resume. The donor here is captured in `pause()`, which is
-        // restartable, so apply the same fixup to build the expected register set.
+        // restart sentinel (-512 ERESTARTSYS, -513 ERESTARTNOINTR, -514
+        // ERESTARTNOHAND, -516 ERESTART_RESTARTBLOCK; note -515 ENOIOCTLCMD is
+        // NOT a sentinel), it reloads rax with orig_rax and rewinds rip by 2
+        // onto the `syscall` instruction so the call re-executes cleanly on
+        // resume. The donor here is captured in `pause()`, which is restartable,
+        // so apply the same fixup to build the expected register set.
         let mut expected = cp.process_state.regs.clone();
         const RAX: usize = 10;
         const ORIG_RAX: usize = 15;
         const RIP: usize = 16;
-        if (-516..=-512).contains(&(expected[RAX] as i64)) {
+        let rax_signed = expected[RAX] as i64;
+        if matches!(rax_signed, -512 | -513 | -514 | -516) {
             expected[RAX] = expected[ORIG_RAX];
             expected[RIP] = expected[RIP].wrapping_sub(2);
         }

--- a/crates/sandlock-core/src/checkpoint/resume.rs
+++ b/crates/sandlock-core/src/checkpoint/resume.rs
@@ -1,4 +1,4 @@
-use crate::checkpoint::{FdInfo, MemoryMap, MemorySegment};
+use crate::checkpoint::{Checkpoint, FdInfo, MemoryMap, MemorySegment};
 
 /// One planned memory-restore action for a saved region.
 #[allow(dead_code)] // used by the restore path (added in a later change)
@@ -77,126 +77,191 @@ fn prot_from_perms(perms: &str) -> libc::c_int {
     prot
 }
 
-/// A memory region prepared for restore, with the path pre-converted to a
-/// CString so the post-fork child performs no allocation.
-#[allow(dead_code)] // used by the restore path (added in a later change)
-pub(crate) enum PreparedRegion {
-    /// anonymous: mmap RW|FIXED|PRIVATE|ANON, copy `bytes`, then mprotect to `prot`.
-    Anon { start: u64, len: usize, prot: libc::c_int, bytes: Vec<u8> },
-    /// file-backed: open `path`, mmap `prot`|FIXED|PRIVATE at `offset`, close.
-    File { start: u64, len: usize, prot: libc::c_int, offset: i64, path: std::ffi::CString },
-}
-
-/// An fd prepared for restore (path pre-converted to CString).
-#[allow(dead_code)] // used by the restore path (added in a later change)
-pub(crate) struct PreparedFd {
-    pub fd: i32,
-    pub flags: i32,
-    pub offset: i64,
-    pub path: std::ffi::CString,
-}
-
-/// All restore actions, with every allocation done up front. Build this BEFORE
-/// forking the restore child; the child then calls `apply_prepared_child` which
-/// allocates nothing (only mmap/mprotect/open/close/dup2/lseek/_exit, all
-/// async-signal-safe).
-#[allow(dead_code)] // used by the restore path (added in a later change)
-pub(crate) struct PreparedRestore {
-    pub regions: Vec<PreparedRegion>,
-    pub fds: Vec<PreparedFd>,
-}
-
-/// Convert plans into a PreparedRestore. Runs in the parent before fork.
-/// Returns an error if any path cannot be converted to a CString (contains an
-/// interior NUL); paths from /proc never do, but we fail loud rather than drop.
-#[allow(dead_code)] // used by the restore path (added in a later change)
-pub(crate) fn prepare_restore(
-    plan: &[RestoreRegion],
-    fds: &[FdInfo],
-) -> Result<PreparedRestore, crate::error::SandlockError> {
+/// Reconstruct the process image of `cp` into an already-ptrace-stopped child
+/// `pid` (the calling process must be its tracer; the child must be stopped at
+/// a valid executable rip). Drives the rebuild entirely via ptrace syscall
+/// injection through a trampoline placed in a hole of the CHECKPOINT's layout.
+/// Leaves the child stopped with the saved registers loaded; the caller resumes
+/// it (PTRACE_CONT / detach). Returns the list of non-transparently-restored
+/// resource names (skipped fds) for the caller to log.
+// `restore_into` is only invoked from tests and (later) the OCI restore path
+// (Task 11), so it is dead code in a plain library build.
+#[allow(dead_code)]
+#[cfg(target_arch = "x86_64")]
+pub(crate) fn restore_into(
+    pid: i32,
+    cp: &Checkpoint,
+) -> Result<Vec<String>, crate::error::SandlockError> {
+    use crate::checkpoint::inject;
     use crate::error::{SandboxRuntimeError, SandlockError};
-    let cstr = |s: &str| -> Result<std::ffi::CString, SandlockError> {
-        std::ffi::CString::new(s).map_err(|e| {
-            SandlockError::Runtime(SandboxRuntimeError::Child(format!("bad restore path {s:?}: {e}")))
-        })
-    };
-    let mut regions = Vec::with_capacity(plan.len());
-    for r in plan {
-        match r {
-            RestoreRegion::WriteBytes { start, end, perms, data } => {
-                regions.push(PreparedRegion::Anon {
-                    start: *start,
-                    len: (end - start) as usize,
-                    prot: prot_from_perms(perms),
-                    bytes: data.clone(),
-                });
-            }
-            RestoreRegion::RemapFromFile { start, end, perms, offset, path } => {
-                regions.push(PreparedRegion::File {
-                    start: *start,
-                    len: (end - start) as usize,
-                    prot: prot_from_perms(perms),
-                    offset: *offset as i64,
-                    path: cstr(path)?,
-                });
-            }
-        }
-    }
-    let mut prepared_fds = Vec::with_capacity(fds.len());
-    for f in fds {
-        prepared_fds.push(PreparedFd {
-            fd: f.fd, flags: f.flags, offset: f.offset as i64, path: cstr(&f.path)?,
-        });
-    }
-    Ok(PreparedRestore { regions, fds: prepared_fds })
-}
 
-/// Apply a PreparedRestore inside the post-fork child. ALLOCATION-FREE: only
-/// async-signal-safe syscalls. On ANY failure it `_exit`s with a distinct code
-/// so the supervising parent observes a failed restore.
-///
-/// Exit codes: 101 anon mmap, 105 mprotect, 104 file mmap, 103 file open,
-/// 106 fd open, 108 lseek.
-#[allow(dead_code)] // used by the restore path (added in a later change)
-pub(crate) fn apply_prepared_child(prepared: &PreparedRestore) -> ! {
-    for region in &prepared.regions {
+    // x86_64 syscall numbers used by the rebuild.
+    const MMAP: u64 = 9;
+    const MPROTECT: u64 = 10;
+    const OPEN: u64 = 2;
+    const CLOSE: u64 = 3;
+    const LSEEK: u64 = 8;
+    const DUP2: u64 = 33;
+
+    // Build SandlockError::Runtime(Child(..)) the same way capture.rs does.
+    let err = |msg: String| SandlockError::Runtime(SandboxRuntimeError::Child(msg));
+
+    let plan = build_memory_plan(&cp.process_state.memory_maps, &cp.process_state.memory_data);
+    let (restorable_fds, skipped) = build_fd_plan(&cp.fd_table);
+
+    // CONTRACT: pass the CHECKPOINT's maps so the trampoline lands in a hole of
+    // the TARGET layout. That hole is, by construction, never a restored region,
+    // so no mmap below can ever clobber the trampoline page.
+    let tramp = inject::setup_trampoline(pid, &cp.process_state.memory_maps)
+        .map_err(|e| err(format!("restore setup trampoline: {e}")))?;
+
+    // Scratch area for NUL-terminated path strings. The 2-byte gadget lives at
+    // `tramp`; the rest of the RWX page (4096 bytes) is free for scratch.
+    let scratch = tramp + 64;
+    const SCRATCH_MAX: usize = 4096 - 64;
+    let write_path = |path: &str| -> Result<(), SandlockError> {
+        let mut p = path.as_bytes().to_vec();
+        p.push(0);
+        if p.len() > SCRATCH_MAX {
+            return Err(err("restore path too long for scratch".into()));
+        }
+        inject::write_child_mem(pid, scratch, &p)
+            .map_err(|e| err(format!("restore write path {path}: {e}")))
+    };
+
+    // Rebuild every planned memory region. Invariant: none of these regions is
+    // the trampoline page -- the trampoline sits in a hole of cp.memory_maps,
+    // a region that does not exist in the checkpoint, so it is never restored.
+    for region in &plan {
         match region {
-            PreparedRegion::Anon { start, len, prot, bytes } => {
-                let p = unsafe {
-                    libc::mmap(*start as *mut libc::c_void, *len,
-                        libc::PROT_READ | libc::PROT_WRITE,
-                        libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_FIXED, -1, 0)
-                };
-                if p == libc::MAP_FAILED { unsafe { libc::_exit(101); } }
-                let n = core::cmp::min(bytes.len(), *len);
-                unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr(), *start as *mut u8, n); }
-                if unsafe { libc::mprotect(*start as *mut libc::c_void, *len, *prot) } != 0 {
-                    unsafe { libc::_exit(105); }
+            RestoreRegion::WriteBytes { start, end, perms, data } => {
+                let len = (end - start) as usize;
+                let r = inject::inject_syscall_at(
+                    pid,
+                    tramp,
+                    MMAP,
+                    [
+                        *start,
+                        len as u64,
+                        (libc::PROT_READ | libc::PROT_WRITE) as u64,
+                        (libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_FIXED) as u64,
+                        (-1i64) as u64,
+                        0,
+                    ],
+                )
+                .map_err(|e| err(format!("restore anon mmap at {start:#x}: {e}")))?;
+                if r as u64 != *start {
+                    return Err(err(format!("restore anon mmap at {start:#x} -> {r:#x}")));
+                }
+                let n = data.len().min(len);
+                inject::write_child_mem(pid, *start, &data[..n])
+                    .map_err(|e| err(format!("restore write bytes at {start:#x}: {e}")))?;
+                let prot = prot_from_perms(perms);
+                if prot != (libc::PROT_READ | libc::PROT_WRITE) {
+                    let m = inject::inject_syscall_at(
+                        pid,
+                        tramp,
+                        MPROTECT,
+                        [*start, len as u64, prot as u64, 0, 0, 0],
+                    )
+                    .map_err(|e| err(format!("restore mprotect {start:#x}: {e}")))?;
+                    if m != 0 {
+                        return Err(err(format!("restore mprotect {start:#x}")));
+                    }
                 }
             }
-            PreparedRegion::File { start, len, prot, offset, path } => {
-                let fd = unsafe { libc::open(path.as_ptr(), libc::O_RDONLY) };
-                if fd < 0 { unsafe { libc::_exit(103); } }
-                let p = unsafe {
-                    libc::mmap(*start as *mut libc::c_void, *len, *prot,
-                        libc::MAP_PRIVATE | libc::MAP_FIXED, fd, *offset)
-                };
-                unsafe { libc::close(fd); }
-                if p == libc::MAP_FAILED { unsafe { libc::_exit(104); } }
+            RestoreRegion::RemapFromFile { start, end, perms, offset, path } => {
+                let len = (end - start) as usize;
+                let prot = prot_from_perms(perms);
+                write_path(path)?;
+                let fd = inject::inject_syscall_at(
+                    pid,
+                    tramp,
+                    OPEN,
+                    [scratch, libc::O_RDONLY as u64, 0, 0, 0, 0],
+                )
+                .map_err(|e| err(format!("restore open {path}: {e}")))?;
+                if fd < 0 {
+                    return Err(err(format!("restore open {path} -> {fd}")));
+                }
+                let r = inject::inject_syscall_at(
+                    pid,
+                    tramp,
+                    MMAP,
+                    [
+                        *start,
+                        len as u64,
+                        prot as u64,
+                        (libc::MAP_PRIVATE | libc::MAP_FIXED) as u64,
+                        fd as u64,
+                        *offset,
+                    ],
+                )
+                .map_err(|e| err(format!("restore file mmap at {start:#x}: {e}")))?;
+                if r as u64 != *start {
+                    return Err(err(format!("restore file mmap at {start:#x} -> {r:#x}")));
+                }
+                inject::inject_syscall_at(pid, tramp, CLOSE, [fd as u64, 0, 0, 0, 0, 0])
+                    .map_err(|e| err(format!("restore close fd {fd}: {e}")))?;
             }
         }
     }
-    for f in &prepared.fds {
-        let opened = unsafe { libc::open(f.path.as_ptr(), f.flags) };
-        if opened < 0 { unsafe { libc::_exit(106); } }
-        if opened != f.fd {
-            unsafe { libc::dup2(opened, f.fd); libc::close(opened); }
+
+    // Reopen transparently restorable fds at their saved numbers/offsets.
+    for f in &restorable_fds {
+        write_path(&f.path)?;
+        let opened = inject::inject_syscall_at(
+            pid,
+            tramp,
+            OPEN,
+            [scratch, f.flags as u64, 0, 0, 0, 0],
+        )
+        .map_err(|e| err(format!("restore fd open {}: {e}", f.path)))?;
+        if opened < 0 {
+            return Err(err(format!("restore fd open {} -> {opened}", f.path)));
         }
-        if unsafe { libc::lseek(f.fd, f.offset, libc::SEEK_SET) } < 0 {
-            unsafe { libc::_exit(108); }
+        if opened as i32 != f.fd {
+            // dup2 may clobber an inherited stub fd at this number; that is
+            // acceptable -- inherited stub fds are disposable. Documented M1
+            // limitation, alongside the W^X trampoline constraint.
+            inject::inject_syscall_at(pid, tramp, DUP2, [opened as u64, f.fd as u64, 0, 0, 0, 0])
+                .map_err(|e| err(format!("restore dup2 {opened}->{}: {e}", f.fd)))?;
+            inject::inject_syscall_at(pid, tramp, CLOSE, [opened as u64, 0, 0, 0, 0, 0])
+                .map_err(|e| err(format!("restore close dup src {opened}: {e}")))?;
+        }
+        let ls = inject::inject_syscall_at(
+            pid,
+            tramp,
+            LSEEK,
+            [f.fd as u64, f.offset, libc::SEEK_SET as u64, 0, 0, 0],
+        )
+        .map_err(|e| err(format!("restore lseek fd {}: {e}", f.fd)))?;
+        if ls < 0 {
+            return Err(err(format!("restore lseek fd {}", f.fd)));
         }
     }
-    unsafe { libc::_exit(0); }
+
+    // Registers last: load the saved FP then GP register files. After this the
+    // child is stopped exactly at the checkpoint's execution point.
+    crate::checkpoint::regs::set_fp_regs(pid, &cp.process_state.fpregs)
+        .map_err(|e| err(format!("restore set fp regs: {e}")))?;
+    crate::checkpoint::regs::set_gp_regs(pid, &cp.process_state.regs)
+        .map_err(|e| err(format!("restore set gp regs: {e}")))?;
+
+    Ok(skipped)
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+#[allow(dead_code)]
+pub(crate) fn restore_into(
+    _pid: i32,
+    _cp: &Checkpoint,
+) -> Result<Vec<String>, crate::error::SandlockError> {
+    Err(crate::error::SandlockError::Runtime(
+        crate::error::SandboxRuntimeError::Child(
+            "injection-based restore is only implemented on x86_64".into(),
+        ),
+    ))
 }
 
 #[cfg(test)]
@@ -250,23 +315,122 @@ mod tests {
         assert_eq!(plan.len(), 2, "special regions are skipped, not planned");
     }
 
+    /// End-to-end proof of the injection-based rebuild: capture a donor's known
+    /// page + registers, then drive `restore_into` against a fresh stub and read
+    /// BOTH back from the still-stopped stub before resuming it. No Landlock and
+    /// no resume are needed -- the read-back alone proves mmap + writev (memory)
+    /// and SETREGSET (registers) flowed through the trampoline correctly.
     #[test]
-    fn child_restore_applies_plan_exit_zero() {
-        let addr: u64 = 0x4000_0000;
-        let plan = vec![RestoreRegion::WriteBytes {
-            start: addr, end: addr + 4096, perms: "rw-p".into(), data: vec![0xABu8; 4096],
-        }];
-        let prepared = prepare_restore(&plan, &[]).expect("prepare");
-        let pid = unsafe { libc::fork() };
-        if pid == 0 {
-            apply_prepared_child(&prepared); // never returns; _exit(0) on success
+    #[cfg(target_arch = "x86_64")]
+    fn restore_into_reconstructs_memory_and_regs() {
+        const DON: u64 = 0x4500_0000_0000;
+        const PAT: u8 = 0xC7;
+
+        // Donor: raw-libc child that maps a known page at a fixed hole, fills it
+        // with a recognizable pattern, then pauses forever. No allocation/panic.
+        let donor = unsafe { libc::fork() };
+        if donor == 0 {
+            unsafe {
+                let p = libc::mmap(
+                    DON as *mut libc::c_void,
+                    4096,
+                    libc::PROT_READ | libc::PROT_WRITE,
+                    libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_FIXED,
+                    -1,
+                    0,
+                );
+                if p != DON as *mut libc::c_void {
+                    libc::_exit(1);
+                }
+                let mut i = 0usize;
+                while i < 4096 {
+                    *(DON as *mut u8).add(i) = PAT;
+                    i += 1;
+                }
+                loop {
+                    libc::pause();
+                }
+            }
         }
+        assert!(donor > 0, "fork donor");
+        // Let the donor finish its mmap+fill before we seize it.
+        unsafe {
+            libc::usleep(50_000);
+        }
+
+        let policy = crate::Sandbox::builder().build().unwrap();
+        let cp = crate::checkpoint::capture::capture(donor as i32, &policy).expect("capture");
+
+        // The donor is no longer needed; capture already detached.
+        unsafe {
+            libc::kill(donor, libc::SIGKILL);
+            let mut s = 0;
+            libc::waitpid(donor, &mut s, 0);
+        }
+
+        // Sanity: the donor's page was captured with our pattern. If not, the
+        // test setup -- not restore_into -- is wrong.
+        let seg = cp
+            .process_state
+            .memory_data
+            .iter()
+            .find(|s| s.start == DON)
+            .expect("donor DON page must be captured");
+        assert!(
+            seg.data.len() >= 4096 && seg.data[..4096].iter().all(|&b| b == PAT),
+            "captured DON page must be all 0x{PAT:02x}"
+        );
+
+        // Stub: a traceable child that stops and is never continued. The test
+        // process becomes its tracer via PTRACE_TRACEME.
+        let stub = unsafe { libc::fork() };
+        if stub == 0 {
+            unsafe {
+                libc::ptrace(libc::PTRACE_TRACEME, 0, 0, 0);
+                libc::raise(libc::SIGSTOP);
+                libc::_exit(0); // only reached if continued, which we never do
+            }
+        }
+        assert!(stub > 0, "fork stub");
         let mut st = 0i32;
-        unsafe { libc::waitpid(pid, &mut st, 0); }
-        // Decode wait status manually: low 7 bits 0 means exited normally.
-        let exited = (st & 0x7f) == 0;
-        let code = (st >> 8) & 0xff;
-        assert!(exited, "restore child should have exited normally; raw status {st:#x}");
-        assert_eq!(code, 0, "restore child should exit 0; got exit code {code}");
+        unsafe {
+            libc::waitpid(stub, &mut st, 0);
+        } // catch the SIGSTOP-stop
+
+        let _skipped = restore_into(stub, &cp).expect("restore_into");
+
+        // Read the restored DON page back out of the still-stopped stub.
+        let mut buf = vec![0u8; 4096];
+        let local = libc::iovec {
+            iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+            iov_len: 4096,
+        };
+        let remote = libc::iovec {
+            iov_base: DON as *mut libc::c_void,
+            iov_len: 4096,
+        };
+        let n = unsafe { libc::process_vm_readv(stub, &local, 1, &remote, 1, 0) };
+
+        // Read the restored GP register file back out of the stub.
+        let read_regs = crate::checkpoint::capture::ptrace_getregs(stub);
+
+        // Reap the stub before asserting so a failed assert never leaks it.
+        unsafe {
+            libc::kill(stub, libc::SIGKILL);
+            let mut s = 0;
+            libc::waitpid(stub, &mut s, 0);
+        }
+
+        assert_eq!(n, 4096, "process_vm_readv of restored DON page");
+        assert!(
+            buf.iter().all(|&b| b == PAT),
+            "restored DON page must be all 0x{PAT:02x}"
+        );
+
+        let read_regs = read_regs.expect("read stub regs");
+        assert_eq!(
+            read_regs, cp.process_state.regs,
+            "restored GP registers must match the checkpoint exactly"
+        );
     }
 }

--- a/crates/sandlock-core/src/checkpoint/resume.rs
+++ b/crates/sandlock-core/src/checkpoint/resume.rs
@@ -1,4 +1,4 @@
-use crate::checkpoint::{MemoryMap, MemorySegment};
+use crate::checkpoint::{FdInfo, MemoryMap, MemorySegment};
 
 /// One planned memory-restore action for a saved region.
 #[allow(dead_code)] // used by the restore path (added in a later change)
@@ -39,10 +39,41 @@ pub(crate) fn build_memory_plan(
     plan
 }
 
+/// Split the saved fd table into transparently restorable regular files and a
+/// list of skipped non-regular fds (sockets, pipes, eventfd, ...). The skipped
+/// list is logged by the caller; those resources fall to the app_state hatch.
+#[allow(dead_code)] // used by the restore path (added in a later change)
+pub(crate) fn build_fd_plan(fds: &[FdInfo]) -> (Vec<FdInfo>, Vec<String>) {
+    let mut restorable = Vec::new();
+    let mut skipped = Vec::new();
+    for f in fds {
+        if f.path.starts_with('/') {
+            restorable.push(f.clone());
+        } else {
+            skipped.push(f.path.clone());
+        }
+    }
+    (restorable, skipped)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::checkpoint::{MemoryMap, MemorySegment};
+
+    #[test]
+    fn fd_plan_keeps_regular_files_only() {
+        use crate::checkpoint::FdInfo;
+        let fds = vec![
+            FdInfo { fd: 3, path: "/etc/hostname".into(), flags: 0, offset: 5 },
+            FdInfo { fd: 4, path: "socket:[12345]".into(), flags: 0, offset: 0 },
+            FdInfo { fd: 5, path: "pipe:[6789]".into(), flags: 0, offset: 0 },
+        ];
+        let (restorable, skipped) = build_fd_plan(&fds);
+        assert_eq!(restorable.len(), 1);
+        assert_eq!(restorable[0].fd, 3);
+        assert_eq!(skipped, vec!["socket:[12345]".to_string(), "pipe:[6789]".to_string()]);
+    }
 
     #[test]
     fn plan_classifies_regions() {

--- a/crates/sandlock-core/src/checkpoint/resume.rs
+++ b/crates/sandlock-core/src/checkpoint/resume.rs
@@ -67,59 +67,6 @@ pub(crate) fn build_fd_plan(fds: &[FdInfo]) -> (Vec<FdInfo>, Vec<String>) {
     (restorable, skipped)
 }
 
-/// Apply the memory plan inside the restore child. Runs post-fork using only
-/// raw libc. `fds` reopens regular files onto their saved fd numbers. On any
-/// failure the child _exits with a distinct nonzero code so the supervising
-/// parent observes a failed restore.
-#[allow(dead_code)] // used by the restore path (added in a later change)
-pub(crate) fn apply_memory_plan_child(plan: &[RestoreRegion], fds: &[FdInfo]) {
-    for region in plan {
-        match region {
-            RestoreRegion::WriteBytes { start, end, perms, data } => {
-                let len = (end - start) as usize;
-                let prot = prot_from_perms(perms);
-                let p = unsafe {
-                    libc::mmap(*start as *mut libc::c_void, len,
-                        libc::PROT_READ | libc::PROT_WRITE,
-                        libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_FIXED, -1, 0)
-                };
-                if p == libc::MAP_FAILED { unsafe { libc::_exit(101); } }
-                unsafe {
-                    std::ptr::copy_nonoverlapping(data.as_ptr(), *start as *mut u8, data.len());
-                    // Re-apply the recorded protection (e.g. drop +w if the region was read-only).
-                    libc::mprotect(*start as *mut libc::c_void, len, prot);
-                }
-            }
-            RestoreRegion::RemapFromFile { start, end, perms, offset, path } => {
-                let len = (end - start) as usize;
-                let prot = prot_from_perms(perms);
-                let cpath = match std::ffi::CString::new(path.as_str()) {
-                    Ok(c) => c, Err(_) => unsafe { libc::_exit(102) },
-                };
-                let fd = unsafe { libc::open(cpath.as_ptr(), libc::O_RDONLY) };
-                if fd < 0 { unsafe { libc::_exit(103); } }
-                let p = unsafe {
-                    libc::mmap(*start as *mut libc::c_void, len, prot,
-                        libc::MAP_PRIVATE | libc::MAP_FIXED, fd, *offset as libc::off_t)
-                };
-                unsafe { libc::close(fd); }
-                if p == libc::MAP_FAILED { unsafe { libc::_exit(104); } }
-            }
-        }
-    }
-    for f in fds {
-        let cpath = match std::ffi::CString::new(f.path.as_str()) {
-            Ok(c) => c, Err(_) => continue,
-        };
-        let opened = unsafe { libc::open(cpath.as_ptr(), f.flags) };
-        if opened < 0 { continue; }
-        if opened != f.fd {
-            unsafe { libc::dup2(opened, f.fd); libc::close(opened); }
-        }
-        unsafe { libc::lseek(f.fd, f.offset as libc::off_t, libc::SEEK_SET); }
-    }
-}
-
 #[allow(dead_code)] // used by the restore path (added in a later change)
 fn prot_from_perms(perms: &str) -> libc::c_int {
     let mut prot = 0;
@@ -128,6 +75,128 @@ fn prot_from_perms(perms: &str) -> libc::c_int {
     if perms.as_bytes().get(2) == Some(&b'x') { prot |= libc::PROT_EXEC; }
     if prot == 0 { prot = libc::PROT_NONE; }
     prot
+}
+
+/// A memory region prepared for restore, with the path pre-converted to a
+/// CString so the post-fork child performs no allocation.
+#[allow(dead_code)] // used by the restore path (added in a later change)
+pub(crate) enum PreparedRegion {
+    /// anonymous: mmap RW|FIXED|PRIVATE|ANON, copy `bytes`, then mprotect to `prot`.
+    Anon { start: u64, len: usize, prot: libc::c_int, bytes: Vec<u8> },
+    /// file-backed: open `path`, mmap `prot`|FIXED|PRIVATE at `offset`, close.
+    File { start: u64, len: usize, prot: libc::c_int, offset: i64, path: std::ffi::CString },
+}
+
+/// An fd prepared for restore (path pre-converted to CString).
+#[allow(dead_code)] // used by the restore path (added in a later change)
+pub(crate) struct PreparedFd {
+    pub fd: i32,
+    pub flags: i32,
+    pub offset: i64,
+    pub path: std::ffi::CString,
+}
+
+/// All restore actions, with every allocation done up front. Build this BEFORE
+/// forking the restore child; the child then calls `apply_prepared_child` which
+/// allocates nothing (only mmap/mprotect/open/close/dup2/lseek/_exit, all
+/// async-signal-safe).
+#[allow(dead_code)] // used by the restore path (added in a later change)
+pub(crate) struct PreparedRestore {
+    pub regions: Vec<PreparedRegion>,
+    pub fds: Vec<PreparedFd>,
+}
+
+/// Convert plans into a PreparedRestore. Runs in the parent before fork.
+/// Returns an error if any path cannot be converted to a CString (contains an
+/// interior NUL); paths from /proc never do, but we fail loud rather than drop.
+#[allow(dead_code)] // used by the restore path (added in a later change)
+pub(crate) fn prepare_restore(
+    plan: &[RestoreRegion],
+    fds: &[FdInfo],
+) -> Result<PreparedRestore, crate::error::SandlockError> {
+    use crate::error::{SandboxRuntimeError, SandlockError};
+    let cstr = |s: &str| -> Result<std::ffi::CString, SandlockError> {
+        std::ffi::CString::new(s).map_err(|e| {
+            SandlockError::Runtime(SandboxRuntimeError::Child(format!("bad restore path {s:?}: {e}")))
+        })
+    };
+    let mut regions = Vec::with_capacity(plan.len());
+    for r in plan {
+        match r {
+            RestoreRegion::WriteBytes { start, end, perms, data } => {
+                regions.push(PreparedRegion::Anon {
+                    start: *start,
+                    len: (end - start) as usize,
+                    prot: prot_from_perms(perms),
+                    bytes: data.clone(),
+                });
+            }
+            RestoreRegion::RemapFromFile { start, end, perms, offset, path } => {
+                regions.push(PreparedRegion::File {
+                    start: *start,
+                    len: (end - start) as usize,
+                    prot: prot_from_perms(perms),
+                    offset: *offset as i64,
+                    path: cstr(path)?,
+                });
+            }
+        }
+    }
+    let mut prepared_fds = Vec::with_capacity(fds.len());
+    for f in fds {
+        prepared_fds.push(PreparedFd {
+            fd: f.fd, flags: f.flags, offset: f.offset as i64, path: cstr(&f.path)?,
+        });
+    }
+    Ok(PreparedRestore { regions, fds: prepared_fds })
+}
+
+/// Apply a PreparedRestore inside the post-fork child. ALLOCATION-FREE: only
+/// async-signal-safe syscalls. On ANY failure it `_exit`s with a distinct code
+/// so the supervising parent observes a failed restore.
+///
+/// Exit codes: 101 anon mmap, 105 mprotect, 104 file mmap, 103 file open,
+/// 106 fd open, 108 lseek.
+#[allow(dead_code)] // used by the restore path (added in a later change)
+pub(crate) fn apply_prepared_child(prepared: &PreparedRestore) -> ! {
+    for region in &prepared.regions {
+        match region {
+            PreparedRegion::Anon { start, len, prot, bytes } => {
+                let p = unsafe {
+                    libc::mmap(*start as *mut libc::c_void, *len,
+                        libc::PROT_READ | libc::PROT_WRITE,
+                        libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_FIXED, -1, 0)
+                };
+                if p == libc::MAP_FAILED { unsafe { libc::_exit(101); } }
+                let n = core::cmp::min(bytes.len(), *len);
+                unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr(), *start as *mut u8, n); }
+                if unsafe { libc::mprotect(*start as *mut libc::c_void, *len, *prot) } != 0 {
+                    unsafe { libc::_exit(105); }
+                }
+            }
+            PreparedRegion::File { start, len, prot, offset, path } => {
+                let fd = unsafe { libc::open(path.as_ptr(), libc::O_RDONLY) };
+                if fd < 0 { unsafe { libc::_exit(103); } }
+                let p = unsafe {
+                    libc::mmap(*start as *mut libc::c_void, *len, *prot,
+                        libc::MAP_PRIVATE | libc::MAP_FIXED, fd, *offset)
+                };
+                unsafe { libc::close(fd); }
+                if p == libc::MAP_FAILED { unsafe { libc::_exit(104); } }
+            }
+        }
+    }
+    for f in &prepared.fds {
+        let opened = unsafe { libc::open(f.path.as_ptr(), f.flags) };
+        if opened < 0 { unsafe { libc::_exit(106); } }
+        if opened != f.fd {
+            unsafe { libc::dup2(opened, f.fd); libc::close(opened); }
+        }
+        if unsafe { libc::lseek(f.fd, f.offset, libc::SEEK_SET) } < 0 {
+            unsafe { libc::_exit(108); }
+        }
+    }
+    unsafe { libc::_exit(0); }
 }
 
 #[cfg(test)]
@@ -182,27 +251,22 @@ mod tests {
     }
 
     #[test]
-    fn child_restore_maps_anon_page() {
+    fn child_restore_applies_plan_exit_zero() {
         let addr: u64 = 0x4000_0000;
         let plan = vec![RestoreRegion::WriteBytes {
             start: addr, end: addr + 4096, perms: "rw-p".into(), data: vec![0xABu8; 4096],
         }];
-
+        let prepared = prepare_restore(&plan, &[]).expect("prepare");
         let pid = unsafe { libc::fork() };
         if pid == 0 {
-            // Child: apply the plan, then SIGSTOP so the parent can inspect.
-            apply_memory_plan_child(&plan, &[]);
-            unsafe { libc::raise(libc::SIGSTOP); libc::_exit(0); }
+            apply_prepared_child(&prepared); // never returns; _exit(0) on success
         }
-        // Parent: wait for the stop, read the page back, then kill.
         let mut st = 0i32;
-        unsafe { libc::waitpid(pid, &mut st, libc::WUNTRACED); }
-        let mut buf = vec![0u8; 4096];
-        let local = libc::iovec { iov_base: buf.as_mut_ptr() as *mut _, iov_len: 4096 };
-        let remote = libc::iovec { iov_base: addr as *mut _, iov_len: 4096 };
-        let n = unsafe { libc::process_vm_readv(pid, &local, 1, &remote, 1, 0) };
-        unsafe { libc::kill(pid, libc::SIGKILL); libc::waitpid(pid, &mut st, 0); }
-        assert_eq!(n, 4096);
-        assert!(buf.iter().all(|&b| b == 0xAB), "anon page pattern must be restored");
+        unsafe { libc::waitpid(pid, &mut st, 0); }
+        // Decode wait status manually: low 7 bits 0 means exited normally.
+        let exited = (st & 0x7f) == 0;
+        let code = (st >> 8) & 0xff;
+        assert!(exited, "restore child should have exited normally; raw status {st:#x}");
+        assert_eq!(code, 0, "restore child should exit 0; got exit code {code}");
     }
 }

--- a/crates/sandlock-core/src/checkpoint/resume.rs
+++ b/crates/sandlock-core/src/checkpoint/resume.rs
@@ -1,7 +1,6 @@
 use crate::checkpoint::{Checkpoint, FdInfo, MemoryMap, MemorySegment};
 
 /// One planned memory-restore action for a saved region.
-#[allow(dead_code)] // used by the restore path (added in a later change)
 #[derive(Debug)]
 pub(crate) enum RestoreRegion {
     /// mmap MAP_FIXED from `path` at `offset`, prot from `perms`.
@@ -15,7 +14,6 @@ pub(crate) enum RestoreRegion {
 /// fresh process and they must not be overwritten. A region with captured
 /// bytes becomes WriteBytes; otherwise a path-backed region becomes
 /// RemapFromFile. Regions that are neither are left to the kernel/ABI.
-#[allow(dead_code)] // used by the restore path (added in a later change)
 pub(crate) fn build_memory_plan(
     maps: &[MemoryMap],
     data: &[MemorySegment],
@@ -58,7 +56,6 @@ fn is_restorable_file_path(path: &str) -> bool {
 /// list is logged by the caller; those resources fall to the app_state hatch.
 /// memfd, "(deleted)", and pseudo-filesystem (/proc/, /sys/, /dev/) paths start
 /// with '/' but are not transparently reopenable, so they are skipped.
-#[allow(dead_code)] // used by the restore path (added in a later change)
 pub(crate) fn build_fd_plan(fds: &[FdInfo]) -> (Vec<FdInfo>, Vec<String>) {
     let mut restorable = Vec::new();
     let mut skipped = Vec::new();
@@ -72,7 +69,6 @@ pub(crate) fn build_fd_plan(fds: &[FdInfo]) -> (Vec<FdInfo>, Vec<String>) {
     (restorable, skipped)
 }
 
-#[allow(dead_code)] // used by the restore path (added in a later change)
 fn prot_from_perms(perms: &str) -> libc::c_int {
     let mut prot = 0;
     if perms.as_bytes().first() == Some(&b'r') { prot |= libc::PROT_READ; }
@@ -94,9 +90,6 @@ fn prot_from_perms(perms: &str) -> libc::c_int {
 /// Limitation: file-backed regions are restored `MAP_PRIVATE` from the on-disk
 /// file, so a checkpointed `MAP_SHARED` mapping is restored as private
 /// (documented M1 limitation).
-// `restore_into` is only invoked from tests and (later) the OCI restore path
-// (Task 11), so it is dead code in a plain library build.
-#[allow(dead_code)]
 #[cfg(target_arch = "x86_64")]
 pub(crate) fn restore_into(
     pid: i32,
@@ -276,14 +269,38 @@ pub(crate) fn restore_into(
     // child is stopped exactly at the checkpoint's execution point.
     crate::checkpoint::regs::set_fp_regs(pid, &cp.process_state.fpregs)
         .map_err(|e| err(format!("restore set fp regs: {e}")))?;
-    crate::checkpoint::regs::set_gp_regs(pid, &cp.process_state.regs)
+
+    // Re-arm an interrupted, restartable syscall. When the checkpoint was taken
+    // (via PTRACE_INTERRUPT) while the process sat in a syscall, the kernel
+    // aborted it with a restart sentinel in rax (-ERESTARTSYS/-ERESTARTNOINTR/
+    // -ERESTARTNOHAND/-ERESTART_RESTARTBLOCK). At the ptrace stop, rip still
+    // points just PAST the `syscall` instruction (it equals rcx, the return
+    // address the CPU latched when `syscall` executed). The kernel's restart
+    // fixup -- rewind rip onto the 2-byte `syscall` instruction and reload rax
+    // with the original syscall number -- normally runs on the syscall-return /
+    // signal-delivery path, which a plain restore + detach bypasses. Without it,
+    // userspace would resume one instruction past the syscall with the raw
+    // sentinel (e.g. -514) in rax and fault. Apply the fixup ourselves so the
+    // syscall re-executes cleanly with its arguments still in registers (this is
+    // what CRIU does). x86_64 user_regs_struct layout: rax=10, orig_rax=15, rip=16.
+    const RAX: usize = 10;
+    const ORIG_RAX: usize = 15;
+    const RIP: usize = 16;
+    let mut regs = cp.process_state.regs.clone();
+    if let (Some(&rax), Some(&orig_rax)) = (regs.get(RAX), regs.get(ORIG_RAX)) {
+        // ERESTART_RESTARTBLOCK..=ERESTARTSYS == -516..=-512.
+        if (-516..=-512).contains(&(rax as i64)) {
+            regs[RAX] = orig_rax;
+            regs[RIP] = regs[RIP].wrapping_sub(2);
+        }
+    }
+    crate::checkpoint::regs::set_gp_regs(pid, &regs)
         .map_err(|e| err(format!("restore set gp regs: {e}")))?;
 
     Ok(skipped)
 }
 
 #[cfg(not(target_arch = "x86_64"))]
-#[allow(dead_code)]
 pub(crate) fn restore_into(
     _pid: i32,
     _cp: &Checkpoint,
@@ -468,9 +485,23 @@ mod tests {
         );
 
         let read_regs = read_regs.expect("read stub regs");
+        // `restore_into` restores registers verbatim EXCEPT it re-arms an
+        // interrupted, restartable syscall: when the checkpoint's rax holds a
+        // restart sentinel (-516..=-512), it reloads rax with orig_rax and
+        // rewinds rip by 2 onto the `syscall` instruction so the call re-executes
+        // cleanly on resume. The donor here is captured in `pause()`, which is
+        // restartable, so apply the same fixup to build the expected register set.
+        let mut expected = cp.process_state.regs.clone();
+        const RAX: usize = 10;
+        const ORIG_RAX: usize = 15;
+        const RIP: usize = 16;
+        if (-516..=-512).contains(&(expected[RAX] as i64)) {
+            expected[RAX] = expected[ORIG_RAX];
+            expected[RIP] = expected[RIP].wrapping_sub(2);
+        }
         assert_eq!(
-            read_regs, cp.process_state.regs,
-            "restored GP registers must match the checkpoint exactly"
+            read_regs, expected,
+            "restored GP registers must match the checkpoint (with syscall-restart re-arm)"
         );
     }
 }

--- a/crates/sandlock-core/src/checkpoint/resume.rs
+++ b/crates/sandlock-core/src/checkpoint/resume.rs
@@ -39,15 +39,26 @@ pub(crate) fn build_memory_plan(
     plan
 }
 
+/// Return true only for paths that refer to a reopenable regular file.
+/// memfd and "(deleted)" paths start with '/' but are not reopenable, so they
+/// are skipped.
+fn is_restorable_file_path(path: &str) -> bool {
+    path.starts_with('/')
+        && !path.starts_with("/memfd:")
+        && !path.ends_with(" (deleted)")
+}
+
 /// Split the saved fd table into transparently restorable regular files and a
 /// list of skipped non-regular fds (sockets, pipes, eventfd, ...). The skipped
 /// list is logged by the caller; those resources fall to the app_state hatch.
+/// memfd and "(deleted)" paths start with '/' but are not reopenable, so they
+/// are skipped.
 #[allow(dead_code)] // used by the restore path (added in a later change)
 pub(crate) fn build_fd_plan(fds: &[FdInfo]) -> (Vec<FdInfo>, Vec<String>) {
     let mut restorable = Vec::new();
     let mut skipped = Vec::new();
     for f in fds {
-        if f.path.starts_with('/') {
+        if is_restorable_file_path(&f.path) {
             restorable.push(f.clone());
         } else {
             skipped.push(f.path.clone());
@@ -59,11 +70,10 @@ pub(crate) fn build_fd_plan(fds: &[FdInfo]) -> (Vec<FdInfo>, Vec<String>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::checkpoint::{MemoryMap, MemorySegment};
+    use crate::checkpoint::{FdInfo, MemoryMap, MemorySegment};
 
     #[test]
     fn fd_plan_keeps_regular_files_only() {
-        use crate::checkpoint::FdInfo;
         let fds = vec![
             FdInfo { fd: 3, path: "/etc/hostname".into(), flags: 0, offset: 5 },
             FdInfo { fd: 4, path: "socket:[12345]".into(), flags: 0, offset: 0 },
@@ -73,6 +83,22 @@ mod tests {
         assert_eq!(restorable.len(), 1);
         assert_eq!(restorable[0].fd, 3);
         assert_eq!(skipped, vec!["socket:[12345]".to_string(), "pipe:[6789]".to_string()]);
+    }
+
+    #[test]
+    fn fd_plan_skips_deleted_and_memfd() {
+        let fds = vec![
+            FdInfo { fd: 3, path: "/etc/hostname".into(), flags: 0, offset: 5 },
+            FdInfo { fd: 6, path: "/tmp/gone (deleted)".into(), flags: 0, offset: 0 },
+            FdInfo { fd: 7, path: "/memfd:scratch (deleted)".into(), flags: 0, offset: 0 },
+        ];
+        let (restorable, skipped) = build_fd_plan(&fds);
+        assert_eq!(restorable.len(), 1);
+        assert_eq!(restorable[0].fd, 3);
+        assert!(restorable.iter().all(|f| f.fd != 6 && f.fd != 7),
+            "deleted and memfd fds must not appear in restorable");
+        assert!(skipped.contains(&"/tmp/gone (deleted)".to_string()));
+        assert!(skipped.contains(&"/memfd:scratch (deleted)".to_string()));
     }
 
     #[test]

--- a/crates/sandlock-core/src/checkpoint/resume.rs
+++ b/crates/sandlock-core/src/checkpoint/resume.rs
@@ -67,6 +67,69 @@ pub(crate) fn build_fd_plan(fds: &[FdInfo]) -> (Vec<FdInfo>, Vec<String>) {
     (restorable, skipped)
 }
 
+/// Apply the memory plan inside the restore child. Runs post-fork using only
+/// raw libc. `fds` reopens regular files onto their saved fd numbers. On any
+/// failure the child _exits with a distinct nonzero code so the supervising
+/// parent observes a failed restore.
+#[allow(dead_code)] // used by the restore path (added in a later change)
+pub(crate) fn apply_memory_plan_child(plan: &[RestoreRegion], fds: &[FdInfo]) {
+    for region in plan {
+        match region {
+            RestoreRegion::WriteBytes { start, end, perms, data } => {
+                let len = (end - start) as usize;
+                let prot = prot_from_perms(perms);
+                let p = unsafe {
+                    libc::mmap(*start as *mut libc::c_void, len,
+                        libc::PROT_READ | libc::PROT_WRITE,
+                        libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_FIXED, -1, 0)
+                };
+                if p == libc::MAP_FAILED { unsafe { libc::_exit(101); } }
+                unsafe {
+                    std::ptr::copy_nonoverlapping(data.as_ptr(), *start as *mut u8, data.len());
+                    // Re-apply the recorded protection (e.g. drop +w if the region was read-only).
+                    libc::mprotect(*start as *mut libc::c_void, len, prot);
+                }
+            }
+            RestoreRegion::RemapFromFile { start, end, perms, offset, path } => {
+                let len = (end - start) as usize;
+                let prot = prot_from_perms(perms);
+                let cpath = match std::ffi::CString::new(path.as_str()) {
+                    Ok(c) => c, Err(_) => unsafe { libc::_exit(102) },
+                };
+                let fd = unsafe { libc::open(cpath.as_ptr(), libc::O_RDONLY) };
+                if fd < 0 { unsafe { libc::_exit(103); } }
+                let p = unsafe {
+                    libc::mmap(*start as *mut libc::c_void, len, prot,
+                        libc::MAP_PRIVATE | libc::MAP_FIXED, fd, *offset as libc::off_t)
+                };
+                unsafe { libc::close(fd); }
+                if p == libc::MAP_FAILED { unsafe { libc::_exit(104); } }
+            }
+        }
+    }
+    for f in fds {
+        let cpath = match std::ffi::CString::new(f.path.as_str()) {
+            Ok(c) => c, Err(_) => continue,
+        };
+        let opened = unsafe { libc::open(cpath.as_ptr(), f.flags) };
+        if opened < 0 { continue; }
+        if opened != f.fd {
+            unsafe { libc::dup2(opened, f.fd); libc::close(opened); }
+        }
+        unsafe { libc::lseek(f.fd, f.offset as libc::off_t, libc::SEEK_SET); }
+    }
+}
+
+#[allow(dead_code)] // used by the restore path (added in a later change)
+fn prot_from_perms(perms: &str) -> libc::c_int {
+    let mut prot = 0;
+    if perms.as_bytes().first() == Some(&b'r') { prot |= libc::PROT_READ; }
+    if perms.as_bytes().get(1) == Some(&b'w') { prot |= libc::PROT_WRITE; }
+    if perms.as_bytes().get(2) == Some(&b'x') { prot |= libc::PROT_EXEC; }
+    if prot == 0 { prot = libc::PROT_NONE; }
+    prot
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -116,5 +179,30 @@ mod tests {
         assert!(matches!(plan[0], RestoreRegion::RemapFromFile { .. }));
         assert!(matches!(plan[1], RestoreRegion::WriteBytes { .. }));
         assert_eq!(plan.len(), 2, "special regions are skipped, not planned");
+    }
+
+    #[test]
+    fn child_restore_maps_anon_page() {
+        let addr: u64 = 0x4000_0000;
+        let plan = vec![RestoreRegion::WriteBytes {
+            start: addr, end: addr + 4096, perms: "rw-p".into(), data: vec![0xABu8; 4096],
+        }];
+
+        let pid = unsafe { libc::fork() };
+        if pid == 0 {
+            // Child: apply the plan, then SIGSTOP so the parent can inspect.
+            apply_memory_plan_child(&plan, &[]);
+            unsafe { libc::raise(libc::SIGSTOP); libc::_exit(0); }
+        }
+        // Parent: wait for the stop, read the page back, then kill.
+        let mut st = 0i32;
+        unsafe { libc::waitpid(pid, &mut st, libc::WUNTRACED); }
+        let mut buf = vec![0u8; 4096];
+        let local = libc::iovec { iov_base: buf.as_mut_ptr() as *mut _, iov_len: 4096 };
+        let remote = libc::iovec { iov_base: addr as *mut _, iov_len: 4096 };
+        let n = unsafe { libc::process_vm_readv(pid, &local, 1, &remote, 1, 0) };
+        unsafe { libc::kill(pid, libc::SIGKILL); libc::waitpid(pid, &mut st, 0); }
+        assert_eq!(n, 4096);
+        assert!(buf.iter().all(|&b| b == 0xAB), "anon page pattern must be restored");
     }
 }

--- a/crates/sandlock-core/src/checkpoint/resume.rs
+++ b/crates/sandlock-core/src/checkpoint/resume.rs
@@ -1,0 +1,63 @@
+use crate::checkpoint::{MemoryMap, MemorySegment};
+
+/// One planned memory-restore action for a saved region.
+#[allow(dead_code)] // used by the restore path (added in a later change)
+#[derive(Debug)]
+pub(crate) enum RestoreRegion {
+    /// mmap MAP_FIXED from `path` at `offset`, prot from `perms`.
+    RemapFromFile { start: u64, end: u64, perms: String, offset: u64, path: String },
+    /// mmap MAP_FIXED|MAP_ANONYMOUS|MAP_PRIVATE, then write `data`.
+    WriteBytes { start: u64, end: u64, perms: String, data: Vec<u8> },
+}
+
+/// Classify saved regions into restore actions. Special kernel maps
+/// ([vdso]/[vvar]/[vsyscall]) are skipped: the kernel provides them in the
+/// fresh process and they must not be overwritten. A region with captured
+/// bytes becomes WriteBytes; otherwise a path-backed region becomes
+/// RemapFromFile. Regions that are neither are left to the kernel/ABI.
+#[allow(dead_code)] // used by the restore path (added in a later change)
+pub(crate) fn build_memory_plan(
+    maps: &[MemoryMap],
+    data: &[MemorySegment],
+) -> Vec<RestoreRegion> {
+    let mut plan = Vec::new();
+    for m in maps {
+        if m.is_special() { continue; }
+        if let Some(seg) = data.iter().find(|s| s.start == m.start) {
+            plan.push(RestoreRegion::WriteBytes {
+                start: m.start, end: m.end, perms: m.perms.clone(), data: seg.data.clone(),
+            });
+        } else if let Some(ref p) = m.path {
+            if p.starts_with('/') {
+                plan.push(RestoreRegion::RemapFromFile {
+                    start: m.start, end: m.end, perms: m.perms.clone(),
+                    offset: m.offset, path: p.clone(),
+                });
+            }
+        }
+    }
+    plan
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checkpoint::{MemoryMap, MemorySegment};
+
+    #[test]
+    fn plan_classifies_regions() {
+        let maps = vec![
+            MemoryMap { start: 0x1000, end: 0x2000, perms: "r-xp".into(), offset: 0,
+                        path: Some("/bin/app".into()) },          // code: remap from file
+            MemoryMap { start: 0x3000, end: 0x4000, perms: "rw-p".into(), offset: 0,
+                        path: None },                              // anon writable: write bytes
+            MemoryMap { start: 0x5000, end: 0x6000, perms: "r--p".into(), offset: 0,
+                        path: Some("[vvar]".into()) },             // special: skip
+        ];
+        let data = vec![MemorySegment { start: 0x3000, data: vec![7u8; 0x1000] }];
+        let plan = build_memory_plan(&maps, &data);
+        assert!(matches!(plan[0], RestoreRegion::RemapFromFile { .. }));
+        assert!(matches!(plan[1], RestoreRegion::WriteBytes { .. }));
+        assert_eq!(plan.len(), 2, "special regions are skipped, not planned");
+    }
+}

--- a/crates/sandlock-core/src/checkpoint/resume.rs
+++ b/crates/sandlock-core/src/checkpoint/resume.rs
@@ -89,6 +89,11 @@ fn prot_from_perms(perms: &str) -> libc::c_int {
 /// Leaves the child stopped with the saved registers loaded; the caller resumes
 /// it (PTRACE_CONT / detach). Returns the list of non-transparently-restored
 /// resource names (skipped fds) for the caller to log.
+/// On `Err`, the child is left half-built and still ptrace-stopped; the caller
+/// MUST kill and reap it.
+/// Limitation: file-backed regions are restored `MAP_PRIVATE` from the on-disk
+/// file, so a checkpointed `MAP_SHARED` mapping is restored as private
+/// (documented M1 limitation).
 // `restore_into` is only invoked from tests and (later) the OCI restore path
 // (Task 11), so it is dead code in a plain library build.
 #[allow(dead_code)]
@@ -103,6 +108,7 @@ pub(crate) fn restore_into(
     // x86_64 syscall numbers used by the rebuild.
     const MMAP: u64 = 9;
     const MPROTECT: u64 = 10;
+    const MUNMAP: u64 = 11;
     const OPEN: u64 = 2;
     const CLOSE: u64 = 3;
     const LSEEK: u64 = 8;
@@ -206,8 +212,9 @@ pub(crate) fn restore_into(
                 if r as u64 != *start {
                     return Err(err(format!("restore file mmap at {start:#x} -> {r:#x}")));
                 }
-                inject::inject_syscall_at(pid, tramp, CLOSE, [fd as u64, 0, 0, 0, 0, 0])
+                let cl = inject::inject_syscall_at(pid, tramp, CLOSE, [fd as u64, 0, 0, 0, 0, 0])
                     .map_err(|e| err(format!("restore close fd {fd}: {e}")))?;
+                if cl < 0 { return Err(err(format!("restore close fd {fd} -> {cl}"))); }
             }
         }
     }
@@ -215,11 +222,16 @@ pub(crate) fn restore_into(
     // Reopen transparently restorable fds at their saved numbers/offsets.
     for f in &restorable_fds {
         write_path(&f.path)?;
+        // Mask creation/truncation flags so the restored open cannot create,
+        // truncate, or fail-exclusive on the workload's real file. The kernel
+        // strips these in fdinfo, but mask defensively since O_TRUNC would be
+        // destructive.
+        let safe_flags = f.flags & !(libc::O_CREAT | libc::O_TRUNC | libc::O_EXCL);
         let opened = inject::inject_syscall_at(
             pid,
             tramp,
             OPEN,
-            [scratch, f.flags as u64, 0, 0, 0, 0],
+            [scratch, safe_flags as u64, 0, 0, 0, 0],
         )
         .map_err(|e| err(format!("restore fd open {}: {e}", f.path)))?;
         if opened < 0 {
@@ -229,10 +241,12 @@ pub(crate) fn restore_into(
             // dup2 may clobber an inherited stub fd at this number; that is
             // acceptable -- inherited stub fds are disposable. Documented M1
             // limitation, alongside the W^X trampoline constraint.
-            inject::inject_syscall_at(pid, tramp, DUP2, [opened as u64, f.fd as u64, 0, 0, 0, 0])
+            let d = inject::inject_syscall_at(pid, tramp, DUP2, [opened as u64, f.fd as u64, 0, 0, 0, 0])
                 .map_err(|e| err(format!("restore dup2 {opened}->{}: {e}", f.fd)))?;
-            inject::inject_syscall_at(pid, tramp, CLOSE, [opened as u64, 0, 0, 0, 0, 0])
+            if d < 0 { return Err(err(format!("restore dup2 {} -> {} failed: {d}", opened, f.fd))); }
+            let cl2 = inject::inject_syscall_at(pid, tramp, CLOSE, [opened as u64, 0, 0, 0, 0, 0])
                 .map_err(|e| err(format!("restore close dup src {opened}: {e}")))?;
+            if cl2 < 0 { return Err(err(format!("restore close dup src {opened} -> {cl2}"))); }
         }
         let ls = inject::inject_syscall_at(
             pid,
@@ -245,6 +259,18 @@ pub(crate) fn restore_into(
             return Err(err(format!("restore lseek fd {}", f.fd)));
         }
     }
+
+    // Unmap the RWX trampoline as the very last injected syscall, after all
+    // region and fd injections (which need it), and before the register restores
+    // (which use ptrace, not the trampoline). The `syscall` instruction at
+    // `tramp` is fetched and executed before the page is removed; after return,
+    // rip is restored to the stub's original rip (still mapped), and the
+    // following set_gp_regs points rip at the checkpoint's saved value. The
+    // unmapped page is therefore never executed again. This closes the W^X gap
+    // that would otherwise leave a writable+executable page in the restored process.
+    let mu = inject::inject_syscall_at(pid, tramp, MUNMAP, [tramp, 4096, 0, 0, 0, 0])
+        .map_err(|e| err(format!("restore munmap trampoline {tramp:#x}: {e}")))?;
+    if mu != 0 { return Err(err(format!("restore munmap trampoline {tramp:#x} -> {mu}"))); }
 
     // Registers last: load the saved FP then GP register files. After this the
     // child is stopped exactly at the checkpoint's execution point.

--- a/crates/sandlock-core/src/checkpoint/resume.rs
+++ b/crates/sandlock-core/src/checkpoint/resume.rs
@@ -41,18 +41,23 @@ pub(crate) fn build_memory_plan(
 
 /// Return true only for paths that refer to a reopenable regular file.
 /// memfd and "(deleted)" paths start with '/' but are not reopenable, so they
-/// are skipped.
+/// are skipped. Pseudo-filesystem paths (/proc/, /sys/, /dev/) are also skipped:
+/// they are ephemeral, may not exist at restore time, and cannot be
+/// transparently reopened in the new process.
 fn is_restorable_file_path(path: &str) -> bool {
     path.starts_with('/')
         && !path.starts_with("/memfd:")
         && !path.ends_with(" (deleted)")
+        && !path.starts_with("/proc/")
+        && !path.starts_with("/sys/")
+        && !path.starts_with("/dev/")
 }
 
 /// Split the saved fd table into transparently restorable regular files and a
 /// list of skipped non-regular fds (sockets, pipes, eventfd, ...). The skipped
 /// list is logged by the caller; those resources fall to the app_state hatch.
-/// memfd and "(deleted)" paths start with '/' but are not reopenable, so they
-/// are skipped.
+/// memfd, "(deleted)", and pseudo-filesystem (/proc/, /sys/, /dev/) paths start
+/// with '/' but are not transparently reopenable, so they are skipped.
 #[allow(dead_code)] // used by the restore path (added in a later change)
 pub(crate) fn build_fd_plan(fds: &[FdInfo]) -> (Vec<FdInfo>, Vec<String>) {
     let mut restorable = Vec::new();
@@ -288,14 +293,23 @@ mod tests {
             FdInfo { fd: 3, path: "/etc/hostname".into(), flags: 0, offset: 5 },
             FdInfo { fd: 6, path: "/tmp/gone (deleted)".into(), flags: 0, offset: 0 },
             FdInfo { fd: 7, path: "/memfd:scratch (deleted)".into(), flags: 0, offset: 0 },
+            FdInfo { fd: 8, path: "/proc/1234/maps".into(), flags: 0, offset: 0 },
+            FdInfo { fd: 9, path: "/dev/pts/3".into(), flags: 0, offset: 0 },
+            FdInfo { fd: 10, path: "/sys/kernel/x".into(), flags: 0, offset: 0 },
         ];
         let (restorable, skipped) = build_fd_plan(&fds);
         assert_eq!(restorable.len(), 1);
         assert_eq!(restorable[0].fd, 3);
-        assert!(restorable.iter().all(|f| f.fd != 6 && f.fd != 7),
-            "deleted and memfd fds must not appear in restorable");
+        assert!(restorable.iter().all(|f| f.fd != 6 && f.fd != 7 && f.fd != 8 && f.fd != 9 && f.fd != 10),
+            "deleted, memfd, and pseudo-filesystem fds must not appear in restorable");
         assert!(skipped.contains(&"/tmp/gone (deleted)".to_string()));
         assert!(skipped.contains(&"/memfd:scratch (deleted)".to_string()));
+        assert!(skipped.contains(&"/proc/1234/maps".to_string()),
+            "/proc/ paths must be skipped");
+        assert!(skipped.contains(&"/dev/pts/3".to_string()),
+            "/dev/ paths must be skipped");
+        assert!(skipped.contains(&"/sys/kernel/x".to_string()),
+            "/sys/ paths must be skipped");
     }
 
     #[test]

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -714,6 +714,68 @@ impl Sandbox {
         self.wait_until_exec().await
     }
 
+    /// Restore a checkpoint into a fresh, fully-sandboxed process.
+    ///
+    /// Reuses the normal create path to fork a child with the saved policy and the
+    /// full notify stack in place (the child parks before execve), then takes the
+    /// parked child over with ptrace and injects the checkpoint image over it via
+    /// `restore_into`, resuming it at the saved program counter. The process comes
+    /// up already sandboxed. Returns the list of non-transparently-restored fd
+    /// paths (skipped; the caller should log them). x86_64 restore engine only.
+    ///
+    /// On error the child may be left half-built; the caller should drop/kill the
+    /// Sandbox (Drop reaps it).
+    pub async fn restore_interactive(
+        &mut self,
+        cp: &crate::checkpoint::Checkpoint,
+    ) -> Result<Vec<String>, crate::error::SandlockError> {
+        use crate::error::SandboxRuntimeError;
+
+        // The exe to launch is the checkpoint's original binary (within the
+        // policy's fs_read/exec grant). It is never actually execve'd: the child
+        // parks blocked in read() on the ready-pipe, and we inject the checkpoint
+        // over it before it could ever be released. Fall back to a benign command
+        // only when the checkpoint recorded no exe path.
+        let exe = if cp.process_state.exe.is_empty() {
+            "/bin/true".to_string()
+        } else {
+            cp.process_state.exe.clone()
+        };
+        self.create_interactive(&[exe.as_str()]).await?;
+        let pid = self.pid().ok_or(SandboxRuntimeError::NotRunning)?;
+
+        // ptrace is per-thread: the seize, inject, and detach must all run on the
+        // SAME OS thread (the seizing thread becomes the tracer). Do the entire
+        // synchronous sequence inside one spawn_blocking closure with no awaits.
+        // `restore_into` borrows the checkpoint, and spawn_blocking requires a
+        // 'static closure, so move a clone of `cp` in. The clone resets the
+        // policy's runtime to None (Sandbox::clone), which is harmless here:
+        // restore_into reads only process_state + fd_table, never policy.
+        let cp = cp.clone();
+        let skipped = tokio::task::spawn_blocking(
+            move || -> Result<Vec<String>, crate::error::SandlockError> {
+                // PTRACE_SEIZE + PTRACE_INTERRUPT + waitpid to reach the ptrace-stop.
+                crate::checkpoint::capture::ptrace_seize(pid).map_err(|e| {
+                    SandboxRuntimeError::Child(format!("restore ptrace seize {pid}: {e}"))
+                })?;
+                // Inject the checkpoint image; leaves the child stopped with the
+                // saved registers (including rip at the checkpoint pc) loaded.
+                let skipped = crate::checkpoint::resume::restore_into(pid, &cp)?;
+                // PTRACE_DETACH resumes the child; because rip points at the
+                // checkpoint pc, it resumes the checkpointed program, abandoning
+                // the ready-pipe read, under the already-installed policy.
+                crate::checkpoint::capture::ptrace_detach(pid).map_err(|e| {
+                    SandboxRuntimeError::Child(format!("restore ptrace detach {pid}: {e}"))
+                })?;
+                Ok(skipped)
+            },
+        )
+        .await
+        .map_err(|e| SandboxRuntimeError::Child(format!("restore join error: {e}")))??;
+
+        Ok(skipped)
+    }
+
     /// Wait for the child to finish `execve`. Detected by `/proc/<pid>/exe`
     /// no longer matching `/proc/self/exe` (before execve the child still
     /// shares the supervisor's binary). The kernel offers no direct event

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -723,6 +723,11 @@ impl Sandbox {
     /// up already sandboxed. Returns the list of non-transparently-restored fd
     /// paths (skipped; the caller should log them). x86_64 restore engine only.
     ///
+    /// Limitation: transparent restore currently works for vDSO-free programs.
+    /// libc/glibc programs that call vDSO functions (e.g. `clock_gettime`) crash
+    /// on resume because the vDSO is not yet relocated/restored (known limitation,
+    /// next milestone).
+    ///
     /// On error the child may be left half-built; the caller should drop/kill the
     /// Sandbox (Drop reaps it).
     pub async fn restore_interactive(
@@ -760,7 +765,15 @@ impl Sandbox {
                 })?;
                 // Inject the checkpoint image; leaves the child stopped with the
                 // saved registers (including rip at the checkpoint pc) loaded.
-                let skipped = crate::checkpoint::resume::restore_into(pid, &cp)?;
+                // On error, best-effort detach so the child is not left seized
+                // with a dangling tracer thread.
+                let skipped = match crate::checkpoint::resume::restore_into(pid, &cp) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        let _ = crate::checkpoint::capture::ptrace_detach(pid);
+                        return Err(e);
+                    }
+                };
                 // PTRACE_DETACH resumes the child; because rip points at the
                 // checkpoint pc, it resumes the checkpointed program, abandoning
                 // the ready-pipe read, under the already-installed policy.

--- a/crates/sandlock-core/tests/integration.rs
+++ b/crates/sandlock-core/tests/integration.rs
@@ -63,3 +63,6 @@ mod test_protection;
 
 #[path = "integration/test_http_inject_ca.rs"]
 mod test_http_inject_ca;
+
+#[path = "integration/test_restore.rs"]
+mod test_restore;

--- a/crates/sandlock-core/tests/integration/test_restore.rs
+++ b/crates/sandlock-core/tests/integration/test_restore.rs
@@ -1,0 +1,153 @@
+use sandlock_core::Sandbox;
+
+/// Freestanding x86_64 program (no libc, no vDSO; raw syscalls only) that opens
+/// an output file ONCE, then loops forever incrementing a counter and writing
+/// it through that same kept-open fd, sleeping via `nanosleep` between writes.
+///
+/// It is deliberately libc/vDSO-free: glibc caches vDSO function pointers in
+/// process memory, and the injection-based restore engine does not relocate the
+/// kernel vDSO, so a libc program (python, sh) resumes but crashes on its first
+/// vDSO call (e.g. clock_gettime). A raw-syscall program avoids that and lets
+/// the test prove the restore engine itself: memory (the loop counter),
+/// registers (resumed mid-`nanosleep`), and the reopened open fd.
+fn counter_source(out_path: &str) -> String {
+    format!(
+        r##"
+#define SYS_write 1
+#define SYS_open 2
+#define SYS_nanosleep 35
+#define SYS_lseek 8
+#define SYS_ftruncate 77
+#define O_WRONLY 1
+#define O_CREAT 0100
+#define O_TRUNC 01000
+static long sys3(long n, long a, long b, long c){{
+  long r; __asm__ volatile("syscall":"=a"(r):"a"(n),"D"(a),"S"(b),"d"(c):"rcx","r11","memory"); return r;
+}}
+struct ts {{ long sec; long nsec; }};
+void _start(void){{
+  const char *path = "{out_path}";
+  long fd = sys3(SYS_open, (long)path, O_WRONLY|O_CREAT|O_TRUNC, 0644);
+  unsigned long i = 0;
+  char buf[24];
+  struct ts t; t.sec = 0; t.nsec = 20000000;
+  for(;;){{
+    i++;
+    int p = 0; unsigned long v = i; char tmp[24]; int k=0;
+    if(v==0){{ tmp[k++]='0'; }} while(v){{ tmp[k++]='0'+(v%10); v/=10; }}
+    while(k>0){{ buf[p++]=tmp[--k]; }} buf[p++]='\n';
+    sys3(SYS_lseek, fd, 0, 0);
+    sys3(SYS_ftruncate, fd, 0, 0);
+    sys3(SYS_write, fd, (long)buf, p);
+    sys3(SYS_nanosleep, (long)&t, 0, 0);
+  }}
+}}
+"##
+    )
+}
+
+/// End-to-end proof of transparent restore of a real program into a fresh,
+/// fully-sandboxed process. Checkpoint the running counter program, kill the
+/// original, then `restore_interactive` a fresh sandbox from the checkpoint and
+/// prove the restored process resumes mid-loop and keeps advancing the counter,
+/// all under the live Landlock + seccomp policy.
+#[tokio::test]
+async fn test_restore_real_program_resumes() {
+    if cfg!(not(target_arch = "x86_64")) {
+        eprintln!("skipping: injection-based restore is x86_64-only");
+        return;
+    }
+
+    let tmp = std::env::temp_dir().join(format!("sandlock-restore-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let src = tmp.join("counter.c");
+    let bin = tmp.join("counter");
+    let counter = tmp.join("counter.cnt");
+    let counter_s = counter.to_str().unwrap().to_string();
+
+    std::fs::write(&src, counter_source(&counter_s)).unwrap();
+
+    // Build the freestanding binary; skip the test gracefully if no C compiler.
+    let cc = if which("cc") { "cc" } else if which("gcc") { "gcc" } else {
+        eprintln!("skipping: no C compiler (cc/gcc) available");
+        let _ = std::fs::remove_dir_all(&tmp);
+        return;
+    };
+    let build = std::process::Command::new(cc)
+        .args(["-static", "-nostdlib", "-no-pie", "-O0", "-o"])
+        .arg(&bin).arg(&src)
+        .output().unwrap();
+    if !build.status.success() {
+        eprintln!("skipping: build failed: {}", String::from_utf8_lossy(&build.stderr));
+        let _ = std::fs::remove_dir_all(&tmp);
+        return;
+    }
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr").fs_read("/lib").fs_read_if_exists("/lib64").fs_read("/bin").fs_read("/etc")
+        .fs_read("/proc")
+        .fs_read(&tmp)            // the binary lives here (exec needs read)
+        .fs_write(&tmp)          // ... and so does its output file
+        .build().unwrap();
+
+    let bin_s = bin.to_str().unwrap().to_string();
+    let mut sb = policy.clone().with_name("restore-src");
+    sb.spawn_interactive(&[bin_s.as_str()]).await.unwrap();
+
+    // Let it run so the counter is well past a few.
+    tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+
+    let cp = sb.checkpoint().await.unwrap();
+
+    let read_counter = |path: &str| -> Option<u64> {
+        std::fs::read_to_string(path).ok().and_then(|s| s.trim().parse::<u64>().ok())
+    };
+    let baseline = read_counter(&counter_s).expect("counter file should exist with a value");
+    assert!(baseline > 2, "counter should have advanced before checkpoint, got {baseline}");
+
+    // Kill the original so only the restored process can advance the file.
+    sb.kill().unwrap();
+    let _ = sb.wait().await;
+
+    // Sentinel: prove the *restored* process (not a leftover original) is writing.
+    std::fs::write(&counter, b"0\n").unwrap();
+
+    // Restore into a fresh, fully-sandboxed process.
+    let mut sb2 = policy.clone().with_name("restore-dst");
+    let skipped = sb2.restore_interactive(&cp).await.unwrap();
+    eprintln!("restore skipped fds: {skipped:?}");
+
+    // Poll up to ~3s for the restored process to resume and advance the counter
+    // past the checkpointed baseline.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    let mut last = 0u64;
+    let mut advanced = false;
+    while std::time::Instant::now() < deadline {
+        if let Some(v) = read_counter(&counter_s) {
+            last = v;
+            if v > baseline {
+                advanced = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    // Clean up before asserting so a failure never leaks the child/files.
+    let _ = sb2.kill();
+    let exit = sb2.wait().await.map(|r| r.exit_status);
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    assert!(
+        advanced,
+        "restored process must resume mid-loop and advance the counter past {baseline}; \
+         last seen {last}, restored exit {exit:?}"
+    );
+}
+
+/// Minimal PATH lookup so the test does not depend on extra crates.
+fn which(prog: &str) -> bool {
+    std::env::var_os("PATH").map_or(false, |paths| {
+        std::env::split_paths(&paths).any(|d| d.join(prog).is_file())
+    })
+}

--- a/crates/sandlock-oci/Cargo.toml
+++ b/crates/sandlock-oci/Cargo.toml
@@ -28,4 +28,5 @@ oci-spec    = { version = "0.7", features = ["runtime"] }
 
 [dev-dependencies]
 tempfile = "3"
-tokio    = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio    = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+sandlock-core = { path = "../sandlock-core" }

--- a/crates/sandlock-oci/src/main.rs
+++ b/crates/sandlock-oci/src/main.rs
@@ -129,6 +129,18 @@ enum Command {
         #[arg(long = "image-path")]
         image_path: String,
     },
+
+    /// Restore a sandbox from a checkpoint image directory (resumes it running).
+    Restore {
+        /// Sandbox/container ID to create.
+        id: String,
+        /// Directory containing the checkpoint image.
+        #[arg(long = "image-path")]
+        image_path: String,
+        /// OCI bundle path (accepted for runc compatibility; may be unused).
+        #[arg(long = "bundle")]
+        bundle: Option<String>,
+    },
 }
 
 fn main() -> Result<()> {
@@ -205,6 +217,9 @@ fn main() -> Result<()> {
         }
         Command::Checkpoint { id, image_path } => {
             cmd_checkpoint(&id, &image_path)?;
+        }
+        Command::Restore { id, image_path, bundle: _ } => {
+            cmd_restore(&id, &image_path)?;
         }
     }
 
@@ -381,6 +396,127 @@ fn cmd_create(id: &str, bundle: &PathBuf, pid_file: Option<&std::path::Path>) ->
     if let Some(pf) = pid_file {
         std::fs::write(pf, child_pid.to_string())
             .with_context(|| format!("write pid file {:?}", pf))?;
+    }
+
+    Ok(())
+}
+
+/// `sandlock-oci restore <id> --image-path <dir>`
+///
+/// Mirrors [`cmd_create`]'s supervisor-spawn + pid-pipe handshake, but the
+/// policy and command come from the checkpoint image (not an OCI bundle), and
+/// there is no separate `start`: `run_supervisor_restore` both creates and
+/// resumes the child, so the sandbox is `Running` once the handshake succeeds.
+fn cmd_restore(id: &str, image_path: &str) -> Result<()> {
+    // Reject a re-used ID up front, exactly like `create`.
+    if SandboxState::load(id).is_ok() {
+        bail!("sandbox {} already exists", id);
+    }
+
+    // Persist an initial state so `state`/`delete` work even if the supervisor
+    // dies before it can write its own Running state. The supervisor overwrites
+    // this with Running once the child is resumed.
+    let state = SandboxState::new(id, std::path::Path::new("/"), "1.0.2");
+    state.save().with_context(|| format!("save state for sandbox {}", id))?;
+
+    // ── Pipe for synchronous PID notification ────────────────────────────────
+    let mut pid_pipe: [i32; 2] = [0; 2];
+    unsafe {
+        if libc::pipe2(pid_pipe.as_mut_ptr(), libc::O_CLOEXEC) < 0 {
+            bail!("pipe2 failed: {}", std::io::Error::last_os_error());
+        }
+    }
+    let read_fd = pid_pipe[0];
+    let write_fd = pid_pipe[1];
+
+    let image_path = image_path.to_string();
+
+    // ── Double-fork daemonization (identical to cmd_create) ──────────────────
+    let pid = unsafe { libc::fork() };
+    if pid < 0 {
+        unsafe {
+            libc::close(read_fd);
+            libc::close(write_fd);
+        }
+        bail!("fork failed: {}", std::io::Error::last_os_error());
+    }
+
+    if pid == 0 {
+        // ===== INTERMEDIATE CHILD =====
+        unsafe { libc::close(read_fd); }
+        unsafe { libc::setsid() };
+
+        let pid2 = unsafe { libc::fork() };
+        if pid2 < 0 {
+            unsafe {
+                libc::close(write_fd);
+                libc::_exit(1);
+            }
+        }
+        if pid2 != 0 {
+            unsafe {
+                libc::close(write_fd);
+                libc::_exit(0);
+            }
+        }
+
+        // ===== SUPERVISOR PROCESS (grandchild) =====
+        unsafe { libc::close(read_fd); }
+        unsafe { libc::chdir(b"/\0".as_ptr() as *const libc::c_char); }
+        unsafe {
+            let devnull = libc::open(
+                b"/dev/null\0".as_ptr() as *const libc::c_char,
+                libc::O_RDONLY,
+            );
+            if devnull >= 0 {
+                libc::dup2(devnull, 0);
+                if devnull > 0 {
+                    libc::close(devnull);
+                }
+            }
+        }
+
+        let _ = supervisor::run_supervisor_restore(id, &image_path, write_fd);
+        unsafe {
+            libc::close(write_fd);
+            libc::_exit(0);
+        }
+    }
+
+    // ===== ORIGINAL PROCESS (caller) =====
+    unsafe { libc::close(write_fd) };
+
+    let mut wstatus = 0i32;
+    unsafe { libc::waitpid(pid, &mut wstatus, 0) };
+
+    let child_pid = {
+        let mut buf = [0u8; 512];
+        let n = unsafe {
+            libc::read(read_fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len())
+        };
+        unsafe { libc::close(read_fd) };
+        if n <= 0 {
+            bail!("supervisor exited without reporting status (check system logs)");
+        }
+        let response = String::from_utf8_lossy(&buf[..n as usize]);
+        let response = response.trim();
+        if let Some(rest) = response.strip_prefix("OK ") {
+            rest.parse::<i32>()
+                .with_context(|| format!("invalid PID in supervisor response: {:?}", response))?
+        } else if let Some(msg) = response.strip_prefix("ERR ") {
+            bail!("sandbox restore failed: {}", msg);
+        } else {
+            bail!("unexpected supervisor response: {:?}", response);
+        }
+    };
+
+    // Restore resumes immediately: record Running with the real PID. This is
+    // authoritative regardless of how the supervisor's own state write races.
+    {
+        let mut state = SandboxState::load(id)?;
+        state.set_created(child_pid);
+        state.set_running();
+        state.save()?;
     }
 
     Ok(())

--- a/crates/sandlock-oci/src/main.rs
+++ b/crates/sandlock-oci/src/main.rs
@@ -204,11 +204,7 @@ fn main() -> Result<()> {
             println!("Platform: {}", std::env::consts::ARCH);
         }
         Command::Checkpoint { id, image_path } => {
-            match supervisor::send_command(&id, supervisor::SupervisorCmd::Checkpoint { dir: image_path })? {
-                supervisor::SupervisorReply::Ok => {}
-                supervisor::SupervisorReply::Err { msg } => bail!("checkpoint failed: {}", msg),
-                other => bail!("unexpected supervisor reply: {:?}", other),
-            }
+            cmd_checkpoint(&id, &image_path)?;
         }
     }
 
@@ -481,6 +477,17 @@ fn cmd_delete(id: &str, force: bool) -> Result<()> {
     // Remove state directory.
     state.delete()?;
     Ok(())
+}
+
+/// `sandlock-oci checkpoint <id> --image-path <dir>`
+///
+/// Asks the Supervisor to snapshot the running sandbox into an image directory.
+fn cmd_checkpoint(id: &str, image_path: &str) -> Result<()> {
+    match supervisor::send_command(id, supervisor::SupervisorCmd::Checkpoint { dir: image_path.to_string() })? {
+        supervisor::SupervisorReply::Ok => Ok(()),
+        supervisor::SupervisorReply::Err { msg } => bail!("checkpoint failed: {}", msg),
+        other => bail!("unexpected supervisor reply: {:?}", other),
+    }
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/crates/sandlock-oci/src/main.rs
+++ b/crates/sandlock-oci/src/main.rs
@@ -120,6 +120,15 @@ enum Command {
         #[arg(num_args = 0.., trailing_var_arg = true, allow_hyphen_values = true)]
         _args: Vec<String>,
     },
+
+    /// Capture a checkpoint of a running sandbox to an image directory.
+    Checkpoint {
+        /// Sandbox/container ID.
+        id: String,
+        /// Directory to write the checkpoint image into.
+        #[arg(long = "image-path")]
+        image_path: String,
+    },
 }
 
 fn main() -> Result<()> {
@@ -193,6 +202,13 @@ fn main() -> Result<()> {
                 }
             }
             println!("Platform: {}", std::env::consts::ARCH);
+        }
+        Command::Checkpoint { id, image_path } => {
+            match supervisor::send_command(&id, supervisor::SupervisorCmd::Checkpoint { dir: image_path })? {
+                supervisor::SupervisorReply::Ok => {}
+                supervisor::SupervisorReply::Err { msg } => bail!("checkpoint failed: {}", msg),
+                other => bail!("unexpected supervisor reply: {:?}", other),
+            }
         }
     }
 

--- a/crates/sandlock-oci/src/supervisor.rs
+++ b/crates/sandlock-oci/src/supervisor.rs
@@ -133,14 +133,6 @@ fn pipe_write(fd: i32, line: &str) {
     }
 }
 
-/// Reason the accept-loop exited.
-enum LoopExit {
-    /// `Start` was received — child is now running, call `sandbox.wait()`.
-    Started,
-    /// `Shutdown` was received — child was never started, drop sandbox to kill it.
-    Shutdown,
-}
-
 /// Async body of `run_supervisor`.
 async fn supervisor_main(
     id: &str,
@@ -149,11 +141,8 @@ async fn supervisor_main(
     sock_path: PathBuf,
     pid_write_fd: i32,
 ) -> Result<()> {
-    use sandlock_core::ExitStatus;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::UnixListener;
-
-    use crate::state::ExitInfo;
 
     // Bind the socket BEFORE create() so the CLI can call `start` the moment
     // `create` returns without a race on socket availability.
@@ -189,11 +178,13 @@ async fn supervisor_main(
         state.save().ok();
     }
 
-    // Accept-loop: serve CLI commands until `Start` or `Shutdown`.
-    let loop_exit: LoopExit = loop {
+    // PRE-START accept-loop: serve CLI commands until `Start` (transition to
+    // the running-serve loop) or `Shutdown`/error (return so the Sandbox Drop
+    // kills and reaps the parked child).
+    loop {
         let (mut stream, _) = match listener.accept().await {
             Ok(pair) => pair,
-            Err(_) => break LoopExit::Shutdown,
+            Err(_) => return Ok(()),
         };
 
         let mut buf = vec![0u8; 4096];
@@ -232,7 +223,15 @@ async fn supervisor_main(
                         let reply = serde_json::to_vec(&SupervisorReply::Ok).unwrap_or_default();
                         let _ = stream.write_all(&reply).await;
                         let _ = stream.write_all(b"\n").await;
-                        break LoopExit::Started;
+                        // Child is now running: keep serving the control socket
+                        // (so `checkpoint` works) until it exits or Shutdown.
+                        let exit_info =
+                            serve_running(id, &mut sandbox, &listener, child_pid).await;
+                        if let Ok(mut s) = SandboxState::load(id) {
+                            s.set_stopped(exit_info);
+                            s.save().ok();
+                        }
+                        return Ok(());
                     }
                     Err(e) => {
                         let reply = serde_json::to_vec(&SupervisorReply::Err { msg: e.to_string() })
@@ -241,9 +240,9 @@ async fn supervisor_main(
                         let _ = stream.write_all(b"\n").await;
                         // start() failed with the child still parked: do NOT
                         // wait() (it would block forever on a child that never
-                        // execve's).  Exit via the Shutdown path so the Sandbox
-                        // Drop kills and reaps the parked child.
-                        break LoopExit::Shutdown;
+                        // execve's).  Return so the Sandbox Drop kills and reaps
+                        // the parked child.
+                        return Ok(());
                     }
                 }
             }
@@ -253,7 +252,7 @@ async fn supervisor_main(
                 let reply = serde_json::to_vec(&SupervisorReply::Ok).unwrap_or_default();
                 let _ = stream.write_all(&reply).await;
                 let _ = stream.write_all(b"\n").await;
-                break LoopExit::Shutdown;
+                return Ok(());
             }
             SupervisorCmd::Checkpoint { dir } => {
                 let reply = match sandbox.checkpoint().await {
@@ -270,31 +269,7 @@ async fn supervisor_main(
                 let _ = stream.write_all(b"\n").await;
             }
         }
-    };
-
-    // On Shutdown (delete-before-start): return immediately.  The Sandbox Drop
-    // kills and reaps the parked child — no wait() needed.
-    if matches!(loop_exit, LoopExit::Shutdown) {
-        return Ok(());
     }
-
-    // On Start: wait for the child to exit and record the exit status.
-    let exit_info = match sandbox.wait().await {
-        Ok(result) => match result.exit_status {
-            ExitStatus::Code(code) => Some(ExitInfo { code: Some(code), signal: None }),
-            ExitStatus::Signal(sig) => Some(ExitInfo { code: None, signal: Some(sig) }),
-            ExitStatus::Killed => Some(ExitInfo { code: None, signal: Some(libc::SIGKILL) }),
-            ExitStatus::Timeout => Some(ExitInfo { code: Some(124), signal: None }),
-        },
-        Err(_) => None,
-    };
-
-    if let Ok(mut s) = SandboxState::load(id) {
-        s.set_stopped(exit_info);
-        s.save().ok();
-    }
-
-    Ok(())
 }
 
 /// Convert a `RunResult` (or wait error) into the on-disk `ExitInfo`.
@@ -311,6 +286,138 @@ fn exit_info_from(
             ExitStatus::Timeout => Some(ExitInfo { code: Some(124), signal: None }),
         },
         Err(_) => None,
+    }
+}
+
+/// Open an independent pidfd for `pid` as an AsyncFd readiness source for child
+/// exit, WITHOUT consuming the sandbox's own pidfd. A pidfd becomes readable
+/// when the process exits. Returns None if pidfd_open is unavailable or the
+/// child is already gone (caller then falls back to a plain wait()).
+fn exit_watcher(pid: i32) -> Option<tokio::io::unix::AsyncFd<std::os::unix::io::OwnedFd>> {
+    use std::os::unix::io::{FromRawFd, OwnedFd};
+    let raw = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) };
+    if raw < 0 {
+        return None;
+    }
+    let fd = unsafe { OwnedFd::from_raw_fd(raw as i32) };
+    tokio::io::unix::AsyncFd::with_interest(fd, tokio::io::Interest::READABLE).ok()
+}
+
+/// Outcome of handling one running-container control command.
+enum RunningCmd {
+    Continue,
+    Shutdown,
+}
+
+/// Handle a single accepted connection while the container is RUNNING. Serves
+/// Ping, Checkpoint, Start (idempotent no-op since already running), and
+/// Shutdown. Returns whether to keep serving or shut down.
+async fn serve_one_running(
+    stream: &mut tokio::net::UnixStream,
+    sandbox: &mut sandlock_core::Sandbox,
+    id: &str,
+    child_pid: i32,
+) -> RunningCmd {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let mut buf = vec![0u8; 4096];
+    let n = stream.read(&mut buf).await.unwrap_or(0);
+    if n == 0 {
+        return RunningCmd::Continue;
+    }
+    let incoming: SupervisorCmd = match serde_json::from_slice(&buf[..n]) {
+        Ok(c) => c,
+        Err(e) => {
+            let reply = serde_json::to_vec(&SupervisorReply::Err { msg: e.to_string() })
+                .unwrap_or_default();
+            let _ = stream.write_all(&reply).await;
+            let _ = stream.write_all(b"\n").await;
+            return RunningCmd::Continue;
+        }
+    };
+    match incoming {
+        SupervisorCmd::Ping => {
+            let reply =
+                serde_json::to_vec(&SupervisorReply::Pid { pid: child_pid }).unwrap_or_default();
+            let _ = stream.write_all(&reply).await;
+            let _ = stream.write_all(b"\n").await;
+            RunningCmd::Continue
+        }
+        SupervisorCmd::Start => {
+            // Already running: idempotent no-op.
+            let reply = serde_json::to_vec(&SupervisorReply::Ok).unwrap_or_default();
+            let _ = stream.write_all(&reply).await;
+            let _ = stream.write_all(b"\n").await;
+            RunningCmd::Continue
+        }
+        SupervisorCmd::Checkpoint { dir } => {
+            let reply = match sandbox.checkpoint().await {
+                Ok(mut cp) => {
+                    cp.name = id.to_string();
+                    match cp.save(std::path::Path::new(&dir)) {
+                        Ok(()) => serde_json::to_vec(&SupervisorReply::Ok).unwrap_or_default(),
+                        Err(e) => serde_json::to_vec(&SupervisorReply::Err { msg: e.to_string() })
+                            .unwrap_or_default(),
+                    }
+                }
+                Err(e) => serde_json::to_vec(&SupervisorReply::Err { msg: e.to_string() })
+                    .unwrap_or_default(),
+            };
+            let _ = stream.write_all(&reply).await;
+            let _ = stream.write_all(b"\n").await;
+            RunningCmd::Continue
+        }
+        SupervisorCmd::Shutdown => {
+            let reply = serde_json::to_vec(&SupervisorReply::Ok).unwrap_or_default();
+            let _ = stream.write_all(&reply).await;
+            let _ = stream.write_all(b"\n").await;
+            RunningCmd::Shutdown
+        }
+    }
+}
+
+/// Serve the control socket while the (already-running) child executes,
+/// returning the recorded exit info once the child exits or a Shutdown is
+/// received. Uses an independent pidfd watcher so the sandbox's own pidfd is
+/// consumed only by the final `wait()`, after exit. `AsyncFd::readable()` is
+/// cancel-safe and borrows only the watcher, so accepted commands can use
+/// `sandbox` freely.
+async fn serve_running(
+    id: &str,
+    sandbox: &mut sandlock_core::Sandbox,
+    listener: &tokio::net::UnixListener,
+    child_pid: i32,
+) -> Option<crate::state::ExitInfo> {
+    let watcher = match exit_watcher(child_pid) {
+        Some(w) => w,
+        None => {
+            // Cannot watch concurrently: just wait for exit (no serving).
+            return exit_info_from(sandbox.wait().await);
+        }
+    };
+    loop {
+        tokio::select! {
+            ready = watcher.readable() => {
+                // Child exited (pidfd readable), or the watcher errored: either
+                // way collect the status via the sandbox's own pidfd. We return
+                // immediately, so there is no need to clear readiness.
+                let _ = ready;
+                return exit_info_from(sandbox.wait().await);
+            }
+            conn = listener.accept() => {
+                match conn {
+                    Ok((mut stream, _)) => {
+                        match serve_one_running(&mut stream, sandbox, id, child_pid).await {
+                            RunningCmd::Continue => {}
+                            RunningCmd::Shutdown => {
+                                let _ = sandbox.kill();
+                                return exit_info_from(sandbox.wait().await);
+                            }
+                        }
+                    }
+                    Err(_) => return exit_info_from(sandbox.wait().await),
+                }
+            }
+        }
     }
 }
 
@@ -358,7 +465,6 @@ async fn supervisor_restore_main(
     sock_path: PathBuf,
     pid_write_fd: i32,
 ) -> Result<()> {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::UnixListener;
 
     // Bind the control socket BEFORE restore (mirrors create binding before
@@ -400,97 +506,13 @@ async fn supervisor_restore_main(
         state.save().ok();
     }
 
-    // Serve the control socket while the resumed child runs. There is no
-    // `Start` (the child is already running): a stray `Start` is an idempotent
-    // no-op. We interleave the accept-loop with `wait()` via `select!` so the
-    // child's exit is recorded while Ping/Checkpoint/Shutdown stay serviceable.
-    //
-    // Command handling that touches `sandbox` runs AFTER the `select!` returns
-    // (the competing `wait()` future is dropped first) to keep the borrows
-    // disjoint. When no command ever arrives, the very first `wait()` future
-    // runs to completion and records the exit via its pidfd.
-    let exit_info = loop {
-        enum Ev {
-            Exited(Result<sandlock_core::RunResult, sandlock_core::SandlockError>),
-            Conn(std::io::Result<(tokio::net::UnixStream, tokio::net::unix::SocketAddr)>),
-        }
-
-        let ev = tokio::select! {
-            res = sandbox.wait() => Ev::Exited(res),
-            conn = listener.accept() => Ev::Conn(conn),
-        };
-
-        match ev {
-            Ev::Exited(res) => break exit_info_from(res),
-            Ev::Conn(Err(_)) => {
-                // Listener broke: stop serving and just record the exit.
-                break exit_info_from(sandbox.wait().await);
-            }
-            Ev::Conn(Ok((mut stream, _))) => {
-                let mut buf = vec![0u8; 4096];
-                let n = stream.read(&mut buf).await.unwrap_or(0);
-                if n == 0 {
-                    continue;
-                }
-                let incoming: SupervisorCmd = match serde_json::from_slice(&buf[..n]) {
-                    Ok(c) => c,
-                    Err(e) => {
-                        let reply =
-                            serde_json::to_vec(&SupervisorReply::Err { msg: e.to_string() })
-                                .unwrap_or_default();
-                        let _ = stream.write_all(&reply).await;
-                        let _ = stream.write_all(b"\n").await;
-                        continue;
-                    }
-                };
-
-                match incoming {
-                    SupervisorCmd::Ping => {
-                        let reply = serde_json::to_vec(&SupervisorReply::Pid { pid: child_pid })
-                            .unwrap_or_default();
-                        let _ = stream.write_all(&reply).await;
-                        let _ = stream.write_all(b"\n").await;
-                    }
-                    SupervisorCmd::Start => {
-                        // Restore already started the child: idempotent no-op.
-                        let reply = serde_json::to_vec(&SupervisorReply::Ok).unwrap_or_default();
-                        let _ = stream.write_all(&reply).await;
-                        let _ = stream.write_all(b"\n").await;
-                    }
-                    SupervisorCmd::Checkpoint { dir } => {
-                        let reply = match sandbox.checkpoint().await {
-                            Ok(mut cp) => {
-                                cp.name = id.to_string();
-                                match cp.save(std::path::Path::new(&dir)) {
-                                    Ok(()) => serde_json::to_vec(&SupervisorReply::Ok)
-                                        .unwrap_or_default(),
-                                    Err(e) => serde_json::to_vec(&SupervisorReply::Err {
-                                        msg: e.to_string(),
-                                    })
-                                    .unwrap_or_default(),
-                                }
-                            }
-                            Err(e) => serde_json::to_vec(&SupervisorReply::Err {
-                                msg: e.to_string(),
-                            })
-                            .unwrap_or_default(),
-                        };
-                        let _ = stream.write_all(&reply).await;
-                        let _ = stream.write_all(b"\n").await;
-                    }
-                    SupervisorCmd::Shutdown => {
-                        let reply = serde_json::to_vec(&SupervisorReply::Ok).unwrap_or_default();
-                        let _ = stream.write_all(&reply).await;
-                        let _ = stream.write_all(b"\n").await;
-                        // The restored child is running: kill and reap it so we
-                        // do not leak a process, then record the exit.
-                        let _ = sandbox.kill();
-                        break exit_info_from(sandbox.wait().await);
-                    }
-                }
-            }
-        }
-    };
+    // Serve the control socket while the resumed child runs (shared with the
+    // create+start path). There is no `Start` (the child is already running): a
+    // stray `Start` is an idempotent no-op. An independent pidfd watcher detects
+    // exit so the sandbox's own pidfd is consumed exactly once, by the final
+    // `wait()`, avoiding the cancellation hazard of re-creating `wait()` per
+    // select iteration.
+    let exit_info = serve_running(id, &mut sandbox, &listener, child_pid).await;
 
     if let Ok(mut s) = SandboxState::load(id) {
         s.set_stopped(exit_info);

--- a/crates/sandlock-oci/src/supervisor.rs
+++ b/crates/sandlock-oci/src/supervisor.rs
@@ -297,6 +297,209 @@ async fn supervisor_main(
     Ok(())
 }
 
+/// Convert a `RunResult` (or wait error) into the on-disk `ExitInfo`.
+fn exit_info_from(
+    res: Result<sandlock_core::RunResult, sandlock_core::SandlockError>,
+) -> Option<crate::state::ExitInfo> {
+    use crate::state::ExitInfo;
+    use sandlock_core::ExitStatus;
+    match res {
+        Ok(r) => match r.exit_status {
+            ExitStatus::Code(code) => Some(ExitInfo { code: Some(code), signal: None }),
+            ExitStatus::Signal(sig) => Some(ExitInfo { code: None, signal: Some(sig) }),
+            ExitStatus::Killed => Some(ExitInfo { code: None, signal: Some(libc::SIGKILL) }),
+            ExitStatus::Timeout => Some(ExitInfo { code: Some(124), signal: None }),
+        },
+        Err(_) => None,
+    }
+}
+
+/// Run the supervisor in the **current process** for an OCI `restore`.
+///
+/// Unlike [`run_supervisor`], the policy comes from the checkpoint image (the
+/// saved `Sandbox`), not from an `OciPolicy`, and there is no separate `start`:
+/// `restore_interactive` both creates the child and resumes it, so the sandbox
+/// is `Running` the moment restore returns.
+pub fn run_supervisor_restore(id: &str, image_dir: &str, pid_write_fd: i32) -> Result<()> {
+    // Load the checkpoint image. On failure report back through the pid pipe so
+    // the CLI surfaces a clear error rather than a bare EOF.
+    let cp = match sandlock_core::Checkpoint::load(std::path::Path::new(image_dir)) {
+        Ok(c) => c,
+        Err(e) => {
+            pipe_write(pid_write_fd, &format!("ERR load checkpoint: {}", e));
+            return Err(anyhow::anyhow!("load checkpoint from {:?}: {}", image_dir, e));
+        }
+    };
+
+    // Build the Sandbox from the SAVED policy (cp.policy is a Sandbox with a
+    // manual Clone), not from an OciPolicy.
+    let mut sandbox = cp.policy.clone();
+    sandbox.set_name(id);
+
+    let sock_path = socket_path(id);
+    if sock_path.exists() {
+        std::fs::remove_file(&sock_path).ok();
+    }
+
+    // Same multi-threaded runtime requirement as run_supervisor.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("build tokio runtime")?;
+
+    rt.block_on(supervisor_restore_main(id, sandbox, cp, sock_path, pid_write_fd))
+}
+
+/// Async body of [`run_supervisor_restore`].
+async fn supervisor_restore_main(
+    id: &str,
+    mut sandbox: sandlock_core::Sandbox,
+    cp: sandlock_core::Checkpoint,
+    sock_path: PathBuf,
+    pid_write_fd: i32,
+) -> Result<()> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::UnixListener;
+
+    // Bind the control socket BEFORE restore (mirrors create binding before
+    // create) so the CLI never races on socket availability.
+    let listener = match UnixListener::bind(&sock_path) {
+        Ok(l) => l,
+        Err(e) => {
+            pipe_write(pid_write_fd, &format!("ERR bind socket: {}", e));
+            anyhow::bail!("bind supervisor socket {:?}: {}", sock_path, e);
+        }
+    };
+
+    // Restore: forks the child under the saved policy, injects the checkpoint,
+    // and RESUMES it. The child is already running on return — there is no
+    // separate start step.
+    let skipped = match sandbox.restore_interactive(&cp).await {
+        Ok(s) => s,
+        Err(e) => {
+            pipe_write(pid_write_fd, &format!("ERR restore: {}", e));
+            return Err(anyhow::anyhow!("sandbox restore_interactive: {}", e));
+        }
+    };
+    for path in &skipped {
+        eprintln!("sandlock: not transparently restored: {}", path);
+    }
+
+    let child_pid = sandbox.pid().unwrap_or(0);
+
+    // Notify the CLI: `OK <pid>` on success.
+    pipe_write(pid_write_fd, &format!("OK {}", child_pid));
+
+    // Restore resumes the child immediately, so persist RUNNING right away
+    // (set_created records the PID, set_running flips the status).
+    {
+        let mut state = SandboxState::load(id)
+            .unwrap_or_else(|_| SandboxState::new(id, Path::new("/"), "1.0.2"));
+        state.set_created(child_pid);
+        state.set_running();
+        state.save().ok();
+    }
+
+    // Serve the control socket while the resumed child runs. There is no
+    // `Start` (the child is already running): a stray `Start` is an idempotent
+    // no-op. We interleave the accept-loop with `wait()` via `select!` so the
+    // child's exit is recorded while Ping/Checkpoint/Shutdown stay serviceable.
+    //
+    // Command handling that touches `sandbox` runs AFTER the `select!` returns
+    // (the competing `wait()` future is dropped first) to keep the borrows
+    // disjoint. When no command ever arrives, the very first `wait()` future
+    // runs to completion and records the exit via its pidfd.
+    let exit_info = loop {
+        enum Ev {
+            Exited(Result<sandlock_core::RunResult, sandlock_core::SandlockError>),
+            Conn(std::io::Result<(tokio::net::UnixStream, tokio::net::unix::SocketAddr)>),
+        }
+
+        let ev = tokio::select! {
+            res = sandbox.wait() => Ev::Exited(res),
+            conn = listener.accept() => Ev::Conn(conn),
+        };
+
+        match ev {
+            Ev::Exited(res) => break exit_info_from(res),
+            Ev::Conn(Err(_)) => {
+                // Listener broke: stop serving and just record the exit.
+                break exit_info_from(sandbox.wait().await);
+            }
+            Ev::Conn(Ok((mut stream, _))) => {
+                let mut buf = vec![0u8; 4096];
+                let n = stream.read(&mut buf).await.unwrap_or(0);
+                if n == 0 {
+                    continue;
+                }
+                let incoming: SupervisorCmd = match serde_json::from_slice(&buf[..n]) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        let reply =
+                            serde_json::to_vec(&SupervisorReply::Err { msg: e.to_string() })
+                                .unwrap_or_default();
+                        let _ = stream.write_all(&reply).await;
+                        let _ = stream.write_all(b"\n").await;
+                        continue;
+                    }
+                };
+
+                match incoming {
+                    SupervisorCmd::Ping => {
+                        let reply = serde_json::to_vec(&SupervisorReply::Pid { pid: child_pid })
+                            .unwrap_or_default();
+                        let _ = stream.write_all(&reply).await;
+                        let _ = stream.write_all(b"\n").await;
+                    }
+                    SupervisorCmd::Start => {
+                        // Restore already started the child: idempotent no-op.
+                        let reply = serde_json::to_vec(&SupervisorReply::Ok).unwrap_or_default();
+                        let _ = stream.write_all(&reply).await;
+                        let _ = stream.write_all(b"\n").await;
+                    }
+                    SupervisorCmd::Checkpoint { dir } => {
+                        let reply = match sandbox.checkpoint().await {
+                            Ok(mut cp) => {
+                                cp.name = id.to_string();
+                                match cp.save(std::path::Path::new(&dir)) {
+                                    Ok(()) => serde_json::to_vec(&SupervisorReply::Ok)
+                                        .unwrap_or_default(),
+                                    Err(e) => serde_json::to_vec(&SupervisorReply::Err {
+                                        msg: e.to_string(),
+                                    })
+                                    .unwrap_or_default(),
+                                }
+                            }
+                            Err(e) => serde_json::to_vec(&SupervisorReply::Err {
+                                msg: e.to_string(),
+                            })
+                            .unwrap_or_default(),
+                        };
+                        let _ = stream.write_all(&reply).await;
+                        let _ = stream.write_all(b"\n").await;
+                    }
+                    SupervisorCmd::Shutdown => {
+                        let reply = serde_json::to_vec(&SupervisorReply::Ok).unwrap_or_default();
+                        let _ = stream.write_all(&reply).await;
+                        let _ = stream.write_all(b"\n").await;
+                        // The restored child is running: kill and reap it so we
+                        // do not leak a process, then record the exit.
+                        let _ = sandbox.kill();
+                        break exit_info_from(sandbox.wait().await);
+                    }
+                }
+            }
+        }
+    };
+
+    if let Ok(mut s) = SandboxState::load(id) {
+        s.set_stopped(exit_info);
+        s.save().ok();
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/sandlock-oci/src/supervisor.rs
+++ b/crates/sandlock-oci/src/supervisor.rs
@@ -36,6 +36,8 @@ pub enum SupervisorCmd {
     /// when the sandbox was never started).  The sandbox `Drop` kills the
     /// parked child.
     Shutdown,
+    /// Capture a checkpoint of the running child into `dir`.
+    Checkpoint { dir: String },
 }
 
 /// Responses from the Supervisor.
@@ -253,6 +255,20 @@ async fn supervisor_main(
                 let _ = stream.write_all(b"\n").await;
                 break LoopExit::Shutdown;
             }
+            SupervisorCmd::Checkpoint { dir } => {
+                let reply = match sandbox.checkpoint().await {
+                    Ok(mut cp) => {
+                        cp.name = id.to_string();
+                        match cp.save(std::path::Path::new(&dir)) {
+                            Ok(()) => serde_json::to_vec(&SupervisorReply::Ok).unwrap_or_default(),
+                            Err(e) => serde_json::to_vec(&SupervisorReply::Err { msg: e.to_string() }).unwrap_or_default(),
+                        }
+                    }
+                    Err(e) => serde_json::to_vec(&SupervisorReply::Err { msg: e.to_string() }).unwrap_or_default(),
+                };
+                let _ = stream.write_all(&reply).await;
+                let _ = stream.write_all(b"\n").await;
+            }
         }
     };
 
@@ -333,5 +349,15 @@ mod tests {
         let json = serde_json::to_string(&reply).unwrap();
         assert!(json.contains("err"));
         assert!(json.contains("test error"));
+    }
+
+    #[test]
+    fn supervisor_cmd_checkpoint_serde() {
+        let cmd = SupervisorCmd::Checkpoint { dir: "/tmp/img".into() };
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(json.contains("checkpoint"));
+        assert!(json.contains("/tmp/img"));
+        let back: SupervisorCmd = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, SupervisorCmd::Checkpoint { .. }));
     }
 }

--- a/crates/sandlock-oci/tests/integration.rs
+++ b/crates/sandlock-oci/tests/integration.rs
@@ -269,19 +269,7 @@ async fn oci_restore_resumes_vdso_free_program() {
     let counter_s = counter.to_str().unwrap().to_string();
     let image = tmp.join("image");
 
-    fs::write(&src, counter_source(&counter_s)).unwrap();
-
-    let cc = if which("cc") { "cc" } else if which("gcc") { "gcc" } else {
-        eprintln!("skipping: no C compiler (cc/gcc) available");
-        let _ = fs::remove_dir_all(&tmp);
-        return;
-    };
-    let build = Command::new(cc)
-        .args(["-static", "-nostdlib", "-no-pie", "-O0", "-o"])
-        .arg(&bin).arg(&src)
-        .output().unwrap();
-    if !build.status.success() {
-        eprintln!("skipping: build failed: {}", String::from_utf8_lossy(&build.stderr));
+    if !build_counter(&bin, &src, &counter_s) {
         let _ = fs::remove_dir_all(&tmp);
         return;
     }
@@ -381,6 +369,253 @@ async fn oci_restore_resumes_vdso_free_program() {
         "OCI-restored process must resume mid-loop and advance the counter past {baseline}; \
          last seen {last}, restore log: {restore_out}",
     );
+}
+
+/// Build the freestanding, vDSO-free counter program (shared with the restore
+/// test) into `bin`, writing its counter to the in-sandbox path `out_path`.
+/// Returns false (and prints a skip reason) when no C compiler is available or
+/// the build fails, so callers can early-return on unsupported hosts.
+fn build_counter(bin: &Path, src: &Path, out_path: &str) -> bool {
+    fs::write(src, counter_source(out_path)).unwrap();
+    let cc = if which("cc") {
+        "cc"
+    } else if which("gcc") {
+        "gcc"
+    } else {
+        eprintln!("skipping: no C compiler (cc/gcc) available");
+        return false;
+    };
+    let build = Command::new(cc)
+        .args(["-static", "-nostdlib", "-no-pie", "-O0", "-o"])
+        .arg(bin)
+        .arg(src)
+        .output()
+        .unwrap();
+    if !build.status.success() {
+        eprintln!(
+            "skipping: build failed: {}",
+            String::from_utf8_lossy(&build.stderr)
+        );
+        return false;
+    }
+    true
+}
+
+/// End-to-end proof that `sandlock-oci checkpoint` works on a RUNNING container
+/// created + started from an OCI bundle.
+///
+/// Before the supervisor fix, `supervisor_main` stopped serving the control
+/// socket once the child started (it only `wait()`ed), so a `checkpoint` of a
+/// running container could not be reached and timed out. This test creates +
+/// starts a sandbox running the vDSO-free counter, waits for it to advance
+/// (proving it is genuinely RUNNING), then checkpoints it and asserts the
+/// checkpoint image (`meta.json`) was written. As a bonus it then `restore`s the
+/// image into a second container and proves the restored counter advances,
+/// exercising a full OCI checkpoint -> restore round-trip of a running program.
+#[tokio::test(flavor = "multi_thread")]
+async fn oci_checkpoint_of_running_container() {
+    if cfg!(not(target_arch = "x86_64")) {
+        eprintln!("skipping: injection-based checkpoint/restore is x86_64-only");
+        return;
+    }
+    if sandlock_core::landlock_abi_version().is_err() {
+        eprintln!("skipping: Landlock unavailable on this host");
+        return;
+    }
+
+    let tmp = std::env::temp_dir().join(format!("sandlock-oci-ckpt-{}", std::process::id()));
+    fs::create_dir_all(&tmp).unwrap();
+    let src = tmp.join("counter.c");
+    let bin = tmp.join("counter");
+
+    // The container chroots to `rootfs`, so the counter's in-sandbox path
+    // `/out.cnt` resolves to `rootfs/out.cnt` on the host.
+    if !build_counter(&bin, &src, "/out.cnt") {
+        let _ = fs::remove_dir_all(&tmp);
+        return;
+    }
+
+    // Build the OCI bundle: the freestanding binary lives inside rootfs and the
+    // spec runs it via its in-chroot path.
+    let bundle = tmp.join("bundle");
+    let rootfs = bundle.join("rootfs");
+    fs::create_dir_all(&rootfs).unwrap();
+    let bin_in_rootfs = rootfs.join("counter");
+    fs::copy(&bin, &bin_in_rootfs).unwrap();
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&bin_in_rootfs, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    create_bundle(&bundle, &["/counter"]);
+
+    let host_counter = rootfs.join("out.cnt");
+    let host_counter_s = host_counter.to_str().unwrap().to_string();
+    let read_counter = |path: &str| -> Option<u64> {
+        fs::read_to_string(path)
+            .ok()
+            .and_then(|s| s.trim().parse::<u64>().ok())
+    };
+
+    let root = tempdir().unwrap();
+    let root_s = root.path().to_str().unwrap().to_string();
+    let id = "oci-ckpt-running";
+    let image = tmp.join("image");
+
+    // ── create (daemonizes a supervisor that inherits stdio; redirect + status) ─
+    let create_log = tmp.join("create.log");
+    let create_status = Command::new(oci_bin())
+        .args(["--root", &root_s, "create", id, "-b", bundle.to_str().unwrap()])
+        .stdout(std::process::Stdio::from(fs::File::create(&create_log).unwrap()))
+        .stderr(std::process::Stdio::from(
+            fs::OpenOptions::new().append(true).open(&create_log).unwrap(),
+        ))
+        .status()
+        .expect("failed to run sandlock-oci create");
+    let create_out = fs::read_to_string(&create_log).unwrap_or_default();
+    assert!(
+        create_status.success(),
+        "create CLI failed (exit {:?}): {}",
+        create_status.code(),
+        create_out
+    );
+
+    // ── start (releases the parked child to execve) ─────────────────────────────
+    let start_out = Command::new(oci_bin())
+        .args(["--root", &root_s, "start", id])
+        .output()
+        .expect("failed to run sandlock-oci start");
+    if !start_out.status.success() {
+        let _ = Command::new(oci_bin())
+            .args(["--root", &root_s, "delete", id, "--force"])
+            .output();
+        let _ = fs::remove_dir_all(&tmp);
+        panic!(
+            "start CLI failed: {}",
+            String::from_utf8_lossy(&start_out.stderr)
+        );
+    }
+
+    // Poll until the running container's counter advances (proves it is RUNNING).
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let mut baseline = 0u64;
+    let mut running = false;
+    while std::time::Instant::now() < deadline {
+        if let Some(v) = read_counter(&host_counter_s) {
+            if v > 2 {
+                baseline = v;
+                running = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    // ── checkpoint the RUNNING container ───────────────────────────────────────
+    let ckpt_out = if running {
+        Some(
+            Command::new(oci_bin())
+                .args(["--root", &root_s, "checkpoint", id, "--image-path", image.to_str().unwrap()])
+                .output()
+                .expect("failed to run sandlock-oci checkpoint"),
+        )
+    } else {
+        None
+    };
+    let ckpt_ok = ckpt_out.as_ref().map(|o| o.status.success()).unwrap_or(false);
+    let meta_exists = image.join("meta.json").exists();
+
+    // ── bonus: restore the checkpoint into a second container ───────────────────
+    let id2 = "oci-ckpt-restored";
+    let mut restored_advanced = None::<bool>;
+    let mut restore_diag = String::new();
+    if ckpt_ok && meta_exists {
+        // Stop the original so only a restored process can advance the file, and
+        // drop a low sentinel to prove the restored process (not a leftover) writes.
+        let _ = Command::new(oci_bin())
+            .args(["--root", &root_s, "delete", id, "--force"])
+            .output();
+        fs::write(&host_counter, b"0\n").unwrap();
+
+        let restore_log = tmp.join("restore.log");
+        let restore_status = Command::new(oci_bin())
+            .args(["--root", &root_s, "restore", id2, "--image-path", image.to_str().unwrap()])
+            .stdout(std::process::Stdio::from(fs::File::create(&restore_log).unwrap()))
+            .stderr(std::process::Stdio::from(
+                fs::OpenOptions::new().append(true).open(&restore_log).unwrap(),
+            ))
+            .status()
+            .expect("failed to run sandlock-oci restore");
+        if restore_status.success() {
+            let rdl = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            let mut adv = false;
+            while std::time::Instant::now() < rdl {
+                if let Some(v) = read_counter(&host_counter_s) {
+                    if v > baseline {
+                        adv = true;
+                        break;
+                    }
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+            restored_advanced = Some(adv);
+            restore_diag = format!(
+                "restore_status ok; last_counter={:?}; log: {}",
+                read_counter(&host_counter_s),
+                fs::read_to_string(&restore_log).unwrap_or_default()
+            );
+        } else {
+            restored_advanced = Some(false);
+            restore_diag = format!(
+                "restore_status FAILED; log: {}",
+                fs::read_to_string(&restore_log).unwrap_or_default()
+            );
+        }
+    }
+
+    // ── clean up before asserting so a failure never leaks a process ────────────
+    let _ = Command::new(oci_bin())
+        .args(["--root", &root_s, "delete", id, "--force"])
+        .output();
+    let _ = Command::new(oci_bin())
+        .args(["--root", &root_s, "delete", id2, "--force"])
+        .output();
+    let _ = fs::remove_dir_all(&tmp);
+
+    assert!(
+        running,
+        "container counter never advanced; create_out: {create_out}"
+    );
+    let ckpt_stderr = ckpt_out
+        .as_ref()
+        .map(|o| String::from_utf8_lossy(&o.stderr).to_string())
+        .unwrap_or_default();
+    assert!(
+        ckpt_ok,
+        "checkpoint of a RUNNING container must succeed; stderr: {ckpt_stderr}"
+    );
+    assert!(
+        meta_exists,
+        "checkpoint must write meta.json to the image dir"
+    );
+    // Bonus (non-fatal): a full OCI checkpoint -> restore round-trip. The
+    // checkpoint-of-running assertions above are the required deliverable. The
+    // restore engine reopens fds/mappings by their recorded HOST path, which
+    // collides with the virtual-chroot path rewriting of a bundle-based
+    // container (the binary at `<rootfs>/counter` gets re-confined under the
+    // restored chroot and Landlock denies it with EACCES). The standalone
+    // `oci_restore_resumes_vdso_free_program` test covers restore on its own,
+    // chroot-free; restore of a *chrooted* checkpoint is a separate limitation
+    // outside the scope of the serve-while-running fix, so we only report it.
+    if let Some(adv) = restored_advanced {
+        if adv {
+            eprintln!("bonus: full OCI checkpoint -> restore round-trip advanced the counter");
+        } else {
+            eprintln!(
+                "note: bonus round-trip restore of a chrooted checkpoint did not advance \
+                 (restore-under-chroot limitation, orthogonal to this fix): {restore_diag}"
+            );
+        }
+    }
 }
 
 /// Minimal PATH lookup so the test does not depend on extra crates.

--- a/crates/sandlock-oci/tests/integration.rs
+++ b/crates/sandlock-oci/tests/integration.rs
@@ -195,3 +195,197 @@ fn oci_create_rejects_duplicate_id() {
         stderr
     );
 }
+
+// ── end-to-end OCI restore (Landlock host, vDSO-free program) ───────────────
+
+/// Freestanding x86_64 program (no libc, no vDSO; raw syscalls only) that opens
+/// an output file once, then loops forever rewriting an incrementing counter
+/// through the kept-open fd, sleeping via `nanosleep` between writes.
+///
+/// It is deliberately libc/vDSO-free: glibc caches vDSO pointers in process
+/// memory and the injection-based restore engine does not relocate the kernel
+/// vDSO, so a libc program (python, sh) resumes but crashes on its first vDSO
+/// call. A raw-syscall program lets the test prove the restore engine itself
+/// (memory, registers, reopened fd). Mirrors the core restore test.
+fn counter_source(out_path: &str) -> String {
+    format!(
+        r##"
+#define SYS_write 1
+#define SYS_open 2
+#define SYS_nanosleep 35
+#define SYS_lseek 8
+#define SYS_ftruncate 77
+#define O_WRONLY 1
+#define O_CREAT 0100
+#define O_TRUNC 01000
+static long sys3(long n, long a, long b, long c){{
+  long r; __asm__ volatile("syscall":"=a"(r):"a"(n),"D"(a),"S"(b),"d"(c):"rcx","r11","memory"); return r;
+}}
+struct ts {{ long sec; long nsec; }};
+void _start(void){{
+  const char *path = "{out_path}";
+  long fd = sys3(SYS_open, (long)path, O_WRONLY|O_CREAT|O_TRUNC, 0644);
+  unsigned long i = 0;
+  char buf[24];
+  struct ts t; t.sec = 0; t.nsec = 20000000;
+  for(;;){{
+    i++;
+    int p = 0; unsigned long v = i; char tmp[24]; int k=0;
+    if(v==0){{ tmp[k++]='0'; }} while(v){{ tmp[k++]='0'+(v%10); v/=10; }}
+    while(k>0){{ buf[p++]=tmp[--k]; }} buf[p++]='\n';
+    sys3(SYS_lseek, fd, 0, 0);
+    sys3(SYS_ftruncate, fd, 0, 0);
+    sys3(SYS_write, fd, (long)buf, p);
+    sys3(SYS_nanosleep, (long)&t, 0, 0);
+  }}
+}}
+"##
+    )
+}
+
+/// End-to-end proof that the OCI `restore` subcommand resumes a checkpointed,
+/// vDSO-free program. The checkpoint is produced with sandlock-core (test
+/// setup), then the real `sandlock-oci restore` CLI is invoked: it spawns the
+/// detached supervisor (`run_supervisor_restore`), which restores AND resumes
+/// the child immediately (no `start`). We verify the restored process advances
+/// the counter past the checkpointed baseline, that `state` reports `running`,
+/// then `delete --force` cleans up.
+#[tokio::test(flavor = "multi_thread")]
+async fn oci_restore_resumes_vdso_free_program() {
+    if cfg!(not(target_arch = "x86_64")) {
+        eprintln!("skipping: injection-based restore is x86_64-only");
+        return;
+    }
+    if sandlock_core::landlock_abi_version().is_err() {
+        eprintln!("skipping: Landlock unavailable on this host");
+        return;
+    }
+
+    let tmp = std::env::temp_dir().join(format!("sandlock-oci-restore-{}", std::process::id()));
+    fs::create_dir_all(&tmp).unwrap();
+    let src = tmp.join("counter.c");
+    let bin = tmp.join("counter");
+    let counter = tmp.join("counter.cnt");
+    let counter_s = counter.to_str().unwrap().to_string();
+    let image = tmp.join("image");
+
+    fs::write(&src, counter_source(&counter_s)).unwrap();
+
+    let cc = if which("cc") { "cc" } else if which("gcc") { "gcc" } else {
+        eprintln!("skipping: no C compiler (cc/gcc) available");
+        let _ = fs::remove_dir_all(&tmp);
+        return;
+    };
+    let build = Command::new(cc)
+        .args(["-static", "-nostdlib", "-no-pie", "-O0", "-o"])
+        .arg(&bin).arg(&src)
+        .output().unwrap();
+    if !build.status.success() {
+        eprintln!("skipping: build failed: {}", String::from_utf8_lossy(&build.stderr));
+        let _ = fs::remove_dir_all(&tmp);
+        return;
+    }
+
+    // ── Test setup: produce a checkpoint image with sandlock-core ───────────
+    let policy = sandlock_core::Sandbox::builder()
+        .fs_read("/usr").fs_read("/lib").fs_read_if_exists("/lib64").fs_read("/bin").fs_read("/etc")
+        .fs_read("/proc")
+        .fs_read(&tmp)
+        .fs_write(&tmp)
+        .build().unwrap();
+
+    let bin_s = bin.to_str().unwrap().to_string();
+    // Capturing spawn so the source's stdio are pipes (not inherited regular
+    // files); pipe fds are skipped on restore, isolating the test from however
+    // the harness wires the test process's own stdout/stderr.
+    let mut sb = policy.clone().with_name("oci-restore-src");
+    sb.spawn(&[bin_s.as_str()]).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+
+    let cp = sb.checkpoint().await.unwrap();
+    let read_counter = |path: &str| -> Option<u64> {
+        fs::read_to_string(path).ok().and_then(|s| s.trim().parse::<u64>().ok())
+    };
+    let baseline = read_counter(&counter_s).expect("counter file should exist with a value");
+    assert!(baseline > 2, "counter should have advanced before checkpoint, got {baseline}");
+    cp.save(&image).unwrap();
+
+    // Kill the source so only a restored process can advance the file.
+    sb.kill().unwrap();
+    let _ = sb.wait().await;
+    // Sentinel: prove the *restored* process (not a leftover) is writing.
+    fs::write(&counter, b"0\n").unwrap();
+
+    // ── Exercise the OCI restore CLI ─────────────────────────────────────────
+    let root = tempdir().unwrap();
+    let root_s = root.path().to_str().unwrap().to_string();
+    let id = "oci-restore-e2e";
+
+    // NB: the restore CLI double-forks a long-lived supervisor daemon that
+    // inherits stdout/stderr (left open for containerd log FIFOs). Capturing
+    // via `Command::output()` would block until those fds close (container
+    // exit), so redirect the CLI's stdio to a file and wait only on the CLI
+    // with `.status()`.
+    let restore_log = tmp.join("restore.log");
+    let status = Command::new(oci_bin())
+        .args(["--root", &root_s, "restore", id, "--image-path", image.to_str().unwrap()])
+        .stdout(std::process::Stdio::from(fs::File::create(&restore_log).unwrap()))
+        .stderr(std::process::Stdio::from(
+            fs::OpenOptions::new().append(true).open(&restore_log).unwrap(),
+        ))
+        .status()
+        .expect("failed to run sandlock-oci restore");
+    let restore_out = fs::read_to_string(&restore_log).unwrap_or_default();
+    assert!(
+        status.success(),
+        "restore CLI failed (exit {:?}): {}",
+        status.code(),
+        restore_out,
+    );
+
+    // State should report running immediately (restore resumes, no start).
+    let st = Command::new(oci_bin())
+        .args(["--root", &root_s, "state", id])
+        .output()
+        .expect("failed to run sandlock-oci state");
+    let st_json = String::from_utf8_lossy(&st.stdout);
+    assert!(
+        st_json.contains("\"running\""),
+        "expected running state after restore, got: {}",
+        st_json
+    );
+
+    // Poll for the restored process to resume mid-loop and advance the counter.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(4);
+    let mut last = 0u64;
+    let mut advanced = false;
+    while std::time::Instant::now() < deadline {
+        if let Some(v) = read_counter(&counter_s) {
+            last = v;
+            if v > baseline {
+                advanced = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    // Clean up via the CLI before asserting so a failure never leaks the child.
+    let _ = Command::new(oci_bin())
+        .args(["--root", &root_s, "delete", id, "--force"])
+        .output();
+    let _ = fs::remove_dir_all(&tmp);
+
+    assert!(
+        advanced,
+        "OCI-restored process must resume mid-loop and advance the counter past {baseline}; \
+         last seen {last}, restore log: {restore_out}",
+    );
+}
+
+/// Minimal PATH lookup so the test does not depend on extra crates.
+fn which(prog: &str) -> bool {
+    std::env::var_os("PATH").map_or(false, |paths| {
+        std::env::split_paths(&paths).any(|d| d.join(prog).is_file())
+    })
+}

--- a/python/README.md
+++ b/python/README.md
@@ -571,7 +571,7 @@ Checkpoint.restore("my-snapshot", restore_fn=lambda data: rebuild(data))
 |--------|-------------|
 | `cp.save(name, store=None)` | Persist checkpoint to disk |
 | `Checkpoint.load(name, store=None)` | Load from disk |
-| `Checkpoint.restore(name, restore_fn, store=None)` | Load and call restore_fn with app_state |
+| `Checkpoint.restore(name, restore_fn=None, store=None)` | Load; if app_state was saved (via save_fn) call restore_fn with it. restore_fn and save_fn must both be present or both absent. |
 | `Checkpoint.list(store=None)` | List saved checkpoint names |
 | `Checkpoint.delete(name, store=None)` | Delete a saved checkpoint |
 

--- a/python/src/sandlock/_sdk.py
+++ b/python/src/sandlock/_sdk.py
@@ -861,18 +861,25 @@ class Checkpoint:
     def restore(
         cls,
         name: str,
-        restore_fn: "Callable[[bytes], None]",
+        restore_fn: "Callable[[bytes], None] | None" = None,
         *,
         store: "Path | str | None" = None,
     ) -> "Checkpoint":
-        """Load a checkpoint and pass its app state to restore_fn.
+        """Load a checkpoint and, if it carries app state, pass it to restore_fn.
 
-        Convenience for ``load()`` + calling ``restore_fn(cp.app_state)``.
+        Convenience for ``load()`` plus calling ``restore_fn(cp.app_state)``.
+
+        ``restore_fn`` mirrors ``save_fn`` on ``Sandbox.checkpoint``: a checkpoint
+        taken without ``save_fn`` has no app state and is restored without
+        ``restore_fn``; a checkpoint taken with ``save_fn`` carries app state and
+        must be restored with ``restore_fn``. Supplying exactly one of the pair
+        is an error.
 
         Args:
             name: Checkpoint name.
-            restore_fn: Callback that receives the saved application-level
-                state bytes. Use this to rebuild state that ptrace can't
+            restore_fn: Optional callback receiving the saved application-level
+                state bytes. Required if (and only if) the checkpoint was taken
+                with ``save_fn``. Use it to rebuild state that ptrace cannot
                 capture (caches, session data, etc.).
             store: Storage root. Defaults to ``~/.sandlock/checkpoints/``.
 
@@ -881,16 +888,26 @@ class Checkpoint:
 
         Raises:
             FileNotFoundError: If the checkpoint does not exist.
-            ValueError: If the checkpoint has no app_state.
+            ValueError: If the checkpoint has app_state but no restore_fn was
+                given, or a restore_fn was given but the checkpoint has no
+                app_state.
         """
         cp = cls.load(name, store=store)
         state = cp.app_state
-        if state is None:
+        has_state = state is not None
+        has_fn = restore_fn is not None
+        if has_state and not has_fn:
             raise ValueError(
-                f"Checkpoint {name!r} has no app_state — "
-                "was it created with save_fn?"
+                f"Checkpoint {name!r} has app_state; pass restore_fn to "
+                "consume it (it was created with save_fn)"
             )
-        restore_fn(state)
+        if has_fn and not has_state:
+            raise ValueError(
+                f"Checkpoint {name!r} has no app_state; restore_fn was given "
+                "but there is nothing to pass (was it created with save_fn?)"
+            )
+        if has_fn:
+            restore_fn(state)
         return cp
 
     @classmethod

--- a/python/tests/test_checkpoint.py
+++ b/python/tests/test_checkpoint.py
@@ -146,12 +146,33 @@ class TestCheckpointRestore:
         assert isinstance(result, Checkpoint)
         assert result.name == "ret-test"
 
-    def test_restore_no_app_state_raises(self, running_sandbox, tmp_dir):
+    def test_restore_no_app_state_no_fn_succeeds(self, running_sandbox, tmp_dir):
+        # save_fn absent at checkpoint, restore_fn absent at restore: both
+        # absent is the symmetric, valid case and must not raise.
         cp = running_sandbox.checkpoint()
         cp.save("no-app", store=tmp_dir)
 
+        result = Checkpoint.restore("no-app", store=tmp_dir)
+        assert isinstance(result, Checkpoint)
+        assert result.app_state is None
+
+    def test_restore_fn_without_app_state_raises(self, running_sandbox, tmp_dir):
+        # restore_fn given but the checkpoint has no app_state: a one-sided
+        # pairing, which is rejected.
+        cp = running_sandbox.checkpoint()
+        cp.save("no-app-fn", store=tmp_dir)
+
         with pytest.raises(ValueError, match="no app_state"):
-            Checkpoint.restore("no-app", lambda d: None, store=tmp_dir)
+            Checkpoint.restore("no-app-fn", lambda d: None, store=tmp_dir)
+
+    def test_restore_app_state_without_fn_raises(self, running_sandbox, tmp_dir):
+        # app_state present but restore_fn omitted: the other one-sided pairing,
+        # also rejected.
+        cp = running_sandbox.checkpoint(save_fn=lambda: b"state")
+        cp.save("app-no-fn", store=tmp_dir)
+
+        with pytest.raises(ValueError, match="has app_state"):
+            Checkpoint.restore("app-no-fn", store=tmp_dir)
 
     def test_restore_nonexistent_raises(self, tmp_dir):
         with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
## Summary

Adds checkpoint and restore for sandlock sandboxes, plus OCI `checkpoint`/`restore` subcommands. Restore is **transparent** (no application cooperation): a checkpointed process is rebuilt and resumed at its exact program counter under its original Landlock + seccomp policy.

This reuses DMTCP-style design ideas (userspace, no namespaces) but is tailored to sandlock and built from scratch (not CRIU, not DMTCP code).

### Engine (`sandlock-core`)
- Capture: general-purpose + FPU/extended registers, memory maps, fd table, versioned on-disk image (v2).
- External **ptrace syscall-injection** restore: an injection primitive, a `syscall` trampoline placed in a free hole of the checkpoint's address space, then `restore_into` which rebuilds memory (re-`mmap` file-backed regions from disk, `process_vm_writev` anonymous bytes), reopens regular-file fds, loads registers via `PTRACE_SETREGSET`, and unmaps the trampoline (preserving W^X).
- `Sandbox::restore_interactive`: reuses the normal launch path to fork a child with the saved policy + notify stack, then seizes the parked child and injects the checkpoint, resuming it already sandboxed. Policy is applied **before** injection (the restore syscalls fall within the policy's grants), so no policy-syscall injection is needed.

### OCI (`sandlock-oci`)
- `sandlock-oci checkpoint <id> --image-path DIR` and `sandlock-oci restore <id> --image-path DIR`.
- A shared `serve_running` loop keeps the control socket served while the container runs (via an independent pidfd watcher), so checkpoint works on a **running** container.

## Known limitations (next milestones)
- **vDSO:** transparent restore currently works for vDSO-free programs. libc/glibc programs resume then SIGSEGV because the kernel vDSO is not relocated to the checkpointed address (cached vDSO pointers go stale). Fix: inject `mremap` of the new vDSO/vvar to the saved addresses.
- **Restore under chroot:** the restore engine reopens files by their recorded host path, which the restored container's rootfs chroot re-confines (Landlock EACCES). Full OCI round-trip of a chrooted container needs chroot-relative path translation.

## Test Plan
- [x] `cargo test -p sandlock-core checkpoint --lib` (13 tests: register capture/inject, image roundtrip, trampoline, restore_into read-back)
- [x] `cargo test -p sandlock-core --test integration test_restore` (resumes a real vDSO-free program under live policy)
- [x] `cargo test -p sandlock-oci --test integration` (11 tests incl. checkpoint-of-running container and OCI restore e2e)
- [x] `cargo test -p sandlock-oci --lib` (38 tests)
- [x] Clean build, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)