### PR TITLE
sandlock-oci: implement OCI exec (supervisor-hosted, non-TTY)

### DIFF
--- a/crates/sandlock-oci/src/fdpass.rs
+++ b/crates/sandlock-oci/src/fdpass.rs
@@ -1,0 +1,165 @@
+//! SCM_RIGHTS file-descriptor passing over the supervisor control socket.
+//!
+//! `exec` is the only control command that carries open fds (the CLI's
+//! stdin/stdout/stderr, which the container shim wired to the exec stream).
+//! The daemon must receive those fds with the SAME `recvmsg` that reads the
+//! command bytes, because ancillary data binds to specific bytes. All other
+//! commands send an empty ancillary payload, so the receive path is uniform.
+
+use std::io;
+use std::os::unix::io::{FromRawFd, OwnedFd, RawFd};
+
+/// Send `data` plus `fds` (as SCM_RIGHTS) over a blocking unix socket.
+pub fn send_with_fds(
+    stream: &std::os::unix::net::UnixStream,
+    data: &[u8],
+    fds: &[RawFd],
+) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+
+    let mut iov = libc::iovec {
+        iov_base: data.as_ptr() as *mut libc::c_void,
+        iov_len: data.len(),
+    };
+    let fds_bytes = std::mem::size_of_val(fds) as u32;
+    let cmsg_space = if fds.is_empty() {
+        0usize
+    } else {
+        unsafe { libc::CMSG_SPACE(fds_bytes) as usize }
+    };
+    let mut cmsg_buf = vec![0u8; cmsg_space];
+
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_iov = &mut iov;
+    msg.msg_iovlen = 1;
+    if !fds.is_empty() {
+        msg.msg_control = cmsg_buf.as_mut_ptr() as *mut libc::c_void;
+        msg.msg_controllen = cmsg_space as _;
+        unsafe {
+            let cmsg = libc::CMSG_FIRSTHDR(&msg);
+            (*cmsg).cmsg_level = libc::SOL_SOCKET;
+            (*cmsg).cmsg_type = libc::SCM_RIGHTS;
+            (*cmsg).cmsg_len = libc::CMSG_LEN(fds_bytes) as _;
+            std::ptr::copy_nonoverlapping(
+                fds.as_ptr(),
+                libc::CMSG_DATA(cmsg) as *mut RawFd,
+                fds.len(),
+            );
+        }
+    }
+
+    let n = unsafe { libc::sendmsg(stream.as_raw_fd(), &msg, 0) };
+    if n < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Receive bytes plus up to `max_fds` SCM_RIGHTS fds from a raw socket fd
+/// (one `recvmsg`). Returns the data and any received `OwnedFd`s.
+pub fn recv_with_fds(fd: RawFd, max_fds: usize) -> io::Result<(Vec<u8>, Vec<OwnedFd>)> {
+    let mut buf = vec![0u8; 8192];
+    let mut iov = libc::iovec {
+        iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+        iov_len: buf.len(),
+    };
+    let cmsg_space =
+        unsafe { libc::CMSG_SPACE((max_fds * std::mem::size_of::<RawFd>()) as u32) as usize };
+    let mut cmsg_buf = vec![0u8; cmsg_space];
+
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_iov = &mut iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = cmsg_buf.as_mut_ptr() as *mut libc::c_void;
+    msg.msg_controllen = cmsg_space as _;
+
+    let n = unsafe { libc::recvmsg(fd, &mut msg, 0) };
+    if n < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let mut fds = Vec::new();
+    unsafe {
+        let mut cmsg = libc::CMSG_FIRSTHDR(&msg);
+        while !cmsg.is_null() {
+            if (*cmsg).cmsg_level == libc::SOL_SOCKET && (*cmsg).cmsg_type == libc::SCM_RIGHTS {
+                let payload = (*cmsg).cmsg_len as usize - libc::CMSG_LEN(0) as usize;
+                let count = payload / std::mem::size_of::<RawFd>();
+                let data_ptr = libc::CMSG_DATA(cmsg) as *const RawFd;
+                for i in 0..count {
+                    fds.push(OwnedFd::from_raw_fd(*data_ptr.add(i)));
+                }
+            }
+            cmsg = libc::CMSG_NXTHDR(&msg, cmsg);
+        }
+    }
+
+    buf.truncate(n as usize);
+    Ok((buf, fds))
+}
+
+/// Tokio wrapper: await readability, then one `recv_with_fds` on the raw fd.
+/// `recvmsg` returns `EAGAIN` (`WouldBlock`) if the socket was not actually
+/// ready; loop until it yields data.
+pub async fn recv_with_fds_async(
+    stream: &tokio::net::UnixStream,
+    max_fds: usize,
+) -> io::Result<(Vec<u8>, Vec<OwnedFd>)> {
+    use std::os::unix::io::AsRawFd;
+    loop {
+        stream.readable().await?;
+        match stream.try_io(tokio::io::Interest::READABLE, || {
+            recv_with_fds(stream.as_raw_fd(), max_fds)
+        }) {
+            Ok(res) => return Ok(res),
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::os::unix::io::AsRawFd;
+    use std::os::unix::net::UnixStream;
+
+    /// Send a pipe's write-end across a socketpair, then prove the received fd
+    /// is the SAME open file: writing through it is readable from the original
+    /// read-end.
+    #[test]
+    fn send_and_recv_one_fd_roundtrip() {
+        let (a, b) = UnixStream::pair().unwrap();
+
+        // A pipe whose write end we will pass over the socket.
+        let mut fds = [0i32; 2];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        let (pipe_r, pipe_w) = (fds[0], fds[1]);
+
+        send_with_fds(&a, b"PING", &[pipe_w]).unwrap();
+        let (data, got) = recv_with_fds(b.as_raw_fd(), 3).unwrap();
+
+        assert_eq!(&data, b"PING");
+        assert_eq!(got.len(), 1);
+
+        // Write through the RECEIVED fd, read from the original pipe read end.
+        let received_w = got[0].as_raw_fd();
+        assert_eq!(unsafe { libc::write(received_w, b"Z".as_ptr() as *const _, 1) }, 1);
+        let mut buf = [0u8; 1];
+        assert_eq!(unsafe { libc::read(pipe_r, buf.as_mut_ptr() as *mut _, 1) }, 1);
+        assert_eq!(buf[0], b'Z');
+
+        unsafe { libc::close(pipe_r); libc::close(pipe_w); }
+        let _ = (a, b);
+    }
+
+    #[test]
+    fn recv_without_fds_returns_empty_vec() {
+        let (mut a, b) = UnixStream::pair().unwrap();
+        a.write_all(b"hello").unwrap();
+        let (data, got) = recv_with_fds(b.as_raw_fd(), 3).unwrap();
+        assert_eq!(&data, b"hello");
+        assert!(got.is_empty());
+    }
+}

--- a/crates/sandlock-oci/src/lib.rs
+++ b/crates/sandlock-oci/src/lib.rs
@@ -9,6 +9,7 @@
 //! - [`SandboxState`] — on-disk lifecycle state for a sandbox
 //! - [`SupervisorCmd`] / [`SupervisorReply`] — IPC messages for the supervisor
 
+pub mod fdpass;
 pub mod policy;
 pub mod spec;
 pub mod state;

--- a/crates/sandlock-oci/src/main.rs
+++ b/crates/sandlock-oci/src/main.rs
@@ -12,11 +12,13 @@
 //!   state  <id>              →  print state.json (reconciled against liveness)
 //!   kill   <id> <signal>     →  forward signal to Child PID
 //!   delete <id>              →  send Shutdown to Supervisor, cleanup state dir
+//!   exec   <id> <cmd>        →  Supervisor spawns a confined sibling (stdio via SCM_RIGHTS)
 //! ```
 //!
 //! ## Known limitations
 //!
-//! - `exec` is not implemented (required for `kubectl exec` / exec probes).
+//! - `exec` runs non-TTY only: `-t` / `--console-socket` are accepted for runc
+//!   compatibility but ignored (no PTY yet).
 
 mod fdpass;
 mod policy;

--- a/crates/sandlock-oci/src/main.rs
+++ b/crates/sandlock-oci/src/main.rs
@@ -18,6 +18,7 @@
 //!
 //! - `exec` is not implemented (required for `kubectl exec` / exec probes).
 
+mod fdpass;
 mod policy;
 mod spec;
 mod state;
@@ -727,17 +728,98 @@ fn resolve_exec_request(
     })
 }
 
-/// Filled in by Task 4.
+/// `sandlock-oci exec <id> [--process spec.json] [-- <cmd> [args...]]`
+///
+/// Connects to the container's supervisor, passes this process's stdio fds via
+/// SCM_RIGHTS, and asks the supervisor to spawn the command under a clone of the
+/// container policy. Attached (default): block until the exec'd process exits
+/// and exit with its status. `--detach`: return after it starts.
 fn cmd_exec(
-    _id: &str,
-    _process_file: Option<&std::path::Path>,
-    _pid_file: Option<&std::path::Path>,
-    _detach: bool,
-    _extra_env: &[String],
-    _extra_cwd: Option<&std::path::Path>,
-    _inline_args: &[String],
+    id: &str,
+    process_file: Option<&std::path::Path>,
+    pid_file: Option<&std::path::Path>,
+    detach: bool,
+    extra_env: &[String],
+    extra_cwd: Option<&std::path::Path>,
+    inline_args: &[String],
 ) -> Result<()> {
-    bail!("exec: not wired yet")
+    use std::io::BufRead;
+    use std::os::unix::io::AsRawFd;
+    use std::os::unix::net::UnixStream;
+
+    let state = SandboxState::load(id).with_context(|| format!("no such container: {}", id))?;
+    if state.status != Status::Running {
+        bail!("container {} is not running (status: {})", id, state.status);
+    }
+
+    let req = resolve_exec_request(process_file, inline_args, extra_env, extra_cwd)?;
+
+    let cmd = supervisor::SupervisorCmd::Exec {
+        args: req.args,
+        env: req.env,
+        cwd: req.cwd,
+        detach,
+    };
+    let payload = serde_json::to_vec(&cmd).context("serialize exec command")?;
+
+    let sock = supervisor::socket_path(id);
+    let stream = UnixStream::connect(&sock)
+        .with_context(|| format!("connect to supervisor socket {:?}", sock))?;
+
+    // Pass our stdin/stdout/stderr to the supervisor alongside the command.
+    fdpass::send_with_fds(
+        &stream,
+        &payload,
+        &[
+            std::io::stdin().as_raw_fd(),
+            std::io::stdout().as_raw_fd(),
+            std::io::stderr().as_raw_fd(),
+        ],
+    )
+    .context("send exec command + stdio fds")?;
+
+    let mut reader = std::io::BufReader::new(&stream);
+
+    // First reply: Pid (or Err).
+    let mut line = String::new();
+    reader.read_line(&mut line).context("read exec pid reply")?;
+    let pid_reply: supervisor::SupervisorReply =
+        serde_json::from_str(line.trim()).context("parse exec pid reply")?;
+    let exec_pid = match pid_reply {
+        supervisor::SupervisorReply::Pid { pid } => pid,
+        supervisor::SupervisorReply::Err { msg } => bail!("exec failed: {}", msg),
+        other => bail!("unexpected exec reply: {:?}", other),
+    };
+
+    if let Some(pf) = pid_file {
+        std::fs::write(pf, exec_pid.to_string())
+            .with_context(|| format!("write pid file {:?}", pf))?;
+    }
+
+    if detach {
+        return Ok(());
+    }
+
+    // Second reply: Exit. Exit this CLI with the same status.
+    let mut line2 = String::new();
+    reader.read_line(&mut line2).context("read exec exit reply")?;
+    let exit_reply: supervisor::SupervisorReply =
+        serde_json::from_str(line2.trim()).context("parse exec exit reply")?;
+    match exit_reply {
+        supervisor::SupervisorReply::Exit { code, signal } => {
+            if let Some(c) = code {
+                std::process::exit(c);
+            }
+            if let Some(s) = signal {
+                std::process::exit(128 + s);
+            }
+            std::process::exit(0);
+        }
+        supervisor::SupervisorReply::Err { msg } => bail!("exec failed: {}", msg),
+        other => bail!("unexpected exec exit reply: {:?}", other),
+    }
+    // Every arm above diverges (process::exit or bail!), so the match types as
+    // `!` and is the function's tail expression: no trailing Ok(()) needed.
 }
 
 /// Parse a signal name (e.g. "SIGTERM", "TERM", "15") into a libc signal number.

--- a/crates/sandlock-oci/src/main.rs
+++ b/crates/sandlock-oci/src/main.rs
@@ -104,21 +104,42 @@ enum Command {
     /// Check kernel feature support (delegates to sandlock-core checks).
     Check,
 
-    /// Execute a process inside a running sandbox.
+    /// Execute a process inside a running container (non-TTY).
     ///
-    /// **Not yet implemented.** Required for `kubectl exec` and exec-based
-    /// liveness/readiness probes.  Tracked as a known limitation.
-    ///
-    /// All arguments are accepted without validation so that containerd/CRI-O
-    /// invocations (which pass flags like `--process`, `--detach`, `--pid-file`
-    /// *before* the sandbox-id) parse cleanly and receive a clear error.
+    /// Supports inline args (`exec <id> <cmd> [args...]`) and the process-spec
+    /// form (`exec --process spec.json <id>`). The exec'd process is spawned by
+    /// the container's supervisor under a clone of the container policy, so it
+    /// is confined identically to the container's main process. `-t` /
+    /// `--console-socket` are accepted for runc compatibility but ignored (no
+    /// PTY yet).
     Exec {
-        /// All exec arguments captured as-is (id, flags, command).
-        /// `allow_hyphen_values` + `trailing_var_arg` ensure that runc-style
-        /// flags preceding the sandbox-id do not trigger an "unexpected
-        /// argument" error.
-        #[arg(num_args = 0.., trailing_var_arg = true, allow_hyphen_values = true)]
-        _args: Vec<String>,
+        /// Container identifier.
+        id: String,
+        /// Path to a process-spec JSON file (OCI `Process`). Takes precedence
+        /// over inline command args when provided.
+        #[arg(short = 'p', long = "process", value_name = "FILE")]
+        process: Option<PathBuf>,
+        /// Write the exec process PID to this file.
+        #[arg(long = "pid-file", value_name = "PATH")]
+        pid_file: Option<PathBuf>,
+        /// Detach: return after the process starts without waiting for exit.
+        #[arg(short = 'd', long)]
+        detach: bool,
+        /// Console socket for PTY exec (accepted, ignored: no PTY yet).
+        #[arg(long = "console-socket", value_name = "PATH")]
+        console_socket: Option<PathBuf>,
+        /// Allocate a pseudo-TTY (accepted, ignored: no PTY yet).
+        #[arg(short = 't', long)]
+        tty: bool,
+        /// Environment variable to set (KEY=VALUE). Repeatable.
+        #[arg(short = 'e', long = "env", value_name = "KEY=VALUE")]
+        env: Vec<String>,
+        /// Working directory inside the container.
+        #[arg(long, value_name = "PATH")]
+        cwd: Option<PathBuf>,
+        /// Command and arguments to execute inside the container.
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        command: Vec<String>,
     },
 
     /// Capture a checkpoint of a running sandbox to an image directory.
@@ -188,12 +209,26 @@ fn main() -> Result<()> {
                 }
             }
         }
-        Command::Exec { _args: _ } => {
-            bail!(
-                "`exec` is not implemented in sandlock-oci. \
-                 It is required for kubectl exec and exec-based probes but has not \
-                 yet been built (tracked as a known limitation)."
-            );
+        Command::Exec {
+            id,
+            process,
+            pid_file,
+            detach,
+            console_socket: _,
+            tty: _,
+            env,
+            cwd,
+            command,
+        } => {
+            cmd_exec(
+                &id,
+                process.as_deref(),
+                pid_file.as_deref(),
+                detach,
+                &env,
+                cwd.as_deref(),
+                &command,
+            )?;
         }
         Command::Check => {
             match sandlock_core::landlock_abi_version() {
@@ -628,6 +663,83 @@ fn cmd_checkpoint(id: &str, image_path: &str) -> Result<()> {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+/// Resolved request for an exec'd process: command, environment overrides, and
+/// optional working directory. Built from either a `--process` spec JSON or
+/// inline args, with `--env`/`--cwd` flags merged on top.
+#[derive(Debug)]
+struct ExecRequest {
+    args: Vec<String>,
+    env: Vec<(String, String)>,
+    cwd: Option<String>,
+}
+
+/// Resolve the exec command/env/cwd from a process-spec file or inline args.
+/// `--env` entries merge over (and override) the spec's env; `--cwd` overrides
+/// the spec's cwd.
+fn resolve_exec_request(
+    process_file: Option<&std::path::Path>,
+    inline_args: &[String],
+    extra_env: &[String],
+    extra_cwd: Option<&std::path::Path>,
+) -> Result<ExecRequest> {
+    use std::collections::BTreeMap;
+
+    let (args, mut env_map, mut cwd): (Vec<String>, BTreeMap<String, String>, Option<String>) =
+        if let Some(pf) = process_file {
+            let raw = std::fs::read_to_string(pf)
+                .with_context(|| format!("read process spec {:?}", pf))?;
+            let proc: oci_spec::runtime::Process =
+                serde_json::from_str(&raw).context("parse process spec JSON")?;
+            let args = proc.args().as_ref().cloned().unwrap_or_default();
+            let env: BTreeMap<String, String> = proc
+                .env()
+                .as_ref()
+                .map(|e| {
+                    e.iter()
+                        .filter_map(|v| v.split_once('=').map(|(k, v)| (k.to_string(), v.to_string())))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let c = proc.cwd().to_string_lossy().to_string();
+            let cwd = if c.is_empty() { None } else { Some(c) };
+            (args, env, cwd)
+        } else {
+            (inline_args.to_vec(), BTreeMap::new(), None)
+        };
+
+    for kv in extra_env {
+        if let Some((k, v)) = kv.split_once('=') {
+            env_map.insert(k.to_string(), v.to_string());
+        }
+    }
+    if let Some(c) = extra_cwd {
+        cwd = Some(c.to_string_lossy().to_string());
+    }
+
+    if args.is_empty() {
+        bail!("exec requires a command; pass it after the container ID or use --process");
+    }
+
+    Ok(ExecRequest {
+        args,
+        env: env_map.into_iter().collect(),
+        cwd,
+    })
+}
+
+/// Filled in by Task 4.
+fn cmd_exec(
+    _id: &str,
+    _process_file: Option<&std::path::Path>,
+    _pid_file: Option<&std::path::Path>,
+    _detach: bool,
+    _extra_env: &[String],
+    _extra_cwd: Option<&std::path::Path>,
+    _inline_args: &[String],
+) -> Result<()> {
+    bail!("exec: not wired yet")
+}
+
 /// Parse a signal name (e.g. "SIGTERM", "TERM", "15") into a libc signal number.
 fn parse_signal(s: &str) -> Result<i32> {
     // Try numeric first.
@@ -672,5 +784,45 @@ mod tests {
     #[test]
     fn parse_signal_unknown_errors() {
         assert!(parse_signal("SIGNOTREAL").is_err());
+    }
+
+    #[test]
+    fn resolve_inline_args_with_env_and_cwd() {
+        let req = resolve_exec_request(
+            None,
+            &["sh".to_string(), "-c".to_string(), "echo hi".to_string()],
+            &["FOO=bar".to_string(), "BAZ=qux".to_string()],
+            Some(std::path::Path::new("/work")),
+        )
+        .unwrap();
+        assert_eq!(req.args, vec!["sh", "-c", "echo hi"]);
+        assert!(req.env.contains(&("FOO".to_string(), "bar".to_string())));
+        assert!(req.env.contains(&("BAZ".to_string(), "qux".to_string())));
+        assert_eq!(req.cwd.as_deref(), Some("/work"));
+    }
+
+    #[test]
+    fn resolve_empty_command_errors() {
+        let err = resolve_exec_request(None, &[], &[], None).unwrap_err();
+        assert!(err.to_string().contains("requires a command"));
+    }
+
+    #[test]
+    fn resolve_process_spec_json() {
+        let dir = std::env::temp_dir().join(format!("sl-exec-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let spec = dir.join("process.json");
+        std::fs::write(
+            &spec,
+            r#"{"user":{"uid":0,"gid":0},"args":["/bin/true"],"env":["A=1"],"cwd":"/srv"}"#,
+        )
+        .unwrap();
+        let req = resolve_exec_request(Some(&spec), &[], &["B=2".to_string()], None).unwrap();
+        assert_eq!(req.args, vec!["/bin/true"]);
+        // --env merges on top of the spec env.
+        assert!(req.env.contains(&("A".to_string(), "1".to_string())));
+        assert!(req.env.contains(&("B".to_string(), "2".to_string())));
+        assert_eq!(req.cwd.as_deref(), Some("/srv"));
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/sandlock-oci/src/supervisor.rs
+++ b/crates/sandlock-oci/src/supervisor.rs
@@ -329,21 +329,27 @@ enum RunningCmd {
 }
 
 /// Handle a single accepted connection while the container is RUNNING. Serves
-/// Ping, Checkpoint, Start (idempotent no-op since already running), and
-/// Shutdown. Returns whether to keep serving or shut down.
+/// Ping, Checkpoint, Start (idempotent no-op since already running), Exec, and
+/// Shutdown. Takes the connection by value so the `Exec` arm can move it into a
+/// background task. Returns whether to keep serving or shut down.
 async fn serve_one_running(
-    stream: &mut tokio::net::UnixStream,
+    mut stream: tokio::net::UnixStream,
     sandbox: &mut sandlock_core::Sandbox,
     id: &str,
     child_pid: i32,
 ) -> RunningCmd {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    let mut buf = vec![0u8; 4096];
-    let n = stream.read(&mut buf).await.unwrap_or(0);
-    if n == 0 {
+    use tokio::io::AsyncWriteExt;
+
+    // Read the command via recvmsg so any SCM_RIGHTS fds (exec stdio) are
+    // captured with the same call as the bytes. Non-exec commands carry none.
+    let (buf, fds) = match crate::fdpass::recv_with_fds_async(&stream, 3).await {
+        Ok(pair) => pair,
+        Err(_) => return RunningCmd::Continue,
+    };
+    if buf.is_empty() {
         return RunningCmd::Continue;
     }
-    let incoming: SupervisorCmd = match serde_json::from_slice(&buf[..n]) {
+    let incoming: SupervisorCmd = match serde_json::from_slice(&buf) {
         Ok(c) => c,
         Err(e) => {
             let reply = serde_json::to_vec(&SupervisorReply::Err { msg: e.to_string() })
@@ -366,6 +372,12 @@ async fn serve_one_running(
             let reply = serde_json::to_vec(&SupervisorReply::Ok).unwrap_or_default();
             let _ = stream.write_all(&reply).await;
             let _ = stream.write_all(b"\n").await;
+            RunningCmd::Continue
+        }
+        SupervisorCmd::Exec { args, env, cwd, detach } => {
+            // Moves `stream` into handle_exec (which spawns the wait task), so
+            // the serve loop is freed to keep watching init and other commands.
+            handle_exec(stream, &*sandbox, id, child_pid, args, env, cwd, detach, fds).await;
             RunningCmd::Continue
         }
         SupervisorCmd::Checkpoint { dir } => {
@@ -391,17 +403,113 @@ async fn serve_one_running(
             let _ = stream.write_all(b"\n").await;
             RunningCmd::Shutdown
         }
-        // Temporary: Task 4 replaces this with the real exec handler.
-        SupervisorCmd::Exec { .. } => {
-            let reply = serde_json::to_vec(&SupervisorReply::Err {
-                msg: "exec not wired yet".into(),
-            })
-            .unwrap_or_default();
-            let _ = stream.write_all(&reply).await;
-            let _ = stream.write_all(b"\n").await;
-            RunningCmd::Continue
-        }
     }
+}
+
+/// Spawn an exec'd process under a clone of the container policy, join it to the
+/// container's process group, reply `Pid`, then (attached only) wait for it and
+/// reply `Exit`. The passed `fds` are stdin/stdout/stderr from the CLI; they are
+/// dup'd into the child by `create_with_io` and dropped afterward.
+#[allow(clippy::too_many_arguments)]
+async fn handle_exec(
+    mut stream: tokio::net::UnixStream,
+    sandbox: &sandlock_core::Sandbox,
+    id: &str,
+    child_pid: i32,
+    args: Vec<String>,
+    env: Vec<(String, String)>,
+    cwd: Option<String>,
+    detach: bool,
+    fds: Vec<std::os::unix::io::OwnedFd>,
+) {
+    use std::os::unix::io::AsRawFd;
+    use tokio::io::AsyncWriteExt;
+
+    if fds.len() < 3 {
+        let reply = serde_json::to_vec(&SupervisorReply::Err {
+            msg: "exec requires 3 stdio fds".into(),
+        })
+        .unwrap_or_default();
+        let _ = stream.write_all(&reply).await;
+        let _ = stream.write_all(b"\n").await;
+        return;
+    }
+    if args.is_empty() {
+        let reply = serde_json::to_vec(&SupervisorReply::Err { msg: "exec: empty command".into() })
+            .unwrap_or_default();
+        let _ = stream.write_all(&reply).await;
+        let _ = stream.write_all(b"\n").await;
+        return;
+    }
+
+    // Clone the live container policy (config only; runtime resets to None) and
+    // apply the exec's env/cwd overrides on top.
+    let mut exec_sb = sandbox.clone();
+    exec_sb.set_name(format!("{}-exec", id));
+    if let Some(c) = cwd {
+        exec_sb.cwd = Some(std::path::PathBuf::from(c));
+    }
+    for (k, v) in env {
+        exec_sb.env.insert(k, v);
+    }
+
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let (f0, f1, f2) = (fds[0].as_raw_fd(), fds[1].as_raw_fd(), fds[2].as_raw_fd());
+
+    if let Err(e) = exec_sb
+        .create_with_io(&arg_refs, Some(f0), Some(f1), Some(f2))
+        .await
+    {
+        let reply = serde_json::to_vec(&SupervisorReply::Err { msg: e.to_string() })
+            .unwrap_or_default();
+        let _ = stream.write_all(&reply).await;
+        let _ = stream.write_all(b"\n").await;
+        return;
+    }
+
+    let exec_pid = exec_sb.pid().unwrap_or(0);
+
+    // Join the container's process group so `kill --all` / `delete --force`
+    // (killpg on the init pid) reap this exec'd process. Valid: the child is
+    // parked pre-execve and shares the daemon's session. Best-effort.
+    if exec_pid > 0 && child_pid > 0 {
+        unsafe { libc::setpgid(exec_pid, child_pid) };
+    }
+
+    if let Err(e) = exec_sb.start() {
+        let reply = serde_json::to_vec(&SupervisorReply::Err { msg: e.to_string() })
+            .unwrap_or_default();
+        let _ = stream.write_all(&reply).await;
+        let _ = stream.write_all(b"\n").await;
+        return;
+    }
+
+    // Child now owns its dup'd stdio; the daemon's copies are no longer needed.
+    drop(fds);
+
+    // Report the pid immediately.
+    let reply = serde_json::to_vec(&SupervisorReply::Pid { pid: exec_pid }).unwrap_or_default();
+    let _ = stream.write_all(&reply).await;
+    let _ = stream.write_all(b"\n").await;
+
+    // Move the exec sandbox AND the connection into a background task so the
+    // daemon's serve loop is never blocked by the exec'd process's lifetime
+    // (init-exit detection and concurrent execs keep working). The task owns
+    // the sandbox so its seccomp-supervisor tasks stay alive until exit.
+    tokio::spawn(async move {
+        let result = exec_sb.wait().await;
+        if detach {
+            return; // reaped; the CLI already returned after Pid.
+        }
+        let (code, signal) = match exit_info_from(result) {
+            Some(ei) => (ei.code, ei.signal),
+            None => (None, None),
+        };
+        let reply =
+            serde_json::to_vec(&SupervisorReply::Exit { code, signal }).unwrap_or_default();
+        let _ = stream.write_all(&reply).await;
+        let _ = stream.write_all(b"\n").await;
+    });
 }
 
 /// Serve the control socket while the (already-running) child executes,
@@ -434,8 +542,8 @@ async fn serve_running(
             }
             conn = listener.accept() => {
                 match conn {
-                    Ok((mut stream, _)) => {
-                        match serve_one_running(&mut stream, sandbox, id, child_pid).await {
+                    Ok((stream, _)) => {
+                        match serve_one_running(stream, sandbox, id, child_pid).await {
                             RunningCmd::Continue => {}
                             RunningCmd::Shutdown => {
                                 let _ = sandbox.kill();

--- a/crates/sandlock-oci/src/supervisor.rs
+++ b/crates/sandlock-oci/src/supervisor.rs
@@ -38,6 +38,15 @@ pub enum SupervisorCmd {
     Shutdown,
     /// Capture a checkpoint of the running child into `dir`.
     Checkpoint { dir: String },
+    /// Run an additional process inside the running container. Carries 3
+    /// ancillary fds (stdin, stdout, stderr) over SCM_RIGHTS alongside this
+    /// JSON. `detach` means the CLI will not wait for an `Exit` reply.
+    Exec {
+        args: Vec<String>,
+        env: Vec<(String, String)>,
+        cwd: Option<String>,
+        detach: bool,
+    },
 }
 
 /// Responses from the Supervisor.
@@ -47,6 +56,8 @@ pub enum SupervisorReply {
     Ok,
     Pid { pid: i32 },
     Err { msg: String },
+    /// Final status of an exec'd process (attached exec only).
+    Exit { code: Option<i32>, signal: Option<i32> },
 }
 
 /// Returns the path to the supervisor socket for the given sandbox ID.
@@ -268,6 +279,14 @@ async fn supervisor_main(
                 let _ = stream.write_all(&reply).await;
                 let _ = stream.write_all(b"\n").await;
             }
+            SupervisorCmd::Exec { .. } => {
+                let reply = serde_json::to_vec(&SupervisorReply::Err {
+                    msg: "container is not running; start it before exec".into(),
+                })
+                .unwrap_or_default();
+                let _ = stream.write_all(&reply).await;
+                let _ = stream.write_all(b"\n").await;
+            }
         }
     }
 }
@@ -371,6 +390,16 @@ async fn serve_one_running(
             let _ = stream.write_all(&reply).await;
             let _ = stream.write_all(b"\n").await;
             RunningCmd::Shutdown
+        }
+        // Temporary: Task 4 replaces this with the real exec handler.
+        SupervisorCmd::Exec { .. } => {
+            let reply = serde_json::to_vec(&SupervisorReply::Err {
+                msg: "exec not wired yet".into(),
+            })
+            .unwrap_or_default();
+            let _ = stream.write_all(&reply).await;
+            let _ = stream.write_all(b"\n").await;
+            RunningCmd::Continue
         }
     }
 }
@@ -605,5 +634,29 @@ mod tests {
         assert!(json.contains("/tmp/img"));
         let back: SupervisorCmd = serde_json::from_str(&json).unwrap();
         assert!(matches!(back, SupervisorCmd::Checkpoint { .. }));
+    }
+
+    #[test]
+    fn supervisor_cmd_exec_serde() {
+        let cmd = SupervisorCmd::Exec {
+            args: vec!["sh".into(), "-c".into(), "echo hi".into()],
+            env: vec![("FOO".into(), "bar".into())],
+            cwd: Some("/work".into()),
+            detach: false,
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(json.contains("exec"));
+        let back: SupervisorCmd = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, SupervisorCmd::Exec { .. }));
+    }
+
+    #[test]
+    fn supervisor_reply_exit_serde() {
+        let reply = SupervisorReply::Exit { code: Some(3), signal: None };
+        let json = serde_json::to_string(&reply).unwrap();
+        assert!(json.contains("exit"));
+        assert!(json.contains('3'));
+        let back: SupervisorReply = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, SupervisorReply::Exit { code: Some(3), .. }));
     }
 }

--- a/crates/sandlock-oci/tests/integration.rs
+++ b/crates/sandlock-oci/tests/integration.rs
@@ -739,3 +739,102 @@ async fn oci_stop_collapses_process_group() {
         sample_a, sample_b
     );
 }
+/// End-to-end proof of `sandlock-oci exec`: create+start a long-lived container
+/// (`rootfs-helper spawn-loop`, whose parent pauses), then `exec` a second
+/// command (`rootfs-helper write`) that creates a sentinel file inside the
+/// container rootfs and exits 0. Verifies the exec CLI exits 0 (the supervisor's
+/// Pid + Exit relay works over SCM_RIGHTS) and that the exec'd process ran under
+/// the container's confinement (the sentinel lands inside the chroot). Landlock
+/// gated; rootfs-helper is portable C so there is no arch restriction.
+#[tokio::test(flavor = "multi_thread")]
+async fn oci_exec_runs_in_running_container() {
+    if sandlock_core::landlock_abi_version().is_err() {
+        eprintln!("skipping: Landlock unavailable on this host");
+        return;
+    }
+    let helper = rootfs_helper();
+    if !helper.exists() {
+        eprintln!("skipping: rootfs-helper not built (needs musl-gcc or cc -static)");
+        return;
+    }
+
+    let tmp = std::env::temp_dir().join(format!("sandlock-oci-exec-{}", std::process::id()));
+    fs::create_dir_all(&tmp).unwrap();
+    let bundle = tmp.join("bundle");
+    let rootfs = bundle.join("rootfs");
+    fs::create_dir_all(&rootfs).unwrap();
+    fs::copy(&helper, rootfs.join("rootfs-helper")).unwrap();
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(rootfs.join("rootfs-helper"), fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    // Long-lived main process: forks a keepalive worker, parent pauses forever.
+    create_bundle(&bundle, &["/rootfs-helper", "spawn-loop", "/keepalive.cnt"]);
+
+    let root = tempdir().unwrap();
+    let root_s = root.path().to_str().unwrap().to_string();
+    let id = "oci-exec-e2e";
+
+    // create (daemonizes a supervisor that inherits stdio; redirect + .status()).
+    let create_log = tmp.join("create.log");
+    let create_status = Command::new(oci_bin())
+        .args(["--root", &root_s, "create", id, "-b", bundle.to_str().unwrap()])
+        .stdout(std::process::Stdio::from(fs::File::create(&create_log).unwrap()))
+        .stderr(std::process::Stdio::from(
+            fs::OpenOptions::new().append(true).open(&create_log).unwrap(),
+        ))
+        .status()
+        .expect("run create");
+    assert!(create_status.success(), "create failed: {}", fs::read_to_string(&create_log).unwrap_or_default());
+
+    let start_out = Command::new(oci_bin())
+        .args(["--root", &root_s, "start", id])
+        .output()
+        .expect("run start");
+    assert!(start_out.status.success(), "start failed: {}", String::from_utf8_lossy(&start_out.stderr));
+
+    // Wait until the container is genuinely running (keepalive counter advances).
+    let host_keepalive = rootfs.join("keepalive.cnt");
+    let host_keepalive_s = host_keepalive.to_str().unwrap().to_string();
+    let read_counter = |path: &str| -> Option<u64> {
+        fs::read_to_string(path).ok().and_then(|s| s.trim().parse::<u64>().ok())
+    };
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let mut running = false;
+    while std::time::Instant::now() < deadline {
+        if read_counter(&host_keepalive_s).map(|v| v > 2).unwrap_or(false) {
+            running = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    assert!(running, "container never started; create_log: {}", fs::read_to_string(&create_log).unwrap_or_default());
+
+    // exec a write command inside the running container (attached). Exits 0.
+    let exec_out = Command::new(oci_bin())
+        .args(["--root", &root_s, "exec", id, "/rootfs-helper", "write", "/exec.ok", "done"])
+        .output()
+        .expect("run exec");
+
+    let sentinel = rootfs.join("exec.ok");
+    let sentinel_exists = sentinel.exists();
+    let sentinel_body = fs::read_to_string(&sentinel).unwrap_or_default();
+
+    // clean up before asserting so a failure never leaks the container.
+    let _ = Command::new(oci_bin())
+        .args(["--root", &root_s, "delete", id, "--force"])
+        .output();
+    let _ = fs::remove_dir_all(&tmp);
+
+    assert!(
+        exec_out.status.success(),
+        "exec CLI must exit 0 (got {:?}); stderr: {}",
+        exec_out.status.code(),
+        String::from_utf8_lossy(&exec_out.stderr)
+    );
+    assert!(
+        sentinel_exists,
+        "exec'd process must run inside the container rootfs and create /exec.ok"
+    );
+    assert_eq!(sentinel_body.trim(), "done", "exec'd process wrote the sentinel content");
+}


### PR DESCRIPTION
## Summary

Implements the OCI `exec` command in `sandlock-oci` so containerd/CRI-O (and thus `kubectl exec` and exec-based liveness/readiness probes) can run an additional, fully-confined process inside a running sandlock container. This was the crate's last known limitation.

## Design (supervisor-hosted, non-TTY)

sandlock has no PID namespace to `setns` into, so `exec` cannot attach to the container's main process. Instead it launches a new process under the same policy, spawned by the container's long-lived supervisor daemon so the daemon owns every process in the container (shared session, process group, and seccomp supervision).

Because the daemon, not the CLI, is the parent, the CLI's stdin/stdout/stderr (which the container shim wired to the exec stream) are passed to the daemon over the control socket via `SCM_RIGHTS`. The daemon spawns the child with those fds via `Sandbox::create_with_io`, folds it into the container's process group with `setpgid` (so `kill --all` / `delete --force` reap it), and relays a two-phase `Pid` then `Exit` reply. Attached exec exits with the child's status; `--detach` returns after `Pid`.

Exec'd processes are confined identically to the container's main process: virtual chroot (notify path rewriting), seccomp filter, network ACL, and resource limits, all rootless.

## Scope

- Supports `--process <spec.json>` and inline args, with `--env` / `--cwd` overrides merged on top.
- `--detach`, `--pid-file`.
- `-t` / `--console-socket` are accepted for runc compatibility but ignored. PTY support is deferred (the confinement model already permits terminal ioctls, so it is a clean follow-up); exec runs non-TTY only for now.

## Implementation (6 commits)

1. `SCM_RIGHTS` fd-passing helpers (`fdpass.rs`) with a roundtrip unit test that proves a passed fd is the same open file.
2. `SupervisorCmd::Exec` and `SupervisorReply::Exit` protocol additions.
3. Exec CLI struct and process-spec / env / cwd resolution.
4. Daemon `handle_exec` (clone policy, `create_with_io`, `setpgid`, two-phase reply, wait in a spawned task so the serve loop never blocks) plus the CLI socket client.
5. Landlock-gated end-to-end test: create+start a long-lived container, exec a command into it, assert the CLI exits 0 and the exec'd process ran inside the container chroot.
6. Docs: record exec in the lifecycle and note the non-TTY limitation.

## Testing

- Full `sandlock-oci` suite green: 42 lib + 48 bin + 13 integration on a Landlock v8 / x86_64 host.
- The e2e exec test passed 12 consecutive runs. It uses the prebuilt `rootfs-helper` (portable C, no inline freestanding program, no arch guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
