### PR TITLE
sandlock-oci: collapse process group on stop, atomic state.json and test writes

### DIFF
--- a/crates/sandlock-oci/src/state.rs
+++ b/crates/sandlock-oci/src/state.rs
@@ -156,14 +156,27 @@ impl SandboxState {
     }
 
     /// Persist state to disk. Creates the directory if needed.
+    ///
+    /// The write is atomic: serialize to a per-writer temp file, then `rename`
+    /// it over `state.json`. During `create`/`restore` the CLI and the detached
+    /// supervisor write `state.json` concurrently; a plain `write` (truncate then
+    /// write) would let the other process `load` a torn or empty file and fail to
+    /// parse it. `rename(2)` is atomic on the same filesystem, so a concurrent
+    /// reader always sees a complete file (the previous one or the new one).
     pub fn save(&self) -> Result<()> {
         let dir = self.state_dir();
         std::fs::create_dir_all(&dir)
             .with_context(|| format!("create state dir {:?}", dir))?;
         let data = serde_json::to_string_pretty(self)
             .context("serialize sandbox state")?;
-        std::fs::write(self.state_file(), data)
-            .with_context(|| format!("write state to {:?}", self.state_file()))
+        // Temp and target share `dir` (same filesystem, so rename is atomic) and
+        // the temp name carries the writer's PID so concurrent writers in
+        // different processes never collide on it.
+        let tmp = dir.join(format!("state.json.{}.tmp", std::process::id()));
+        std::fs::write(&tmp, data)
+            .with_context(|| format!("write state to {:?}", tmp))?;
+        std::fs::rename(&tmp, self.state_file())
+            .with_context(|| format!("rename {:?} -> {:?}", tmp, self.state_file()))
     }
 
     /// Load state from disk.

--- a/crates/sandlock-oci/src/supervisor.rs
+++ b/crates/sandlock-oci/src/supervisor.rs
@@ -391,7 +391,7 @@ async fn serve_running(
         Some(w) => w,
         None => {
             // Cannot watch concurrently: just wait for exit (no serving).
-            return exit_info_from(sandbox.wait().await);
+            return reap_and_collapse(sandbox, child_pid).await;
         }
     };
     loop {
@@ -401,7 +401,7 @@ async fn serve_running(
                 // way collect the status via the sandbox's own pidfd. We return
                 // immediately, so there is no need to clear readiness.
                 let _ = ready;
-                return exit_info_from(sandbox.wait().await);
+                return reap_and_collapse(sandbox, child_pid).await;
             }
             conn = listener.accept() => {
                 match conn {
@@ -414,11 +414,32 @@ async fn serve_running(
                             }
                         }
                     }
-                    Err(_) => return exit_info_from(sandbox.wait().await),
+                    Err(_) => return reap_and_collapse(sandbox, child_pid).await,
                 }
             }
         }
     }
+}
+
+/// Collect the main process's exit status, then collapse its process group.
+///
+/// sandlock uses no PID namespace, so when the container's main process exits
+/// the kernel does not tear down the processes it spawned (background children,
+/// and exec'd siblings sharing the group). Send SIGKILL to the whole group so
+/// nothing outlives the container with a now-dead supervisor. `child_pid` is the
+/// group's pgid (core does `setpgid(0, 0)` in the child); `killpg` reaches any
+/// remaining members and is a harmless `ESRCH` when the group is already empty.
+/// The `Shutdown` path does not call this because `sandbox.kill()` already
+/// SIGKILLs the same process group.
+async fn reap_and_collapse(
+    sandbox: &mut sandlock_core::Sandbox,
+    child_pid: i32,
+) -> Option<crate::state::ExitInfo> {
+    let info = exit_info_from(sandbox.wait().await);
+    if child_pid > 0 {
+        unsafe { libc::killpg(child_pid, libc::SIGKILL) };
+    }
+    info
 }
 
 /// Run the supervisor in the **current process** for an OCI `restore`.

--- a/crates/sandlock-oci/tests/integration.rs
+++ b/crates/sandlock-oci/tests/integration.rs
@@ -214,7 +214,6 @@ fn counter_source(out_path: &str) -> String {
 #define SYS_open 2
 #define SYS_nanosleep 35
 #define SYS_lseek 8
-#define SYS_ftruncate 77
 #define O_WRONLY 1
 #define O_CREAT 0100
 #define O_TRUNC 01000
@@ -230,12 +229,14 @@ void _start(void){{
   struct ts t; t.sec = 0; t.nsec = 20000000;
   for(;;){{
     i++;
-    int p = 0; unsigned long v = i; char tmp[24]; int k=0;
-    if(v==0){{ tmp[k++]='0'; }} while(v){{ tmp[k++]='0'+(v%10); v/=10; }}
-    while(k>0){{ buf[p++]=tmp[--k]; }} buf[p++]='\n';
+    // Publish the counter atomically: one fixed-width, zero-padded 21-byte
+    // overwrite (20 digits + newline) at offset 0, never truncating. A reader
+    // therefore always sees a complete, parseable value, never an empty file.
+    unsigned long v = i; int d;
+    for(d = 19; d >= 0; d--){{ buf[d] = '0' + (v % 10); v /= 10; }}
+    buf[20] = '\n';
     sys3(SYS_lseek, fd, 0, 0);
-    sys3(SYS_ftruncate, fd, 0, 0);
-    sys3(SYS_write, fd, (long)buf, p);
+    sys3(SYS_write, fd, (long)buf, 21);
     sys3(SYS_nanosleep, (long)&t, 0, 0);
   }}
 }}

--- a/crates/sandlock-oci/tests/integration.rs
+++ b/crates/sandlock-oci/tests/integration.rs
@@ -624,3 +624,117 @@ fn which(prog: &str) -> bool {
         std::env::split_paths(&paths).any(|d| d.join(prog).is_file())
     })
 }
+
+/// Path to the prebuilt static `rootfs-helper` (compiled by sandlock-core's
+/// build.rs). It is a self-contained, busybox-style binary the chroot
+/// integration tests drop into a rootfs; building `sandlock-oci` pulls in
+/// `sandlock-core`, so the binary is available here too.
+fn rootfs_helper() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/rootfs-helper")
+}
+
+/// Regression test for process-group collapse on container stop. sandlock has
+/// no PID namespace, so when the container's main process exits the supervisor
+/// must explicitly SIGKILL the process group; otherwise background children (or
+/// exec'd siblings) outlive the container with a dead supervisor.
+///
+/// The container's main process (`rootfs-helper spawn-loop`) forks a worker that
+/// advances `/child.cnt`, then `pause`s. We confirm the worker is running,
+/// `kill` the main process, and assert the worker stops advancing. Without the
+/// `reap_and_collapse` fix the orphaned worker keeps writing and this test fails.
+#[tokio::test(flavor = "multi_thread")]
+async fn oci_stop_collapses_process_group() {
+    if sandlock_core::landlock_abi_version().is_err() {
+        eprintln!("skipping: Landlock unavailable on this host");
+        return;
+    }
+    let helper = rootfs_helper();
+    if !helper.exists() {
+        eprintln!("skipping: rootfs-helper not built (needs musl-gcc or cc -static)");
+        return;
+    }
+
+    let tmp = std::env::temp_dir().join(format!("sandlock-oci-pgroup-{}", std::process::id()));
+    fs::create_dir_all(&tmp).unwrap();
+
+    // The container chroots to rootfs, so the worker's in-sandbox path
+    // `/child.cnt` resolves to `rootfs/child.cnt` on the host. Drop the static
+    // rootfs-helper into the rootfs and run its `spawn-loop` worker.
+    let bundle = tmp.join("bundle");
+    let rootfs = bundle.join("rootfs");
+    fs::create_dir_all(&rootfs).unwrap();
+    fs::copy(&helper, rootfs.join("rootfs-helper")).unwrap();
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(rootfs.join("rootfs-helper"), fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    create_bundle(&bundle, &["/rootfs-helper", "spawn-loop", "/child.cnt"]);
+
+    let host_child = rootfs.join("child.cnt");
+    let host_child_s = host_child.to_str().unwrap().to_string();
+    let read_counter = |path: &str| -> Option<u64> {
+        fs::read_to_string(path).ok().and_then(|s| s.trim().parse::<u64>().ok())
+    };
+
+    let root = tempdir().unwrap();
+    let root_s = root.path().to_str().unwrap().to_string();
+    let id = "oci-pgroup-e2e";
+
+    // create (daemonizes a supervisor that inherits stdio; redirect + .status()).
+    let create_log = tmp.join("create.log");
+    let create_status = Command::new(oci_bin())
+        .args(["--root", &root_s, "create", id, "-b", bundle.to_str().unwrap()])
+        .stdout(std::process::Stdio::from(fs::File::create(&create_log).unwrap()))
+        .stderr(std::process::Stdio::from(
+            fs::OpenOptions::new().append(true).open(&create_log).unwrap(),
+        ))
+        .status()
+        .expect("run create");
+    assert!(create_status.success(), "create failed: {}", fs::read_to_string(&create_log).unwrap_or_default());
+
+    let start_out = Command::new(oci_bin())
+        .args(["--root", &root_s, "start", id])
+        .output()
+        .expect("run start");
+    assert!(start_out.status.success(), "start failed: {}", String::from_utf8_lossy(&start_out.stderr));
+
+    // Wait until the forked worker is genuinely running.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let mut worker_running = false;
+    while std::time::Instant::now() < deadline {
+        if read_counter(&host_child_s).map(|v| v > 2).unwrap_or(false) {
+            worker_running = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    // Kill ONLY the main process (default SIGTERM to state.pid, not the group).
+    // The supervisor's group-collapse is what must take the worker down.
+    let kill_out = Command::new(oci_bin())
+        .args(["--root", &root_s, "kill", id, "SIGTERM"])
+        .output()
+        .expect("run kill");
+    let kill_ok = kill_out.status.success();
+
+    // Give the supervisor time to observe the exit and collapse the group.
+    tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+    let sample_a = read_counter(&host_child_s);
+    tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+    let sample_b = read_counter(&host_child_s);
+
+    // clean up before asserting so a failure never leaks the worker.
+    let _ = Command::new(oci_bin())
+        .args(["--root", &root_s, "delete", id, "--force"])
+        .output();
+    let _ = fs::remove_dir_all(&tmp);
+
+    assert!(worker_running, "forked worker never started; create_log: {}", fs::read_to_string(&create_log).unwrap_or_default());
+    assert!(kill_ok, "kill failed: {}", String::from_utf8_lossy(&kill_out.stderr));
+    assert_eq!(
+        sample_a, sample_b,
+        "worker must stop advancing after the container's main process is killed \
+         (process group was not collapsed); samples {:?} -> {:?}",
+        sample_a, sample_b
+    );
+}

--- a/tests/rootfs-helper.c
+++ b/tests/rootfs-helper.c
@@ -19,7 +19,9 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
+#include <sys/types.h>
 #include <sys/xattr.h>
+#include <time.h>
 #include <unistd.h>
 
 /* ── echo ───────────────────────────────────────────────────── */
@@ -545,6 +547,40 @@ static int cmd_legacy_chmod(int argc, char **argv) {
 }
 #endif
 
+/* ── spawn-loop (non-standard: fork a background worker, then pause) ──────── */
+/*
+ * Models a container whose main process spawns a long-lived background worker.
+ * The forked child opens <file> once and loops publishing an incrementing
+ * counter (single fixed-width 21-byte overwrite, never truncating, so a reader
+ * always sees a complete value); the parent blocks forever in pause(). Used by
+ * the OCI process-group-collapse test: when the container's main process is
+ * killed, the worker must be reaped with the group rather than left running.
+ */
+static int cmd_spawn_loop(int argc, char **argv) {
+    if (argc < 1) { fprintf(stderr, "spawn-loop: missing file operand\n"); return 1; }
+    const char *path = argv[0];
+    pid_t pid = fork();
+    if (pid < 0) { perror("spawn-loop: fork"); return 1; }
+    if (pid == 0) {
+        int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (fd < 0) _exit(1);
+        unsigned long i = 0;
+        char buf[24];
+        struct timespec t = { 0, 20000000 };
+        for (;;) {
+            i++;
+            unsigned long v = i;
+            for (int d = 19; d >= 0; d--) { buf[d] = '0' + (v % 10); v /= 10; }
+            buf[20] = '\n';
+            lseek(fd, 0, SEEK_SET);
+            if (write(fd, buf, 21) < 0) _exit(1);
+            nanosleep(&t, NULL);
+        }
+    }
+    for (;;) pause();
+    return 0;
+}
+
 /* ── dispatch ───────────────────────────────────────────────── */
 
 static int dispatch(const char *cmd, int argc, char **argv) {
@@ -572,6 +608,7 @@ static int dispatch(const char *cmd, int argc, char **argv) {
     if (strcmp(cmd, "setxattr") == 0)       return cmd_setxattr(argc, argv);
     if (strcmp(cmd, "listxattr") == 0)      return cmd_listxattr(argc, argv);
     if (strcmp(cmd, "fstat-fd") == 0)      return cmd_fstat_fd(argc, argv);
+    if (strcmp(cmd, "spawn-loop") == 0)     return cmd_spawn_loop(argc, argv);
     if (strcmp(cmd, "true") == 0)           return 0;
     if (strcmp(cmd, "false") == 0)          return 1;
 


### PR DESCRIPTION
## Summary

Three fixes to the `sandlock-oci` runtime shim, surfaced while preparing to add `exec`. Two are real bugs (a process lifecycle gap and a state-file concurrency race); the third deflakes the e2e tests at the source.

### 1. Collapse the container process group when the main process exits
sandlock uses no PID namespace, so when a container's main process exits the kernel does not tear down whatever it spawned. The supervisor's natural-exit path only `wait()`ed on the main process, so background children (and, later, exec'd siblings) were left running with a now-dead supervisor. `serve_running` now SIGKILLs the process group on the main process's exit, mirroring the `Shutdown` path's existing `kill()`. Covered by a new Landlock-gated regression test that forks a worker via `rootfs-helper spawn-loop`, kills only the main process, and asserts the worker stops advancing.

### 2. Write `state.json` atomically
During `create`/`restore`, the CLI and the detached supervisor write `state.json` concurrently. `SandboxState::save()` used `std::fs::write` (truncate then write), so the other process could `load()` a torn or empty file and fail to parse it (observed as an intermittent `restore` failure: `parse state JSON ...`). `save()` now writes to a per-PID temp file and `rename`s it into place; `rename(2)` is atomic on the same filesystem, so a concurrent reader always sees a complete file.

### 3. Publish e2e counter files atomically
The freestanding counter test programs rewrote their output via `lseek` + `ftruncate` + `write`, exposing a momentarily empty file to readers. They now publish with a single fixed-width 21-byte overwrite (no truncate), so a reader always sees a complete, parseable value. The reader-side polling workaround was removed in favor of this source fix.

## Testing

- Full `sandlock-oci` suite green (38 lib + 41 bin + 12 integration) on a Landlock v8 / x86_64 host.
- The new process-group test is a genuine regression guard: it fails with the `killpg` removed and passes with it; 25 consecutive runs clean.
- The previously-flaky `oci_restore_resumes_vdso_free_program` is now stable across 80 consecutive runs.
- The shared `tests/rootfs-helper` change is additive (`spawn-loop` command); core chroot tests (15) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
