### PR TITLE
ci: add ubuntu-22.04 low-ABI job + end-to-end degrade test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   rust:
@@ -31,6 +32,36 @@ jobs:
 
       - name: Run integration tests
         run: cargo test --release --test integration -- --test-threads=1
+
+  rust-low-abi:
+    name: Rust low-ABI (ubuntu-22.04)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --release
+
+      # The ubuntu-22.04 image runs a 6.8 Azure kernel (Landlock ABI v4),
+      # below the project's MIN_ABI = 6. Surface the host ABI so a future
+      # runner-image kernel bump that changes it is visible at a glance.
+      - name: Report Landlock ABI on this runner
+        run: ./target/release/sandlock check || true
+
+      # The default strict_all() suite (test_sandbox, test_network, ...)
+      # hard-requires v6 and would panic on this runner, so we run only the
+      # host-ABI-independent resolution tests plus the end-to-end degrade
+      # test. That degrade test is the point of having a sub-v6 runner: it
+      # proves a fully-degradable policy still builds and confines on v4,
+      # exercising the Protection opt-out path that the v6 runners cannot.
+      - name: Run host-ABI-independent and degrade tests
+        run: cargo test --release --test integration test_protection -- --test-threads=1
 
   rust-riscv64-cross:
     name: Rust cross-build (riscv64)

--- a/crates/sandlock-core/tests/integration/test_protection.rs
+++ b/crates/sandlock-core/tests/integration/test_protection.rs
@@ -1,9 +1,13 @@
 //! Integration tests for the per-protection availability resolution
 //! in `landlock::confine_inner`.
 //!
-//! These tests exercise the policy-driven resolution path directly via
-//! the `ProtectionStatus::resolve()` helper with synthetic ABI values,
-//! so they are independent of the host kernel's actual Landlock ABI.
+//! Most of these tests exercise the policy-driven resolution path
+//! directly via the `ProtectionStatus::resolve()` helper with synthetic
+//! ABI values, so they are independent of the host kernel's actual
+//! Landlock ABI. The one exception is
+//! `degraded_policy_confines_and_runs_below_v6`, which builds and runs a
+//! genuinely confined child to cover the end-to-end degrade path on a
+//! real low-ABI kernel; it self-skips where Landlock is unavailable.
 
 use sandlock_core::landlock::compute_fs_mask;
 use sandlock_core::{Protection, ProtectionPolicy, ProtectionState, ProtectionStatus};
@@ -459,4 +463,73 @@ fn disable_fsrefer_is_rejected_at_build() {
         .allow_degraded(Protection::FsRefer)
         .build()
         .expect("allow_degraded(FsRefer) must remain allowed");
+}
+
+// ----------------------------------------------------------------------
+// End-to-end degrade path: real confinement on a low-ABI host
+//
+// Unlike the synthetic resolve() tests above, this one builds and runs a
+// genuinely confined child. A *fully degradable* policy must build on
+// any Landlock-capable kernel and confine with whatever the host
+// supports, degrading (silently skipping) the scopes it lacks instead of
+// hard-failing the way the default `strict_all()` does below ABI 6.
+//
+// This is the test that gives the ubuntu-22.04 CI runner (a 6.8 Azure
+// kernel, Landlock ABI v4) its purpose: there, SignalScope /
+// AbstractUnixSocketScope (v6) and FsIoctlDev (v5) resolve to Degraded,
+// exercising the opt-out path end-to-end. On a v6 host the same scopes
+// resolve Active and the degrade assertion is skipped. Where Landlock is
+// unavailable entirely, the test self-skips rather than failing.
+// ----------------------------------------------------------------------
+
+#[tokio::test]
+async fn degraded_policy_confines_and_runs_below_v6() {
+    let abi = match sandlock_core::landlock_abi_version() {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Skipping: Landlock unavailable ({e})");
+            return;
+        }
+    };
+
+    let mut builder = sandlock_core::Sandbox::builder();
+    for p in Protection::all() {
+        builder = builder.allow_degraded(p);
+    }
+    let sandbox = builder
+        .fs_read("/usr")
+        .fs_read("/lib")
+        .fs_read_if_exists("/lib64")
+        .fs_read("/bin")
+        .fs_read("/etc")
+        .build()
+        .expect("a fully-degradable policy must build on any Landlock host");
+
+    // Below ABI 6, every scope the host cannot provide must resolve to
+    // Degraded — not Unavailable, which is what makes `confine` refuse.
+    if abi < 6 {
+        let states = sandbox
+            .active_protections()
+            .expect("resolve protections against host ABI");
+        for (p, status) in &states {
+            if p.min_abi() > abi {
+                assert_eq!(
+                    *status,
+                    ProtectionStatus::Degraded,
+                    "{p:?} (needs v{}) on a v{abi} host must degrade, not fail",
+                    p.min_abi()
+                );
+            }
+        }
+    }
+
+    let result = sandbox
+        .with_name("degraded")
+        .run(&["echo", "ok"])
+        .await
+        .expect("a confined child must run under a degraded policy");
+    assert!(
+        result.success(),
+        "degraded-mode confinement must still execute the child"
+    );
 }


### PR DESCRIPTION
Follow-up to the CI split-out agreed in #71 (the `ci.yml` review thread).

## Motivation

The CI matrix only runs v6-capable runners (`ubuntu-latest`, `ubuntu-24.04-arm`), so the Protection opt-out path added in #71 — which lets a sandbox confine on kernels below Landlock ABI 6 by degrading the scopes the host lacks — has no automated coverage on a real low-ABI kernel. The synthetic `test_protection` resolution tests cover the mechanics, but nothing exercised a genuine `build()` + `run()` below v6.

## What this adds

- A dedicated `rust-low-abi` job on `ubuntu-22.04`. That image runs a 6.8 Azure kernel — **Landlock ABI v4** — below the project's `MIN_ABI = 6`. The default `strict_all()` suite (`test_sandbox`, `test_network`, …) hard-requires v6 and would panic there, so the job runs only the host-ABI-independent resolution tests plus a new end-to-end degrade test, and reports the runner's ABI via `sandlock check` (so a future runner-image kernel bump that changes it is visible at a glance).
- `degraded_policy_confines_and_runs_below_v6`: builds a fully-degradable policy, asserts every scope the host cannot provide resolves to `Degraded` (not `Unavailable`, which is what makes `confine` refuse), and runs a genuinely confined child. This is the test that gives a sub-v6 runner its purpose.
- A `workflow_dispatch` trigger for manual runs.

## Verification

Ran on real kernels across the low-ABI spectrum:

- ABI v1 — Ubuntu 22.04, kernel 5.15
- ABI v4 — the GHA `ubuntu-22.04` runner itself (confirmed by the job's own `sandlock check` output)
- ABI v5 — Rocky 9.6, kernel 5.14
- ABI v8 — dev host

`test_protection` is 22/22 on every host; the degrade assertion fires on each sub-v6 kernel and the confined child runs.

## Note on the `ubuntu-latest` check

`Rust tests (ubuntu-latest)` currently fails on `main` independently of this change: `test_restore::test_restore_real_program_resumes` fails on x86 (it passes on `ubuntu-24.04-arm`), introduced with the checkpoint/restore merge (#105). This PR doesn't touch that path, and the new `rust-low-abi` job is green. Happy to file that separately if it isn't already tracked.
