### PR TITLE
sandlock-core: confine COW supervisor against symlink escape

### DIFF
--- a/crates/sandlock-core/src/chroot/dispatch.rs
+++ b/crates/sandlock-core/src/chroot/dispatch.rs
@@ -47,7 +47,8 @@ use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
-use crate::chroot::resolve::{confine, openat2_in_root, resolve_existing_in_root, resolve_in_root, to_virtual_path};
+use crate::chroot::resolve::{confine, resolve_existing_in_root, resolve_in_root, to_virtual_path};
+use crate::sys::fs::openat2_in_root;
 use crate::seccomp::notif::{read_child_mem, write_child_mem, NotifAction};
 use crate::seccomp::state::{ChrootState, CowState};
 use crate::sys::structs::{SeccompNotif, SeccompNotifAddfd, SECCOMP_IOCTL_NOTIF_ADDFD};

--- a/crates/sandlock-core/src/chroot/resolve.rs
+++ b/crates/sandlock-core/src/chroot/resolve.rs
@@ -1,6 +1,6 @@
-use std::ffi::CString;
-use std::os::unix::io::RawFd;
 use std::path::{Path, PathBuf};
+
+use crate::sys::fs::openat2_in_root;
 
 /// Collapse `..` components clamping at `/` (pivot_root semantics).
 /// Always returns an absolute path under `/`.
@@ -34,86 +34,6 @@ pub fn to_virtual_path(chroot_root: &Path, host_path: &Path) -> Option<PathBuf> 
         .strip_prefix(chroot_root)
         .ok()
         .map(|rel| PathBuf::from("/").join(rel))
-}
-
-// ============================================================
-// openat2(RESOLVE_IN_ROOT) based resolution
-// ============================================================
-
-/// openat2 syscall number, sourced from the `syscalls` crate via `arch`.
-const SYS_OPENAT2: libc::c_long = crate::arch::SYS_OPENAT2;
-
-/// RESOLVE_IN_ROOT — treat the dirfd as the filesystem root for resolution.
-const RESOLVE_IN_ROOT: u64 = 0x10;
-
-/// Kernel `struct open_how` for openat2().
-#[repr(C)]
-struct OpenHow {
-    flags: u64,
-    mode: u64,
-    resolve: u64,
-}
-
-fn last_errno(fallback: i32) -> i32 {
-    std::io::Error::last_os_error()
-        .raw_os_error()
-        .unwrap_or(fallback)
-}
-
-/// Open a path confined within `chroot_root` using `openat2(RESOLVE_IN_ROOT)`.
-///
-/// The kernel handles symlink resolution, `..` traversal, and prevents
-/// escapes above the root — eliminating TOCTOU races and edge cases
-/// inherent in userspace path walking.
-pub fn openat2_in_root(
-    chroot_root: &Path,
-    path: &str,
-    flags: i32,
-    mode: u32,
-) -> Result<RawFd, i32> {
-    let c_root =
-        CString::new(chroot_root.to_str().unwrap_or("")).map_err(|_| libc::EINVAL)?;
-    let root_fd = unsafe {
-        libc::open(
-            c_root.as_ptr(),
-            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
-        )
-    };
-    if root_fd < 0 {
-        return Err(last_errno(libc::EIO));
-    }
-
-    let rel_path = path.strip_prefix('/').unwrap_or(path);
-    // Empty path means the root itself — use "."
-    let rel_path = if rel_path.is_empty() { "." } else { rel_path };
-    let c_path = CString::new(rel_path).map_err(|_| {
-        unsafe { libc::close(root_fd) };
-        libc::EINVAL
-    })?;
-
-    let how = OpenHow {
-        flags: flags as u64,
-        mode: mode as u64,
-        resolve: RESOLVE_IN_ROOT,
-    };
-
-    let fd = unsafe {
-        libc::syscall(
-            SYS_OPENAT2,
-            root_fd,
-            c_path.as_ptr(),
-            &how as *const OpenHow,
-            std::mem::size_of::<OpenHow>(),
-        )
-    } as i32;
-
-    unsafe { libc::close(root_fd) };
-
-    if fd < 0 {
-        Err(last_errno(libc::ENOENT))
-    } else {
-        Ok(fd)
-    }
 }
 
 /// Resolve a virtual path within the chroot using `openat2(RESOLVE_IN_ROOT)`.

--- a/crates/sandlock-core/src/cow/dispatch.rs
+++ b/crates/sandlock-core/src/cow/dispatch.rs
@@ -550,8 +550,9 @@ pub(crate) async fn handle_cow_write(
         None => return NotifAction::Continue,
     };
 
-    // Phase 1: check if we need to pre-copy a file (under lock, no heavy I/O)
-    let (copy_plan, copy_workdir, copy_rel) = {
+    // Phase 1: check if we need to pre-copy a file (under lock, no heavy I/O).
+    // Capture both layer roots here so Phase 2 needs no second lock.
+    let (copy_plan, copy_workdir, copy_upper, copy_rel) = {
         let mut st = cow_state.lock().await;
         let cow = match st.branch.as_mut() {
             Some(c) => c,
@@ -562,30 +563,21 @@ pub(crate) async fn handle_cow_write(
         match cow_copy_rel(&op, cow) {
             Some((_match_path, ref rel)) => {
                 let workdir = cow.workdir().to_path_buf();
+                let upper = cow.upper_dir().to_path_buf();
                 match cow.prepare_copy(rel) {
-                    Ok(plan) => (Some(plan), workdir, rel.clone()),
+                    Ok(plan) => (Some(plan), workdir, upper, rel.clone()),
                     Err(crate::error::BranchError::QuotaExceeded) => return NotifAction::Errno(libc::ENOSPC),
                     Err(_) => return NotifAction::Continue,
                 }
             }
-            None => (None, std::path::PathBuf::new(), String::new()),
+            None => (None, std::path::PathBuf::new(), std::path::PathBuf::new(), String::new()),
         }
     };
     // Lock is released here
 
     // Phase 2: execute the file copy outside the lock (if needed)
     if let Some(crate::cow::seccomp::CowCopyPlan::NeedsCopy { upper, lower: _lower, file_size }) = copy_plan {
-        // copy_workdir is workdir_root; we need upper_root for the dest side.
-        // Re-acquire it briefly: execute_deferred_copy needs both roots.
-        let uroot = {
-            let st = cow_state.lock().await;
-            st.branch.as_ref().map(|c| c.upper_dir().to_path_buf())
-        };
-        let uroot = match uroot {
-            Some(p) => p,
-            None => return NotifAction::Continue,
-        };
-        if execute_deferred_copy(cow_state, copy_workdir, uroot, copy_rel, upper, file_size).await.is_none() {
+        if execute_deferred_copy(cow_state, copy_workdir, copy_upper, copy_rel, upper, file_size).await.is_none() {
             return NotifAction::Continue;
         }
     }

--- a/crates/sandlock-core/src/cow/dispatch.rs
+++ b/crates/sandlock-core/src/cow/dispatch.rs
@@ -154,13 +154,16 @@ fn map_cow_upper_path(cow: &SeccompCowBranch, path: &str) -> String {
 /// child-controlled path cannot escape the upper/lower tree (issue #112).
 /// Picks the anchor root by prefix, then defers all resolution to the kernel
 /// via `openat2(RESOLVE_IN_ROOT)`.
-fn open_confined(
-    upper_root: &Path,
-    workdir_root: &Path,
+/// Select the layer root (`upper` first, then `workdir`) that `real_path` lives
+/// under and return it with the relative remainder. `Err(EACCES)` if the path
+/// is under neither root. This only selects the anchor; the kernel re-resolves
+/// the relative path under it with `RESOLVE_IN_ROOT`, so the lexical
+/// `strip_prefix` grants no trust.
+fn pick_root_rel<'a>(
+    upper_root: &'a Path,
+    workdir_root: &'a Path,
     real_path: &Path,
-    flags: i32,
-    mode: u32,
-) -> Result<RawFd, i32> {
+) -> Result<(&'a Path, String), i32> {
     let (root, rel) = if let Ok(rel) = real_path.strip_prefix(upper_root) {
         (upper_root, rel)
     } else if let Ok(rel) = real_path.strip_prefix(workdir_root) {
@@ -168,8 +171,18 @@ fn open_confined(
     } else {
         return Err(libc::EACCES);
     };
-    let rel = rel.to_str().ok_or(libc::EINVAL)?;
-    crate::sys::fs::openat2_in_root(root, rel, flags, mode)
+    Ok((root, rel.to_str().ok_or(libc::EINVAL)?.to_string()))
+}
+
+fn open_confined(
+    upper_root: &Path,
+    workdir_root: &Path,
+    real_path: &Path,
+    flags: i32,
+    mode: u32,
+) -> Result<RawFd, i32> {
+    let (root, rel) = pick_root_rel(upper_root, workdir_root, real_path)?;
+    crate::sys::fs::openat2_in_root(root, &rel, flags, mode)
 }
 
 /// Handle openat under workdir: redirect to COW upper/lower.
@@ -702,22 +715,25 @@ pub(crate) async fn handle_cow_utimensat(
         None => return NotifAction::Continue,
     };
 
-    let upper_path = {
+    let (upper_path, upper_root, workdir_root) = {
         let mut st = cow_state.lock().await;
         let cow = match st.branch.as_mut() {
             Some(c) => c,
             None => return NotifAction::Continue,
         };
+        let upper_root = cow.upper_dir().to_path_buf();
+        let workdir_root = cow.workdir().to_path_buf();
         let path = map_cow_upper_path(cow, &path);
         if !cow.matches(&path) {
             return NotifAction::Continue;
         }
-        match cow.handle_utimensat(&path) {
+        let p = match cow.handle_utimensat(&path) {
             Ok(Some(p)) => p,
             Ok(None) => return NotifAction::Continue,
             Err(crate::error::BranchError::QuotaExceeded) => return NotifAction::Errno(libc::ENOSPC),
             Err(_) => return NotifAction::Continue,
-        }
+        };
+        (p, upper_root, workdir_root)
     };
 
     // Read times from child memory (2 x struct timespec = 32 bytes on x86_64)
@@ -736,13 +752,14 @@ pub(crate) async fn handle_cow_utimensat(
         None
     };
 
-    let c_path = match std::ffi::CString::new(upper_path.to_str().unwrap_or("")) {
-        Ok(c) => c,
-        Err(_) => return NotifAction::Continue,
+    let (root, rel) = match pick_root_rel(&upper_root, &workdir_root, &upper_path) {
+        Ok(v) => v,
+        Err(e) => return NotifAction::Errno(e),
     };
     let times_raw = times.as_ref().map(|t| t.as_ptr()).unwrap_or(std::ptr::null());
-    if unsafe { libc::utimensat(libc::AT_FDCWD, c_path.as_ptr(), times_raw, flags) } < 0 {
-        return NotifAction::Errno(libc::EIO);
+    let follow = (flags & libc::AT_SYMLINK_NOFOLLOW) == 0;
+    if let Err(e) = crate::sys::fs::utimensat_in_root(root, &rel, times_raw, follow) {
+        return NotifAction::Errno(e);
     }
     NotifAction::ReturnValue(0)
 }
@@ -771,49 +788,52 @@ pub(crate) async fn handle_cow_stat(
         None => return NotifAction::Continue,
     };
 
-    let st = cow_state.lock().await;
-    let cow = match st.branch.as_ref() {
-        Some(c) => c,
-        None => return NotifAction::Continue,
-    };
-
-    let path = map_cow_upper_path(cow, &path);
-    if !cow.has_changes() || !cow.matches(&path) {
-        return NotifAction::Continue;
-    }
-
-    let real_path = match cow.handle_stat(&path) {
-        Some(p) => p,
-        None => {
-            return NotifAction::Errno(libc::ENOENT);
+    let (real_path, upper_root, workdir_root) = {
+        let st = cow_state.lock().await;
+        let cow = match st.branch.as_ref() {
+            Some(c) => c,
+            None => return NotifAction::Continue,
+        };
+        let upper_root = cow.upper_dir().to_path_buf();
+        let workdir_root = cow.workdir().to_path_buf();
+        let path = map_cow_upper_path(cow, &path);
+        if !cow.has_changes() || !cow.matches(&path) {
+            return NotifAction::Continue;
         }
+        let real = match cow.handle_stat(&path) {
+            Some(p) => p,
+            None => return NotifAction::Errno(libc::ENOENT),
+        };
+        (real, upper_root, workdir_root)
     };
-    drop(st);
 
     if nr == libc::SYS_faccessat || nr == crate::arch::SYS_FACCESSAT2 {
-        // For faccessat, just check if the file exists (we already resolved it)
-        if real_path.exists() || real_path.is_symlink() {
+        // Existence check, confined: lstat succeeds for any present entry
+        // (including a dangling symlink), matching the prior semantics.
+        let (root, rel) = match pick_root_rel(&upper_root, &workdir_root, &real_path) {
+            Ok(v) => v,
+            Err(_) => return NotifAction::Errno(libc::ENOENT),
+        };
+        if crate::sys::fs::statat_in_root(root, &rel, false).is_ok() {
             return NotifAction::ReturnValue(0);
         }
         return NotifAction::Errno(libc::ENOENT);
     }
 
-    // newfstatat — stat the resolved path and write the native libc layout
-    // back to the child. Do not hand-pack struct stat; its layout is
-    // architecture-specific.
+    // newfstatat — stat the resolved path (confined to its layer root) and
+    // write the native libc layout back to the child. Do not hand-pack struct
+    // stat; its layout is architecture-specific.
     let statbuf_addr = notif.data.args[2];
     let flags = (notif.data.args[3] & 0xFFFF_FFFF) as i32;
-    let c_path = match std::ffi::CString::new(real_path.to_str().unwrap_or("")) {
-        Ok(c) => c,
-        Err(_) => return NotifAction::Continue,
+    let follow = (flags & libc::AT_SYMLINK_NOFOLLOW) == 0;
+    let (root, rel) = match pick_root_rel(&upper_root, &workdir_root, &real_path) {
+        Ok(v) => v,
+        Err(e) => return NotifAction::Errno(e),
     };
-    let mut statbuf: libc::stat = unsafe { std::mem::zeroed() };
-    if unsafe { libc::fstatat(libc::AT_FDCWD, c_path.as_ptr(), &mut statbuf, flags) } < 0 {
-        let errno = std::io::Error::last_os_error()
-            .raw_os_error()
-            .unwrap_or(libc::EIO);
-        return NotifAction::Errno(errno);
-    }
+    let statbuf = match crate::sys::fs::statat_in_root(root, &rel, follow) {
+        Ok(s) => s,
+        Err(e) => return NotifAction::Errno(e),
+    };
     let buf = unsafe {
         std::slice::from_raw_parts(
             &statbuf as *const libc::stat as *const u8,
@@ -859,44 +879,32 @@ pub(crate) async fn handle_cow_statx(
         _ => return NotifAction::Continue,
     };
 
-    let real_path = {
+    let (real_path, upper_root, workdir_root) = {
         let st = cow_state.lock().await;
         let cow = match st.branch.as_ref() {
             Some(c) => c,
             None => return NotifAction::Continue,
         };
-
+        let upper_root = cow.upper_dir().to_path_buf();
+        let workdir_root = cow.workdir().to_path_buf();
         let path = map_cow_upper_path(cow, &path);
         if !cow.has_changes() || !cow.matches(&path) {
             return NotifAction::Continue;
         }
-
-        match cow.handle_stat(&path) {
+        let real = match cow.handle_stat(&path) {
             Some(p) => p,
             None => return NotifAction::Errno(libc::ENOENT), // deleted or absent
-        }
+        };
+        (real, upper_root, workdir_root)
     };
 
-    let c_path = match std::ffi::CString::new(real_path.to_str().unwrap_or("")) {
-        Ok(c) => c,
-        Err(_) => return NotifAction::Continue,
+    let (root, rel) = match pick_root_rel(&upper_root, &workdir_root, &real_path) {
+        Ok(v) => v,
+        Err(e) => return NotifAction::Errno(e),
     };
     let mut stx_buf = vec![0u8; 256]; // sizeof(struct statx)
-    let ret = unsafe {
-        libc::syscall(
-            libc::SYS_statx,
-            libc::AT_FDCWD,
-            c_path.as_ptr(),
-            flags,
-            mask,
-            stx_buf.as_mut_ptr(),
-        )
-    };
-    if ret < 0 {
-        let errno = std::io::Error::last_os_error()
-            .raw_os_error()
-            .unwrap_or(libc::EIO);
-        return NotifAction::Errno(errno);
+    if let Err(e) = crate::sys::fs::statx_in_root(root, &rel, flags, mask, &mut stx_buf) {
+        return NotifAction::Errno(e);
     }
 
     if write_child_mem(notif_fd, notif.id, notif.pid, statxbuf_addr, &stx_buf).is_err() {

--- a/crates/sandlock-core/src/cow/dispatch.rs
+++ b/crates/sandlock-core/src/cow/dispatch.rs
@@ -150,6 +150,28 @@ fn map_cow_upper_path(cow: &SeccompCowBranch, path: &str) -> String {
 // openat handler
 // ============================================================
 
+/// Open `real_path` confined to its layer root, so a symlink or `..` in the
+/// child-controlled path cannot escape the upper/lower tree (issue #112).
+/// Picks the anchor root by prefix, then defers all resolution to the kernel
+/// via `openat2(RESOLVE_IN_ROOT)`.
+fn open_confined(
+    upper_root: &Path,
+    workdir_root: &Path,
+    real_path: &Path,
+    flags: i32,
+    mode: u32,
+) -> Result<RawFd, i32> {
+    let (root, rel) = if let Ok(rel) = real_path.strip_prefix(upper_root) {
+        (upper_root, rel)
+    } else if let Ok(rel) = real_path.strip_prefix(workdir_root) {
+        (workdir_root, rel)
+    } else {
+        return Err(libc::EACCES);
+    };
+    let rel = rel.to_str().ok_or(libc::EINVAL)?;
+    crate::sys::fs::openat2_in_root(root, rel, flags, mode)
+}
+
 /// Handle openat under workdir: redirect to COW upper/lower.
 /// openat(dirfd, pathname, flags, mode): args[0]=dirfd, args[1]=path, args[2]=flags
 pub(crate) async fn handle_cow_open(
@@ -182,12 +204,14 @@ pub(crate) async fn handle_cow_open(
     let mut path = resolve_at_path_with_virtual(notif, dirfd, &rel_path, virtual_cwd.as_deref());
 
     // Phase 1: determine plan under lock (no heavy I/O)
-    let plan = {
+    let (plan, upper_root, workdir_root) = {
         let mut st = cow_state.lock().await;
         let cow = match st.branch.as_mut() {
             Some(c) => c,
             None => return NotifAction::Continue,
         };
+        let upper_root = cow.upper_dir().to_path_buf();
+        let workdir_root = cow.workdir().to_path_buf();
 
         path = map_cow_upper_path(cow, &path);
         if !cow.matches(&path) {
@@ -206,12 +230,13 @@ pub(crate) async fn handle_cow_open(
             return NotifAction::Continue;
         }
 
-        match cow.prepare_open(&path, flags) {
+        let plan = match cow.prepare_open(&path, flags) {
             Ok(plan) => plan,
             Err(crate::error::BranchError::QuotaExceeded) => return NotifAction::Errno(libc::ENOSPC),
             Err(crate::error::BranchError::Exists) => return NotifAction::Errno(libc::EEXIST),
             Err(_) => return NotifAction::Continue,
-        }
+        };
+        (plan, upper_root, workdir_root)
     };
     // Lock is released here
 
@@ -219,11 +244,13 @@ pub(crate) async fn handle_cow_open(
     let real_path = match plan {
         CowOpenPlan::Skip => return NotifAction::Continue,
         CowOpenPlan::Resolved(p) | CowOpenPlan::UpperReady { upper: p } => p,
-        CowOpenPlan::NeedsCopy { upper, lower, file_size, rel_path: _rel } => {
+        CowOpenPlan::NeedsCopy { upper, lower: _lower, file_size, rel_path } => {
             // Do the potentially-expensive copy on a blocking thread
             let upper_clone = upper.clone();
+            let root = workdir_root.clone();
+            let rel = rel_path.clone();
             let copy_result = tokio::task::spawn_blocking(move || {
-                crate::cow::seccomp::SeccompCowBranch::execute_copy(&upper_clone, &lower)
+                crate::cow::seccomp::SeccompCowBranch::execute_copy(&root, &rel, &upper_clone)
             }).await;
 
             match copy_result {
@@ -244,19 +271,15 @@ pub(crate) async fn handle_cow_open(
     // Strip O_EXCL — the COW layer already verified exclusivity. Keeping it
     // would fail because we may have just copied the file into upper.
     let open_flags = (flags & !(libc::O_EXCL as u64)) as i32;
-    let c_path = match std::ffi::CString::new(real_path.to_str().unwrap_or("")) {
-        Ok(c) => c,
-        Err(_) => return NotifAction::Continue,
-    };
     // Honor the child's requested creation mode (masked to permission bits).
     // Hardcoding 0o666 dropped the execute bits, so a binary copied into the
     // workdir (e.g. `cp /bin/echo m`) landed in upper non-executable and
     // `./m` failed with EACCES. The kernel ignores mode unless O_CREAT is set.
     let create_mode = (mode & 0o7777) as libc::c_uint;
-    let fd = unsafe { libc::open(c_path.as_ptr(), open_flags, create_mode) };
-    if fd < 0 {
-        return NotifAction::Continue;
-    }
+    let fd = match open_confined(&upper_root, &workdir_root, &real_path, open_flags, create_mode) {
+        Ok(fd) => fd,
+        Err(_) => return NotifAction::Continue,
+    };
 
     // Preserve O_CLOEXEC from the original openat flags.
     let newfd_flags = if flags & libc::O_CLOEXEC as u64 != 0 {
@@ -473,13 +496,14 @@ fn cow_copy_rel<'a>(
 /// Returns the upper path on success, or rolls back quota on failure.
 async fn execute_deferred_copy(
     cow_state: &Arc<Mutex<CowState>>,
+    workdir_root: std::path::PathBuf,
+    rel: String,
     upper: std::path::PathBuf,
-    lower: std::path::PathBuf,
     file_size: u64,
 ) -> Option<std::path::PathBuf> {
     let upper_clone = upper.clone();
     let copy_result = tokio::task::spawn_blocking(move || {
-        crate::cow::seccomp::SeccompCowBranch::execute_copy(&upper_clone, &lower)
+        crate::cow::seccomp::SeccompCowBranch::execute_copy(&workdir_root, &rel, &upper_clone)
     }).await;
     match copy_result {
         Ok(Ok(())) => Some(upper),
@@ -514,7 +538,7 @@ pub(crate) async fn handle_cow_write(
     };
 
     // Phase 1: check if we need to pre-copy a file (under lock, no heavy I/O)
-    let copy_plan = {
+    let (copy_plan, copy_workdir, copy_rel) = {
         let mut st = cow_state.lock().await;
         let cow = match st.branch.as_mut() {
             Some(c) => c,
@@ -524,20 +548,21 @@ pub(crate) async fn handle_cow_write(
         op.remap_upper_paths(cow);
         match cow_copy_rel(&op, cow) {
             Some((_match_path, ref rel)) => {
+                let workdir = cow.workdir().to_path_buf();
                 match cow.prepare_copy(rel) {
-                    Ok(plan) => Some(plan),
+                    Ok(plan) => (Some(plan), workdir, rel.clone()),
                     Err(crate::error::BranchError::QuotaExceeded) => return NotifAction::Errno(libc::ENOSPC),
                     Err(_) => return NotifAction::Continue,
                 }
             }
-            None => None,
+            None => (None, std::path::PathBuf::new(), String::new()),
         }
     };
     // Lock is released here
 
     // Phase 2: execute the file copy outside the lock (if needed)
-    if let Some(crate::cow::seccomp::CowCopyPlan::NeedsCopy { upper, lower, file_size }) = copy_plan {
-        if execute_deferred_copy(cow_state, upper, lower, file_size).await.is_none() {
+    if let Some(crate::cow::seccomp::CowCopyPlan::NeedsCopy { upper, lower: _lower, file_size }) = copy_plan {
+        if execute_deferred_copy(cow_state, copy_workdir, copy_rel, upper, file_size).await.is_none() {
             return NotifAction::Continue;
         }
     }
@@ -921,35 +946,40 @@ pub(crate) async fn handle_cow_exec(
     };
     let resolved = resolve_at_path_with_virtual(notif, dirfd, &rel_path, virtual_cwd.as_deref());
 
-    let upper_path = {
+    let (upper_path, upper_root, workdir_root) = {
         let st = cow_state.lock().await;
         let cow = match st.branch.as_ref() {
             Some(c) => c,
             None => return NotifAction::Continue,
         };
+        let upper_root = cow.upper_dir().to_path_buf();
+        let workdir_root = cow.workdir().to_path_buf();
         let path = map_cow_upper_path(cow, &resolved);
         if !cow.has_changes() || !cow.matches(&path) {
             return NotifAction::Continue;
         }
-        match cow.handle_stat(&path) {
+        let real = match cow.handle_stat(&path) {
             // Only redirect when the binary lives in the upper layer.
             Some(real) if real.starts_with(cow.upper_dir()) => real,
             // Lower-layer (unmodified) binary — kernel resolves it fine.
             Some(_) => return NotifAction::Continue,
             // Deleted in the COW layer (or absent) — must not exec the lower file.
             None => return NotifAction::Errno(libc::ENOENT),
-        }
+        };
+        (real, upper_root, workdir_root)
     };
 
     // Open the upper binary and inject the fd into the child.
-    let c_path = match std::ffi::CString::new(upper_path.to_str().unwrap_or("")) {
-        Ok(c) => c,
-        Err(_) => return NotifAction::Continue,
+    let src_fd = match open_confined(
+        &upper_root,
+        &workdir_root,
+        &upper_path,
+        libc::O_RDONLY | libc::O_CLOEXEC,
+        0,
+    ) {
+        Ok(fd) => fd,
+        Err(_) => return NotifAction::Errno(libc::ENOENT),
     };
-    let src_fd = unsafe { libc::open(c_path.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC) };
-    if src_fd < 0 {
-        return NotifAction::Errno(libc::ENOENT);
-    }
 
     let addfd = crate::sys::structs::SeccompNotifAddfd {
         id: notif.id,
@@ -1189,12 +1219,14 @@ pub(crate) async fn handle_cow_chdir(
         virtual_cwd.as_deref(),
     );
 
-    let (abs_path, upper_path) = {
+    let (abs_path, upper_path, upper_root, workdir_root) = {
         let st = cow_state.lock().await;
         let cow = match st.branch.as_ref() {
             Some(c) => c,
             None => return NotifAction::Continue,
         };
+        let upper_root = cow.upper_dir().to_path_buf();
+        let workdir_root = cow.workdir().to_path_buf();
         let abs_path = map_cow_upper_path(cow, &resolved);
         if !cow.matches(&abs_path) {
             return NotifAction::Continue;
@@ -1204,7 +1236,7 @@ pub(crate) async fn handle_cow_chdir(
             None => return NotifAction::Continue,
         };
         let upper_path = cow.upper_dir().join(&rel);
-        (abs_path, upper_path)
+        (abs_path, upper_path, upper_root, workdir_root)
     };
 
     // If the directory exists on the real filesystem, let the kernel handle it.
@@ -1218,16 +1250,16 @@ pub(crate) async fn handle_cow_chdir(
     }
 
     // Open the upper directory and inject fd into the child.
-    let c_path = match std::ffi::CString::new(upper_path.to_str().unwrap_or("")) {
-        Ok(c) => c,
-        Err(_) => return NotifAction::Continue,
+    let src_fd = match open_confined(
+        &upper_root,
+        &workdir_root,
+        &upper_path,
+        libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+        0,
+    ) {
+        Ok(fd) => fd,
+        Err(_) => return NotifAction::Errno(libc::ENOENT),
     };
-    let src_fd = unsafe {
-        libc::open(c_path.as_ptr(), libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC)
-    };
-    if src_fd < 0 {
-        return NotifAction::Errno(libc::ENOENT);
-    }
 
     let addfd = crate::sys::structs::SeccompNotifAddfd {
         id: notif.id,
@@ -1319,4 +1351,80 @@ pub(crate) async fn handle_cow_getcwd(
         return NotifAction::Continue;
     }
     NotifAction::ReturnValue(write_buf.len() as i64)
+}
+
+#[cfg(test)]
+mod confine_tests {
+    use super::open_confined;
+    use std::os::unix::fs::symlink;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn read_fd_path(fd: i32) -> std::path::PathBuf {
+        std::fs::read_link(format!("/proc/self/fd/{}", fd)).unwrap()
+    }
+
+    #[test]
+    fn serves_in_tree_file() {
+        let upper = TempDir::new().unwrap();
+        let lower = TempDir::new().unwrap();
+        std::fs::write(lower.path().join("ok.txt"), "data").unwrap();
+        let real = lower.path().join("ok.txt");
+        match open_confined(upper.path(), lower.path(), &real, libc::O_RDONLY, 0) {
+            Ok(fd) => {
+                assert_eq!(std::fs::read_to_string(format!("/proc/self/fd/{}", fd)).unwrap(), "data");
+                unsafe { libc::close(fd) };
+            }
+            Err(libc::ENOSYS) => {}
+            Err(e) => panic!("unexpected error: {}", e),
+        }
+    }
+
+    #[test]
+    fn blocks_final_component_symlink_escape() {
+        let upper = TempDir::new().unwrap();
+        let lower = TempDir::new().unwrap();
+        // workdir/link -> /etc/passwd
+        symlink("/etc/passwd", lower.path().join("link")).unwrap();
+        let real = lower.path().join("link");
+        match open_confined(upper.path(), lower.path(), &real, libc::O_RDONLY, 0) {
+            // Confined: /etc/passwd resolves under <lower>/etc/passwd, absent.
+            Err(libc::ENOENT) | Err(libc::ENOSYS) => {}
+            Ok(fd) => {
+                let resolved = read_fd_path(fd);
+                unsafe { libc::close(fd) };
+                assert!(resolved.starts_with(lower.path()), "escaped: {:?}", resolved);
+            }
+            Err(e) => panic!("unexpected error: {}", e),
+        }
+    }
+
+    #[test]
+    fn blocks_intermediate_component_symlink_escape() {
+        let upper = TempDir::new().unwrap();
+        let lower = TempDir::new().unwrap();
+        // workdir/evil -> /etc, child opens evil/passwd
+        symlink("/etc", lower.path().join("evil")).unwrap();
+        let real = lower.path().join("evil/passwd");
+        match open_confined(upper.path(), lower.path(), &real, libc::O_RDONLY, 0) {
+            Err(libc::ENOENT) | Err(libc::ENOSYS) => {}
+            Ok(fd) => {
+                let resolved = read_fd_path(fd);
+                unsafe { libc::close(fd) };
+                assert!(resolved.starts_with(lower.path()), "escaped: {:?}", resolved);
+            }
+            Err(e) => panic!("unexpected error: {}", e),
+        }
+    }
+
+    #[test]
+    fn refuses_path_under_neither_root() {
+        let upper = TempDir::new().unwrap();
+        let lower = TempDir::new().unwrap();
+        let real = Path::new("/etc/passwd");
+        assert_eq!(
+            open_confined(upper.path(), lower.path(), real, libc::O_RDONLY, 0),
+            Err(libc::EACCES)
+        );
+    }
 }

--- a/crates/sandlock-core/src/cow/dispatch.rs
+++ b/crates/sandlock-core/src/cow/dispatch.rs
@@ -259,11 +259,11 @@ pub(crate) async fn handle_cow_open(
         CowOpenPlan::Resolved(p) | CowOpenPlan::UpperReady { upper: p } => p,
         CowOpenPlan::NeedsCopy { upper, lower: _lower, file_size, rel_path } => {
             // Do the potentially-expensive copy on a blocking thread
-            let upper_clone = upper.clone();
             let root = workdir_root.clone();
+            let uroot = upper_root.clone();
             let rel = rel_path.clone();
             let copy_result = tokio::task::spawn_blocking(move || {
-                crate::cow::seccomp::SeccompCowBranch::execute_copy(&root, &rel, &upper_clone)
+                crate::cow::seccomp::SeccompCowBranch::execute_copy(&root, &uroot, &rel)
             }).await;
 
             match copy_result {
@@ -510,13 +510,13 @@ fn cow_copy_rel<'a>(
 async fn execute_deferred_copy(
     cow_state: &Arc<Mutex<CowState>>,
     workdir_root: std::path::PathBuf,
+    upper_root: std::path::PathBuf,
     rel: String,
     upper: std::path::PathBuf,
     file_size: u64,
 ) -> Option<std::path::PathBuf> {
-    let upper_clone = upper.clone();
     let copy_result = tokio::task::spawn_blocking(move || {
-        crate::cow::seccomp::SeccompCowBranch::execute_copy(&workdir_root, &rel, &upper_clone)
+        crate::cow::seccomp::SeccompCowBranch::execute_copy(&workdir_root, &upper_root, &rel)
     }).await;
     match copy_result {
         Ok(Ok(())) => Some(upper),
@@ -575,7 +575,17 @@ pub(crate) async fn handle_cow_write(
 
     // Phase 2: execute the file copy outside the lock (if needed)
     if let Some(crate::cow::seccomp::CowCopyPlan::NeedsCopy { upper, lower: _lower, file_size }) = copy_plan {
-        if execute_deferred_copy(cow_state, copy_workdir, copy_rel, upper, file_size).await.is_none() {
+        // copy_workdir is workdir_root; we need upper_root for the dest side.
+        // Re-acquire it briefly: execute_deferred_copy needs both roots.
+        let uroot = {
+            let st = cow_state.lock().await;
+            st.branch.as_ref().map(|c| c.upper_dir().to_path_buf())
+        };
+        let uroot = match uroot {
+            Some(p) => p,
+            None => return NotifAction::Continue,
+        };
+        if execute_deferred_copy(cow_state, copy_workdir, uroot, copy_rel, upper, file_size).await.is_none() {
             return NotifAction::Continue;
         }
     }

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -260,22 +260,39 @@ impl SeccompCowBranch {
 
     /// Execute a file copy synchronously. Used by `ensure_cow_copy` and the
     /// async dispatch (via `spawn_blocking`).
-    pub fn execute_copy(upper: &Path, lower: &Path) -> Result<(), std::io::Error> {
-        match fs::copy(lower, upper) {
-            Ok(_) => {
-                if let Ok(meta) = lower.metadata() {
-                    let _ = fs::set_permissions(upper, meta.permissions());
-                }
-                Ok(())
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
-                // Can't read the lower file (e.g. root-owned 0640).
-                // Create an empty file in upper so writes can proceed.
+    pub fn execute_copy(
+        workdir_root: &Path,
+        rel: &str,
+        upper: &Path,
+    ) -> Result<(), std::io::Error> {
+        use std::os::unix::io::FromRawFd;
+
+        // Read the lower source confined to the workdir root: a symlink or
+        // `..` in `rel` cannot escape the tree (issue #112).
+        let fd = match crate::sys::fs::openat2_in_root(
+            workdir_root,
+            rel,
+            libc::O_RDONLY | libc::O_CLOEXEC,
+            0,
+        ) {
+            Ok(fd) => fd,
+            // Unreadable (EACCES) or confined-out / absent (ENOENT): give the
+            // child an empty COW file so writes proceed, never leaking the
+            // escape target.
+            Err(libc::EACCES) | Err(libc::ENOENT) => {
                 fs::File::create(upper)?;
-                Ok(())
+                return Ok(());
             }
-            Err(e) => Err(e),
+            Err(e) => return Err(std::io::Error::from_raw_os_error(e)),
+        };
+
+        let mut src = unsafe { fs::File::from_raw_fd(fd) };
+        let mut dst = fs::File::create(upper)?;
+        std::io::copy(&mut src, &mut dst)?;
+        if let Ok(meta) = src.metadata() {
+            let _ = fs::set_permissions(upper, meta.permissions());
         }
+        Ok(())
     }
 
     /// Ensure a COW copy exists in upper (synchronous). Returns the upper path.
@@ -283,8 +300,8 @@ impl SeccompCowBranch {
     pub fn ensure_cow_copy(&mut self, rel_path: &str) -> Result<PathBuf, BranchError> {
         match self.prepare_copy(rel_path)? {
             CowCopyPlan::Ready(upper) => Ok(upper),
-            CowCopyPlan::NeedsCopy { upper, lower, file_size } => {
-                match Self::execute_copy(&upper, &lower) {
+            CowCopyPlan::NeedsCopy { upper, lower: _lower, file_size } => {
+                match Self::execute_copy(&self.workdir, rel_path, &upper) {
                     Ok(()) => Ok(upper),
                     Err(e) => {
                         self.rollback_copy(file_size);
@@ -1463,5 +1480,34 @@ mod tests {
         // unlink (is_dir=false) on a regular file should succeed.
         let path = abs(&branch, "existing.txt");
         assert!(branch.handle_unlink(&path, false).unwrap());
+    }
+
+    #[test]
+    fn copy_up_does_not_follow_symlinked_parent() {
+        // workdir/evil -> /etc ; writing evil/group must not copy /etc/group.
+        let (workdir, storage) = setup_workdir();
+        std::os::unix::fs::symlink("/etc", workdir.path().join("evil")).unwrap();
+        let mut branch =
+            SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+
+        // ensure_cow_copy on a path reached through the symlinked parent.
+        let upper = branch.ensure_cow_copy("evil/group").unwrap();
+
+        // The upper file must NOT contain the host /etc/group contents.
+        let host = std::fs::read_to_string("/etc/group").unwrap_or_default();
+        let copied = std::fs::read_to_string(&upper).unwrap_or_default();
+        assert!(
+            copied.is_empty() || copied != host,
+            "copy-up leaked /etc/group into the upper layer"
+        );
+    }
+
+    #[test]
+    fn copy_up_copies_legitimate_in_tree_file() {
+        let (workdir, storage) = setup_workdir();
+        let mut branch =
+            SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        let upper = branch.ensure_cow_copy("existing.txt").unwrap();
+        assert_eq!(std::fs::read_to_string(&upper).unwrap(), "hello");
     }
 }

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -6,6 +6,8 @@
 
 use std::collections::HashSet;
 use std::fs;
+use std::os::unix::ffi::OsStringExt;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 use crate::error::BranchError;
@@ -207,7 +209,9 @@ impl SeccompCowBranch {
         let upper_file = self.upper.join(rel_path);
         let lower_file = self.workdir.join(rel_path);
 
-        if upper_file.exists() || upper_file.is_symlink() {
+        // Already materialized in upper? Confined lstat succeeds for any
+        // existing entry (including a dangling symlink).
+        if crate::sys::fs::statat_in_root(&self.upper, rel_path, false).is_ok() {
             return Ok(CowCopyPlan::Ready(upper_file));
         }
 
@@ -216,11 +220,26 @@ impl SeccompCowBranch {
                 .map_err(|e| BranchError::Operation(format!("create parent: {}", e)))?;
         }
 
-        // Symlink — copy immediately (tiny, not worth deferring)
-        if lower_file.is_symlink() {
+        // Classify the lower entry confined to the workdir root, so a symlinked
+        // parent component cannot make us follow out of the tree (issue #112).
+        // The lstat also yields the size of the entry we will actually copy.
+        let st = match crate::sys::fs::statat_in_root(&self.workdir, rel_path, false) {
+            Ok(st) => st,
+            // Absent or confined-out: treat as a new file created in upper.
+            Err(libc::ENOENT) => {
+                self.check_quota(0)?;
+                return Ok(CowCopyPlan::Ready(upper_file));
+            }
+            Err(e) => return Err(BranchError::Operation(format!("stat lower: {}", e))),
+        };
+        let kind = st.st_mode & libc::S_IFMT;
+
+        // Symlink — copy verbatim (tiny, not worth deferring)
+        if kind == libc::S_IFLNK {
             self.check_quota(256)?;
-            let target = fs::read_link(&lower_file)
+            let target = crate::sys::fs::readlink_in_root(&self.workdir, rel_path)
                 .map_err(|e| BranchError::Operation(format!("readlink: {}", e)))?;
+            let target = std::path::PathBuf::from(std::ffi::OsString::from_vec(target));
             std::os::unix::fs::symlink(&target, &upper_file)
                 .map_err(|e| BranchError::Operation(format!("symlink: {}", e)))?;
             self.disk_used += 256;
@@ -228,34 +247,29 @@ impl SeccompCowBranch {
         }
 
         // Directory — create immediately (no data copy)
-        if lower_file.is_dir() {
+        if kind == libc::S_IFDIR {
             self.check_quota(4096)?;
             fs::create_dir_all(&upper_file)
                 .map_err(|e| BranchError::Operation(format!("create dir: {}", e)))?;
-            if let Ok(meta) = lower_file.metadata() {
-                let _ = fs::set_permissions(&upper_file, meta.permissions());
-            }
+            let _ = fs::set_permissions(
+                &upper_file,
+                std::fs::Permissions::from_mode(st.st_mode & 0o7777),
+            );
             self.disk_used += 4096;
             return Ok(CowCopyPlan::Ready(upper_file));
         }
 
-        // Regular file — defer the potentially expensive copy
-        if lower_file.exists() {
-            let meta = lower_file.metadata()
-                .map_err(|e| BranchError::Operation(format!("metadata: {}", e)))?;
-            let file_size = meta.len();
-            self.check_quota(file_size)?;
-            self.disk_used += file_size;
-            return Ok(CowCopyPlan::NeedsCopy {
-                upper: upper_file,
-                lower: lower_file,
-                file_size,
-            });
-        }
-
-        // New file (not in lower layer)
-        self.check_quota(0)?;
-        Ok(CowCopyPlan::Ready(upper_file))
+        // Regular file — defer the potentially expensive copy. Size comes from
+        // the confined lstat, so the quota reservation matches the file
+        // execute_copy will actually read.
+        let file_size = st.st_size as u64;
+        self.check_quota(file_size)?;
+        self.disk_used += file_size;
+        Ok(CowCopyPlan::NeedsCopy {
+            upper: upper_file,
+            lower: lower_file,
+            file_size,
+        })
     }
 
     /// Execute a file copy synchronously. Used by `ensure_cow_copy` and the
@@ -704,15 +718,14 @@ impl SeccompCowBranch {
         if self.is_deleted(&rel) {
             return None;
         }
-        let upper = self.upper.join(&rel);
-        let lower = self.workdir.join(&rel);
-        if upper.is_symlink() {
-            fs::read_link(&upper).ok().map(|p| p.to_string_lossy().into_owned())
-        } else if lower.is_symlink() {
-            fs::read_link(&lower).ok().map(|p| p.to_string_lossy().into_owned())
-        } else {
-            None
+        // Read the link confined to each layer root so a symlinked parent
+        // component cannot escape the tree (issue #112).
+        for root in [&self.upper, &self.workdir] {
+            if let Ok(target) = crate::sys::fs::readlink_in_root(root, &rel) {
+                return Some(String::from_utf8_lossy(&target).into_owned());
+            }
         }
+        None
     }
 
     /// List all filesystem changes in the COW layer.
@@ -1553,5 +1566,21 @@ mod tests {
         // The workdir entry must not have become a regular file holding the host content.
         let meta = std::fs::symlink_metadata(&committed).unwrap();
         assert!(meta.file_type().is_symlink());
+    }
+
+    #[test]
+    fn cow_copy_preserves_in_tree_symlink() {
+        // The confined-stat classification in prepare_copy must still treat an
+        // in-tree symlink as a symlink and copy it verbatim into upper.
+        let (workdir, storage) = setup_workdir();
+        std::os::unix::fs::symlink("existing.txt", workdir.path().join("link")).unwrap();
+        let mut branch =
+            SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        let upper = branch.ensure_cow_copy("link").unwrap();
+        assert!(upper.is_symlink(), "in-tree symlink was not preserved");
+        assert_eq!(
+            std::fs::read_link(&upper).unwrap(),
+            std::path::Path::new("existing.txt")
+        );
     }
 }

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -1631,32 +1631,34 @@ mod tests {
 
     #[test]
     fn upper_write_does_not_escape_through_symlink() {
-        // workdir/evil -> /etc (absolute symlink). Copy it up verbatim into
-        // upper so upper/evil is also an absolute symlink. Then invoke
-        // handle_mkdir with a path that would go through that symlink.
-        // The confined mkdirp_in_root must clamp the walk to the upper root
-        // and never create /etc/sandlock_escape_dir on the host.
+        // workdir/evil -> <outside> (absolute symlink to a writable dir
+        // outside the sandbox). Copy it up verbatim so upper/evil is also that
+        // absolute symlink, then mkdir through it. The confined mkdirp must
+        // clamp to the upper root, refuse, and never create the dir in
+        // <outside>. Pointing at a writable TempDir (not /etc) means the test
+        // distinguishes the fix from the old lexical code even when not root.
         let (workdir, storage) = setup_workdir();
-        std::os::unix::fs::symlink("/etc", workdir.path().join("evil")).unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(outside.path(), workdir.path().join("evil")).unwrap();
         let mut branch =
             SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
 
-        // Copy up the symlink so upper/evil -> /etc verbatim.
         branch.ensure_cow_copy("evil").unwrap();
         assert!(
             branch.upper_dir().join("evil").is_symlink(),
             "precondition: upper/evil must be a verbatim symlink"
         );
 
-        // Attempt to mkdir via the symlinked parent component.
         let wd = workdir.path().canonicalize().unwrap();
         let escape_path = format!("{}/evil/sandlock_escape_dir", wd.display());
-        let _ = branch.handle_mkdir(&escape_path);
-
-        // The confined write must not have escaped.
+        // Confined: the write is clamped to the upper root and must be refused.
         assert!(
-            !std::path::Path::new("/etc/sandlock_escape_dir").exists(),
-            "upper write escaped through symlinked parent into /etc"
+            !branch.handle_mkdir(&escape_path).unwrap(),
+            "handle_mkdir reported success writing through an escaping symlink"
+        );
+        assert!(
+            !outside.path().join("sandlock_escape_dir").exists(),
+            "upper write escaped through symlinked parent into the outside dir"
         );
     }
 }

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -7,7 +7,7 @@
 use std::collections::HashSet;
 use std::fs;
 use std::os::unix::ffi::OsStringExt;
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::io::FromRawFd;
 use std::path::{Path, PathBuf};
 
 use crate::error::BranchError;
@@ -21,6 +21,11 @@ const O_APPEND: u64 = libc::O_APPEND as u64;
 const O_EXCL: u64 = libc::O_EXCL as u64;
 const O_DIRECTORY: u64 = libc::O_DIRECTORY as u64;
 const WRITE_FLAGS: u64 = O_WRONLY | O_RDWR | O_CREAT | O_TRUNC | O_APPEND;
+
+/// Parent of a relative path, or None if it has no parent component.
+fn parent_rel(rel: &str) -> Option<&str> {
+    rel.trim_end_matches('/').rfind('/').map(|i| &rel[..i])
+}
 
 /// Plan for a COW copy — returned by `prepare_copy()` to separate metadata
 /// updates (under lock) from potentially expensive file I/O (outside lock).
@@ -215,9 +220,8 @@ impl SeccompCowBranch {
             return Ok(CowCopyPlan::Ready(upper_file));
         }
 
-        if let Some(parent) = upper_file.parent() {
-            fs::create_dir_all(parent)
-                .map_err(|e| BranchError::Operation(format!("create parent: {}", e)))?;
+        if let Some(p) = parent_rel(rel_path) {
+            let _ = crate::sys::fs::mkdirp_in_root(&self.upper, p, 0o755);
         }
 
         // Classify the lower entry confined to the workdir root, so a symlinked
@@ -240,7 +244,7 @@ impl SeccompCowBranch {
             let target = crate::sys::fs::readlink_in_root(&self.workdir, rel_path)
                 .map_err(|e| BranchError::Operation(format!("readlink: {}", e)))?;
             let target = std::path::PathBuf::from(std::ffi::OsString::from_vec(target));
-            std::os::unix::fs::symlink(&target, &upper_file)
+            crate::sys::fs::symlinkat_in_root(&self.upper, rel_path, &target.to_string_lossy())
                 .map_err(|e| BranchError::Operation(format!("symlink: {}", e)))?;
             self.disk_used += 256;
             return Ok(CowCopyPlan::Ready(upper_file));
@@ -249,12 +253,9 @@ impl SeccompCowBranch {
         // Directory — create immediately (no data copy)
         if kind == libc::S_IFDIR {
             self.check_quota(4096)?;
-            fs::create_dir_all(&upper_file)
+            crate::sys::fs::mkdirp_in_root(&self.upper, rel_path, st.st_mode & 0o7777)
                 .map_err(|e| BranchError::Operation(format!("create dir: {}", e)))?;
-            let _ = fs::set_permissions(
-                &upper_file,
-                std::fs::Permissions::from_mode(st.st_mode & 0o7777),
-            );
+            let _ = crate::sys::fs::chmod_in_root(&self.upper, rel_path, st.st_mode & 0o7777);
             self.disk_used += 4096;
             return Ok(CowCopyPlan::Ready(upper_file));
         }
@@ -276,14 +277,23 @@ impl SeccompCowBranch {
     /// async dispatch (via `spawn_blocking`).
     pub fn execute_copy(
         workdir_root: &Path,
+        upper_root: &Path,
         rel: &str,
-        upper: &Path,
     ) -> Result<(), std::io::Error> {
-        use std::os::unix::io::FromRawFd;
+        let create_dest = || -> Result<fs::File, std::io::Error> {
+            let fd = crate::sys::fs::openat2_in_root(
+                upper_root,
+                rel,
+                libc::O_WRONLY | libc::O_CREAT | libc::O_TRUNC | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                0o600,
+            )
+            .map_err(std::io::Error::from_raw_os_error)?;
+            Ok(unsafe { fs::File::from_raw_fd(fd) })
+        };
 
         // Read the lower source confined to the workdir root: a symlink or
         // `..` in `rel` cannot escape the tree (issue #112).
-        let fd = match crate::sys::fs::openat2_in_root(
+        let src_fd = match crate::sys::fs::openat2_in_root(
             workdir_root,
             rel,
             libc::O_RDONLY | libc::O_CLOEXEC,
@@ -294,7 +304,7 @@ impl SeccompCowBranch {
             // child an empty COW file so writes proceed, never leaking the
             // escape target.
             Err(libc::EACCES) | Err(libc::ENOENT) => {
-                fs::File::create(upper)?;
+                create_dest()?;
                 return Ok(());
             }
             // On a kernel without openat2 (ENOSYS) the copy fails and the caller
@@ -303,11 +313,11 @@ impl SeccompCowBranch {
             Err(e) => return Err(std::io::Error::from_raw_os_error(e)),
         };
 
-        let mut src = unsafe { fs::File::from_raw_fd(fd) };
-        let mut dst = fs::File::create(upper)?;
+        let mut src = unsafe { fs::File::from_raw_fd(src_fd) };
+        let mut dst = create_dest()?;
         std::io::copy(&mut src, &mut dst)?;
         if let Ok(meta) = src.metadata() {
-            let _ = fs::set_permissions(upper, meta.permissions());
+            let _ = dst.set_permissions(meta.permissions());
         }
         Ok(())
     }
@@ -318,7 +328,7 @@ impl SeccompCowBranch {
         match self.prepare_copy(rel_path)? {
             CowCopyPlan::Ready(upper) => Ok(upper),
             CowCopyPlan::NeedsCopy { upper, lower: _lower, file_size } => {
-                match Self::execute_copy(&self.workdir, rel_path, &upper) {
+                match Self::execute_copy(&self.workdir, &self.upper, rel_path) {
                     Ok(()) => Ok(upper),
                     Err(e) => {
                         self.rollback_copy(file_size);
@@ -522,9 +532,9 @@ impl SeccompCowBranch {
 
         if upper_file.exists() || upper_file.is_symlink() {
             if is_dir {
-                let _ = fs::remove_dir_all(&upper_file);
+                let _ = crate::sys::fs::remove_dir_all_in_root(&self.upper, &rel);
             } else {
-                let _ = fs::remove_file(&upper_file);
+                let _ = crate::sys::fs::unlinkat_in_root(&self.upper, &rel, false);
             }
             self.recalc_disk_used();
         }
@@ -548,8 +558,7 @@ impl SeccompCowBranch {
         self.check_quota(4096)?; // directory metadata
         self.deleted.remove(&rel);
         self.has_changes = true;
-        let upper_dir = self.upper.join(&rel);
-        let ok = fs::create_dir_all(&upper_dir).is_ok();
+        let ok = crate::sys::fs::mkdirp_in_root(&self.upper, &rel, 0o755).is_ok();
         if ok {
             self.disk_used += 4096;
         }
@@ -568,12 +577,11 @@ impl SeccompCowBranch {
             Some(r) => r,
             None => return Ok(false),
         };
-        let old_upper = self.ensure_cow_copy(&old_rel)?;
-        let new_upper = self.upper.join(&new_rel);
-        if let Some(parent) = new_upper.parent() {
-            let _ = fs::create_dir_all(parent);
+        let _old_upper = self.ensure_cow_copy(&old_rel)?;
+        if let Some(p) = parent_rel(&new_rel) {
+            let _ = crate::sys::fs::mkdirp_in_root(&self.upper, p, 0o755);
         }
-        if fs::rename(&old_upper, &new_upper).is_err() {
+        if crate::sys::fs::renameat_in_root(&self.upper, &old_rel, &new_rel).is_err() {
             return Ok(false);
         }
         let lower_old = self.workdir.join(&old_rel);
@@ -611,11 +619,10 @@ impl SeccompCowBranch {
         self.check_quota(256)?;
         self.deleted.remove(&rel);
         self.has_changes = true;
-        let upper_link = self.upper.join(&rel);
-        if let Some(parent) = upper_link.parent() {
-            let _ = fs::create_dir_all(parent);
+        if let Some(p) = parent_rel(&rel) {
+            let _ = crate::sys::fs::mkdirp_in_root(&self.upper, p, 0o755);
         }
-        let ok = std::os::unix::fs::symlink(target, &upper_link).is_ok();
+        let ok = crate::sys::fs::symlinkat_in_root(&self.upper, &rel, target).is_ok();
         if ok {
             self.disk_used += 256;
         }
@@ -634,12 +641,11 @@ impl SeccompCowBranch {
             Some(r) => r,
             None => return Ok(false),
         };
-        let old_upper = self.ensure_cow_copy(&old_rel)?;
-        let new_upper = self.upper.join(&new_rel);
-        if let Some(parent) = new_upper.parent() {
-            let _ = fs::create_dir_all(parent);
+        let _ = self.ensure_cow_copy(&old_rel)?;
+        if let Some(p) = parent_rel(&new_rel) {
+            let _ = crate::sys::fs::mkdirp_in_root(&self.upper, p, 0o755);
         }
-        Ok(fs::hard_link(&old_upper, &new_upper).is_ok())
+        Ok(crate::sys::fs::linkat_in_root(&self.upper, &old_rel, &new_rel).is_ok())
     }
 
     /// Handle fchmodat.
@@ -650,9 +656,8 @@ impl SeccompCowBranch {
             Some(r) => r,
             None => return Ok(false),
         };
-        let upper = self.ensure_cow_copy(&rel)?;
-        use std::os::unix::fs::PermissionsExt;
-        Ok(fs::set_permissions(&upper, fs::Permissions::from_mode(mode)).is_ok())
+        let _ = self.ensure_cow_copy(&rel)?;
+        Ok(crate::sys::fs::chmod_in_root(&self.upper, &rel, mode).is_ok())
     }
 
     /// Handle fchownat.
@@ -663,14 +668,11 @@ impl SeccompCowBranch {
             Some(r) => r,
             None => return Ok(false),
         };
-        let upper = self.ensure_cow_copy(&rel)?;
+        let _ = self.ensure_cow_copy(&rel)?;
         // Best-effort: try the real chown but succeed either way — the
         // supervisor typically lacks CAP_CHOWN so this will fail, but
         // in COW/dry-run mode the ownership doesn't matter.
-        unsafe {
-            let c_path = std::ffi::CString::new(upper.to_str().unwrap_or("")).unwrap();
-            libc::chown(c_path.as_ptr(), uid, gid);
-        }
+        let _ = crate::sys::fs::chown_in_root(&self.upper, &rel, uid, gid);
         Ok(true)
     }
 
@@ -683,16 +685,22 @@ impl SeccompCowBranch {
             None => return Ok(false),
         };
         let new_len = length as u64;
-        let upper = self.ensure_cow_copy(&rel)?;
-        let old_len = upper.metadata().map(|m| m.len()).unwrap_or(0);
+        let _ = self.ensure_cow_copy(&rel)?;
+        let old_len = crate::sys::fs::statat_in_root(&self.upper, &rel, true)
+            .map(|st| st.st_size as u64)
+            .unwrap_or(0);
         if new_len > old_len {
             self.check_quota(new_len - old_len)?;
         }
-        let file = match fs::OpenOptions::new().write(true).open(&upper) {
-            Ok(f) => f,
+        let fd = match crate::sys::fs::openat2_in_root(
+            &self.upper, &rel,
+            libc::O_WRONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC, 0,
+        ) {
+            Ok(fd) => fd,
             Err(_) => return Ok(false),
         };
-        let ok = file.set_len(new_len).is_ok();
+        let ok = unsafe { libc::ftruncate(fd, new_len as libc::off_t) } == 0;
+        unsafe { libc::close(fd) };
         if ok {
             if new_len > old_len {
                 self.disk_used += new_len - old_len;
@@ -798,9 +806,9 @@ impl SeccompCowBranch {
         for rel_path in &self.deleted {
             let dest = self.workdir.join(rel_path);
             if dest.is_dir() {
-                let _ = fs::remove_dir_all(&dest);
+                let _ = crate::sys::fs::remove_dir_all_in_root(&self.workdir, rel_path);
             } else if dest.exists() || dest.is_symlink() {
-                let _ = fs::remove_file(&dest);
+                let _ = crate::sys::fs::unlinkat_in_root(&self.workdir, rel_path, false);
             }
         }
 
@@ -809,30 +817,47 @@ impl SeccompCowBranch {
         for entry in walkdir::WalkDir::new(&self.upper).min_depth(1) {
             let entry = entry.map_err(|e| BranchError::Operation(format!("walk: {}", e)))?;
             let rel = entry.path().strip_prefix(&self.upper).unwrap();
+            let rel_str = match rel.to_str() {
+                Some(s) => s,
+                None => continue,
+            };
             let dest = self.workdir.join(rel);
             if entry.file_type().is_dir() {
-                fs::create_dir_all(&dest)
+                crate::sys::fs::mkdirp_in_root(&self.workdir, rel_str, 0o755)
                     .map_err(|e| BranchError::Operation(format!("mkdir: {}", e)))?;
             } else if entry.file_type().is_symlink() {
                 // Recreate the symlink verbatim. fs::copy would follow it and
                 // read the target outside any root or Landlock (issue #112),
                 // and dereferencing would also lose the link in the workdir.
-                if let Some(parent) = dest.parent() {
-                    let _ = fs::create_dir_all(parent);
+                if let Some(p) = parent_rel(rel_str) {
+                    let _ = crate::sys::fs::mkdirp_in_root(&self.workdir, p, 0o755);
                 }
                 let target = fs::read_link(entry.path())
                     .map_err(|e| BranchError::Operation(format!("readlink: {}", e)))?;
-                if dest.exists() || dest.is_symlink() {
-                    let _ = fs::remove_file(&dest);
-                }
-                std::os::unix::fs::symlink(&target, &dest)
-                    .map_err(|e| BranchError::Operation(format!("symlink: {}", e)))?;
+                let _ = crate::sys::fs::unlinkat_in_root(&self.workdir, rel_str, false);
+                crate::sys::fs::symlinkat_in_root(
+                    &self.workdir,
+                    rel_str,
+                    &target.to_string_lossy(),
+                )
+                .map_err(|e| BranchError::Operation(format!("symlink: {}", e)))?;
                 synced_dirs.insert(dest.parent().unwrap().to_path_buf());
             } else {
-                if let Some(parent) = dest.parent() {
-                    let _ = fs::create_dir_all(parent);
+                if let Some(p) = parent_rel(rel_str) {
+                    let _ = crate::sys::fs::mkdirp_in_root(&self.workdir, p, 0o755);
                 }
-                fs::copy(entry.path(), &dest)
+                // Source is the upper entry (supervisor-owned real path, safe to read directly).
+                let mut src = fs::File::open(entry.path())
+                    .map_err(|e| BranchError::Operation(format!("copy: {}", e)))?;
+                let dst_fd = crate::sys::fs::openat2_in_root(
+                    &self.workdir,
+                    rel_str,
+                    libc::O_WRONLY | libc::O_CREAT | libc::O_TRUNC | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                    0o644,
+                )
+                .map_err(|e| BranchError::Operation(format!("copy: {}", e)))?;
+                let mut dst = unsafe { fs::File::from_raw_fd(dst_fd) };
+                std::io::copy(&mut src, &mut dst)
                     .map_err(|e| BranchError::Operation(format!("copy: {}", e)))?;
                 synced_dirs.insert(dest.parent().unwrap().to_path_buf());
             }
@@ -1601,6 +1626,37 @@ mod tests {
         assert!(
             !matches!(branch.prepare_open(&path, flags), Err(BranchError::Exists)),
             "O_EXCL followed a symlinked parent into the host /etc/group"
+        );
+    }
+
+    #[test]
+    fn upper_write_does_not_escape_through_symlink() {
+        // workdir/evil -> /etc (absolute symlink). Copy it up verbatim into
+        // upper so upper/evil is also an absolute symlink. Then invoke
+        // handle_mkdir with a path that would go through that symlink.
+        // The confined mkdirp_in_root must clamp the walk to the upper root
+        // and never create /etc/sandlock_escape_dir on the host.
+        let (workdir, storage) = setup_workdir();
+        std::os::unix::fs::symlink("/etc", workdir.path().join("evil")).unwrap();
+        let mut branch =
+            SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+
+        // Copy up the symlink so upper/evil -> /etc verbatim.
+        branch.ensure_cow_copy("evil").unwrap();
+        assert!(
+            branch.upper_dir().join("evil").is_symlink(),
+            "precondition: upper/evil must be a verbatim symlink"
+        );
+
+        // Attempt to mkdir via the symlinked parent component.
+        let wd = workdir.path().canonicalize().unwrap();
+        let escape_path = format!("{}/evil/sandlock_escape_dir", wd.display());
+        let _ = branch.handle_mkdir(&escape_path);
+
+        // The confined write must not have escaped.
+        assert!(
+            !std::path::Path::new("/etc/sandlock_escape_dir").exists(),
+            "upper write escaped through symlinked parent into /etc"
         );
     }
 }

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -377,10 +377,11 @@ impl SeccompCowBranch {
 
         // O_EXCL: fail if file already exists (in upper or lower)
         if flags & O_CREAT != 0 && flags & O_EXCL != 0 {
-            let upper_file = self.upper.join(&rel);
-            let lower_file = self.workdir.join(&rel);
-            if upper_file.exists() || upper_file.is_symlink()
-                || lower_file.exists() || lower_file.is_symlink()
+            // Confined existence check: a symlinked parent component must not
+            // let this probe follow out of the tree, which would turn O_EXCL
+            // into a host-file existence oracle (issue #112).
+            if crate::sys::fs::statat_in_root(&self.upper, &rel, false).is_ok()
+                || crate::sys::fs::statat_in_root(&self.workdir, &rel, false).is_ok()
             {
                 return Err(BranchError::Exists);
             }
@@ -441,10 +442,11 @@ impl SeccompCowBranch {
 
         // O_EXCL: fail if file already exists
         if flags & O_CREAT != 0 && flags & O_EXCL != 0 {
-            let upper_file = self.upper.join(&rel);
-            let lower_file = self.workdir.join(&rel);
-            if upper_file.exists() || upper_file.is_symlink()
-                || lower_file.exists() || lower_file.is_symlink()
+            // Confined existence check: a symlinked parent component must not
+            // let this probe follow out of the tree, which would turn O_EXCL
+            // into a host-file existence oracle (issue #112).
+            if crate::sys::fs::statat_in_root(&self.upper, &rel, false).is_ok()
+                || crate::sys::fs::statat_in_root(&self.workdir, &rel, false).is_ok()
             {
                 return Err(BranchError::Exists);
             }
@@ -1581,6 +1583,24 @@ mod tests {
         assert_eq!(
             std::fs::read_link(&upper).unwrap(),
             std::path::Path::new("existing.txt")
+        );
+    }
+
+    #[test]
+    fn o_excl_does_not_probe_through_symlinked_parent() {
+        // workdir/evil -> /etc ; open("evil/group", O_CREAT|O_EXCL) must not
+        // report EEXIST based on the host /etc/group: the existence probe is
+        // confined, so it cannot become a host-file oracle (issue #112).
+        let (workdir, storage) = setup_workdir();
+        std::os::unix::fs::symlink("/etc", workdir.path().join("evil")).unwrap();
+        let mut branch =
+            SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        let wd = workdir.path().canonicalize().unwrap();
+        let path = format!("{}/evil/group", wd.display());
+        let flags = (libc::O_CREAT | libc::O_EXCL | libc::O_WRONLY) as u64;
+        assert!(
+            !matches!(branch.prepare_open(&path, flags), Err(BranchError::Exists)),
+            "O_EXCL followed a symlinked parent into the host /etc/group"
         );
     }
 }

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -283,6 +283,9 @@ impl SeccompCowBranch {
                 fs::File::create(upper)?;
                 return Ok(());
             }
+            // On a kernel without openat2 (ENOSYS) the copy fails and the caller
+            // rolls back / returns Continue; the child then hits Landlock, which
+            // is the backstop. Do not "fix" this with an unconfined fs::copy.
             Err(e) => return Err(std::io::Error::from_raw_os_error(e)),
         };
 
@@ -795,6 +798,21 @@ impl SeccompCowBranch {
             if entry.file_type().is_dir() {
                 fs::create_dir_all(&dest)
                     .map_err(|e| BranchError::Operation(format!("mkdir: {}", e)))?;
+            } else if entry.file_type().is_symlink() {
+                // Recreate the symlink verbatim. fs::copy would follow it and
+                // read the target outside any root or Landlock (issue #112),
+                // and dereferencing would also lose the link in the workdir.
+                if let Some(parent) = dest.parent() {
+                    let _ = fs::create_dir_all(parent);
+                }
+                let target = fs::read_link(entry.path())
+                    .map_err(|e| BranchError::Operation(format!("readlink: {}", e)))?;
+                if dest.exists() || dest.is_symlink() {
+                    let _ = fs::remove_file(&dest);
+                }
+                std::os::unix::fs::symlink(&target, &dest)
+                    .map_err(|e| BranchError::Operation(format!("symlink: {}", e)))?;
+                synced_dirs.insert(dest.parent().unwrap().to_path_buf());
             } else {
                 if let Some(parent) = dest.parent() {
                     let _ = fs::create_dir_all(parent);
@@ -1509,5 +1527,31 @@ mod tests {
             SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
         let upper = branch.ensure_cow_copy("existing.txt").unwrap();
         assert_eq!(std::fs::read_to_string(&upper).unwrap(), "hello");
+    }
+
+    #[test]
+    fn commit_does_not_dereference_escaping_symlink() {
+        // A pre-existing workdir symlink with an absolute target gets copied
+        // verbatim into upper by prepare_copy; commit() must recreate it as a
+        // symlink, never read the target's content (issue #112, commit path).
+        let (workdir, storage) = setup_workdir();
+        std::os::unix::fs::symlink("/etc/group", workdir.path().join("secret")).unwrap();
+        let mut branch =
+            SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        // Trigger copy-up of the symlink into upper.
+        let upper = branch.ensure_cow_copy("secret").unwrap();
+        assert!(upper.is_symlink(), "precondition: upper holds a verbatim symlink");
+
+        branch.commit().unwrap();
+
+        let committed = workdir.path().join("secret");
+        assert!(
+            committed.is_symlink(),
+            "commit dereferenced the symlink instead of recreating it"
+        );
+        assert_eq!(std::fs::read_link(&committed).unwrap(), std::path::Path::new("/etc/group"));
+        // The workdir entry must not have become a regular file holding the host content.
+        let meta = std::fs::symlink_metadata(&committed).unwrap();
+        assert!(meta.file_type().is_symlink());
     }
 }

--- a/crates/sandlock-core/src/sys/fs.rs
+++ b/crates/sandlock-core/src/sys/fs.rs
@@ -1,0 +1,129 @@
+//! Filesystem syscall helpers shared by the chroot and COW supervisors.
+//!
+//! `openat2_in_root` is the single confined-open primitive: it asks the
+//! kernel to resolve a path with `RESOLVE_IN_ROOT`, so symlinks and `..`
+//! cannot escape the given root. Both supervisors route child-controlled
+//! path opens through it (see issue #112).
+
+use std::ffi::CString;
+use std::os::unix::io::RawFd;
+use std::path::Path;
+
+/// openat2 syscall number, sourced from the `syscalls` crate via `arch`.
+const SYS_OPENAT2: libc::c_long = crate::arch::SYS_OPENAT2 as libc::c_long;
+
+/// RESOLVE_IN_ROOT: treat the dirfd as the filesystem root for resolution.
+const RESOLVE_IN_ROOT: u64 = 0x10;
+
+/// Kernel `struct open_how` for openat2().
+#[repr(C)]
+struct OpenHow {
+    flags: u64,
+    mode: u64,
+    resolve: u64,
+}
+
+fn last_errno(fallback: i32) -> i32 {
+    std::io::Error::last_os_error()
+        .raw_os_error()
+        .unwrap_or(fallback)
+}
+
+/// Open a path confined within `root` using `openat2(RESOLVE_IN_ROOT)`.
+///
+/// The kernel handles symlink resolution, `..` traversal, and prevents
+/// escapes above the root, eliminating TOCTOU races and the edge cases
+/// inherent in userspace path walking.
+pub(crate) fn openat2_in_root(
+    root: &Path,
+    path: &str,
+    flags: i32,
+    mode: u32,
+) -> Result<RawFd, i32> {
+    let c_root = CString::new(root.to_str().unwrap_or("")).map_err(|_| libc::EINVAL)?;
+    let root_fd = unsafe {
+        libc::open(
+            c_root.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+        )
+    };
+    if root_fd < 0 {
+        return Err(last_errno(libc::EIO));
+    }
+
+    let rel_path = path.strip_prefix('/').unwrap_or(path);
+    let rel_path = if rel_path.is_empty() { "." } else { rel_path };
+    let c_path = CString::new(rel_path).map_err(|_| {
+        unsafe { libc::close(root_fd) };
+        libc::EINVAL
+    })?;
+
+    let how = OpenHow {
+        flags: flags as u64,
+        mode: mode as u64,
+        resolve: RESOLVE_IN_ROOT,
+    };
+
+    let fd = unsafe {
+        libc::syscall(
+            SYS_OPENAT2,
+            root_fd,
+            c_path.as_ptr(),
+            &how as *const OpenHow,
+            std::mem::size_of::<OpenHow>(),
+        )
+    } as i32;
+
+    unsafe { libc::close(root_fd) };
+
+    if fd < 0 {
+        Err(last_errno(libc::ENOENT))
+    } else {
+        Ok(fd)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+    use tempfile::TempDir;
+
+    #[test]
+    fn openat2_in_root_confines_absolute_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("etc")).unwrap();
+        std::fs::write(root.join("etc/shadow"), "confined").unwrap();
+        // Absolute symlink to the host /etc/shadow: kernel keeps it in root.
+        symlink("/etc/shadow", root.join("evil")).unwrap();
+
+        match openat2_in_root(root, "/evil", libc::O_PATH, 0) {
+            Ok(fd) => {
+                let resolved =
+                    std::fs::read_link(format!("/proc/self/fd/{}", fd)).unwrap();
+                unsafe { libc::close(fd) };
+                assert!(resolved.starts_with(root), "escaped root: {:?}", resolved);
+            }
+            Err(libc::ENOSYS) => {} // kernel without openat2
+            Err(e) => panic!("unexpected error: {}", e),
+        }
+    }
+
+    #[test]
+    fn openat2_in_root_clamps_parent_escape() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        match openat2_in_root(root, "/../../../etc/group", libc::O_PATH, 0) {
+            Err(libc::ENOENT) => {} // clamped to <root>/etc/group, absent
+            Err(libc::ENOSYS) => {}
+            Ok(fd) => {
+                let resolved =
+                    std::fs::read_link(format!("/proc/self/fd/{}", fd)).unwrap();
+                unsafe { libc::close(fd) };
+                assert!(resolved.starts_with(root), "escaped root: {:?}", resolved);
+            }
+            Err(e) => panic!("unexpected error: {}", e),
+        }
+    }
+}

--- a/crates/sandlock-core/src/sys/fs.rs
+++ b/crates/sandlock-core/src/sys/fs.rs
@@ -200,6 +200,280 @@ pub(crate) fn readlink_in_root(root: &Path, path: &str) -> Result<Vec<u8>, i32> 
     Ok(buf)
 }
 
+// ============================================================
+// Confined mutating operations (write side, issue #112)
+//
+// Every upper-layer mutation must resolve its target's PARENT confined to the
+// layer root, then act via an `*at` call on the basename. A verbatim-copied
+// symlink in upper must never let `create_dir_all`/`File::create`/`symlink`/
+// `rename`/`unlink` follow out of the tree and write/delete on the host.
+// ============================================================
+
+/// Split a relative path into (parent, basename). Parent is "" when `rel` is a
+/// single component (meaning the root itself).
+fn split_rel(rel: &str) -> (&str, &str) {
+    let rel = rel.trim_matches('/');
+    match rel.rfind('/') {
+        Some(i) => (&rel[..i], &rel[i + 1..]),
+        None => ("", rel),
+    }
+}
+
+/// Open a confined `O_PATH|O_DIRECTORY` handle to the PARENT of `rel` under
+/// `root`, returning (parent_fd, basename). The parent must already exist;
+/// `RESOLVE_IN_ROOT` clamps any symlink/`..` in the parent walk to `root`.
+fn parent_dir_in_root(root: &Path, rel: &str) -> Result<(RawFd, String), i32> {
+    let (parent, base) = split_rel(rel);
+    if base.is_empty() || base == "." || base == ".." {
+        return Err(libc::EINVAL);
+    }
+    let parent = if parent.is_empty() { "." } else { parent };
+    let fd = openat2_in_root(root, parent, libc::O_PATH | libc::O_DIRECTORY | libc::O_CLOEXEC, 0)?;
+    Ok((fd, base.to_string()))
+}
+
+/// `mkdir` a single component confined within `root` (parent must exist).
+pub(crate) fn mkdir_in_root(root: &Path, rel: &str, mode: u32) -> Result<(), i32> {
+    let (pfd, base) = parent_dir_in_root(root, rel)?;
+    let cbase = CString::new(base).map_err(|_| {
+        unsafe { libc::close(pfd) };
+        libc::EINVAL
+    })?;
+    let rc = unsafe { libc::mkdirat(pfd, cbase.as_ptr(), mode as libc::mode_t) };
+    let err = last_errno(libc::EIO);
+    unsafe { libc::close(pfd) };
+    if rc < 0 {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
+/// `mkdir -p` confined within `root`. Each level is created via `mkdir_in_root`,
+/// so a symlinked parent component is clamped to the root and cannot escape.
+pub(crate) fn mkdirp_in_root(root: &Path, rel: &str, mode: u32) -> Result<(), i32> {
+    let mut prefix = String::new();
+    for comp in rel.split('/').filter(|c| !c.is_empty() && *c != ".") {
+        if comp == ".." {
+            return Err(libc::EINVAL);
+        }
+        if !prefix.is_empty() {
+            prefix.push('/');
+        }
+        prefix.push_str(comp);
+        match mkdir_in_root(root, &prefix, mode) {
+            Ok(()) | Err(libc::EEXIST) => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+/// Create a symlink `rel -> target` confined within `root` (parent must exist).
+pub(crate) fn symlinkat_in_root(root: &Path, rel: &str, target: &str) -> Result<(), i32> {
+    let (pfd, base) = parent_dir_in_root(root, rel)?;
+    let cbase = CString::new(base).ok();
+    let ctarget = CString::new(target).ok();
+    let (cbase, ctarget) = match (cbase, ctarget) {
+        (Some(b), Some(t)) => (b, t),
+        _ => {
+            unsafe { libc::close(pfd) };
+            return Err(libc::EINVAL);
+        }
+    };
+    let rc = unsafe { libc::symlinkat(ctarget.as_ptr(), pfd, cbase.as_ptr()) };
+    let err = last_errno(libc::EIO);
+    unsafe { libc::close(pfd) };
+    if rc < 0 {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
+/// Unlink a file (or rmdir an empty dir) confined within `root`.
+pub(crate) fn unlinkat_in_root(root: &Path, rel: &str, remove_dir: bool) -> Result<(), i32> {
+    let (pfd, base) = parent_dir_in_root(root, rel)?;
+    let cbase = CString::new(base).map_err(|_| {
+        unsafe { libc::close(pfd) };
+        libc::EINVAL
+    })?;
+    let flag = if remove_dir { libc::AT_REMOVEDIR } else { 0 };
+    let rc = unsafe { libc::unlinkat(pfd, cbase.as_ptr(), flag) };
+    let err = last_errno(libc::EIO);
+    unsafe { libc::close(pfd) };
+    if rc < 0 {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
+/// Recursively remove a directory tree confined within `root`. Each descent
+/// uses `O_NOFOLLOW`, so a symlink entry is unlinked (never traversed).
+pub(crate) fn remove_dir_all_in_root(root: &Path, rel: &str) -> Result<(), i32> {
+    // Open the target directory itself confined, without following a final
+    // symlink, then empty it via the dirfd before removing the now-empty dir.
+    let dir_fd = openat2_in_root(
+        root,
+        rel,
+        libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        0,
+    )?;
+    remove_dir_contents(dir_fd); // consumes/closes dir_fd
+    unlinkat_in_root(root, rel, true)
+}
+
+/// Empty a directory referred to by `dir_fd` (which this function takes
+/// ownership of and closes), recursing into subdirectories via `O_NOFOLLOW`.
+fn remove_dir_contents(dir_fd: RawFd) {
+    // fdopendir takes ownership of dir_fd; closedir closes it.
+    let dirp = unsafe { libc::fdopendir(dir_fd) };
+    if dirp.is_null() {
+        unsafe { libc::close(dir_fd) };
+        return;
+    }
+    loop {
+        let ent = unsafe { libc::readdir(dirp) };
+        if ent.is_null() {
+            break;
+        }
+        let name_ptr = unsafe { (*ent).d_name.as_ptr() };
+        let name = unsafe { std::ffi::CStr::from_ptr(name_ptr) };
+        let bytes = name.to_bytes();
+        if bytes == b"." || bytes == b".." {
+            continue;
+        }
+        // Is this entry a directory (without following a symlink)?
+        let mut st: libc::stat = unsafe { std::mem::zeroed() };
+        let is_dir = unsafe {
+            libc::fstatat(
+                libc::dirfd(dirp),
+                name_ptr,
+                &mut st,
+                libc::AT_SYMLINK_NOFOLLOW,
+            ) == 0
+        } && (st.st_mode & libc::S_IFMT) == libc::S_IFDIR;
+        if is_dir {
+            let child = unsafe {
+                libc::openat(
+                    libc::dirfd(dirp),
+                    name_ptr,
+                    libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                )
+            };
+            if child >= 0 {
+                remove_dir_contents(child);
+            }
+            unsafe { libc::unlinkat(libc::dirfd(dirp), name_ptr, libc::AT_REMOVEDIR) };
+        } else {
+            unsafe { libc::unlinkat(libc::dirfd(dirp), name_ptr, 0) };
+        }
+    }
+    unsafe { libc::closedir(dirp) };
+}
+
+/// Rename `old_rel` to `new_rel`, both confined within `root`.
+pub(crate) fn renameat_in_root(root: &Path, old_rel: &str, new_rel: &str) -> Result<(), i32> {
+    let (opfd, ob) = parent_dir_in_root(root, old_rel)?;
+    let (npfd, nb) = match parent_dir_in_root(root, new_rel) {
+        Ok(v) => v,
+        Err(e) => {
+            unsafe { libc::close(opfd) };
+            return Err(e);
+        }
+    };
+    let close_both = || unsafe {
+        libc::close(opfd);
+        libc::close(npfd);
+    };
+    let (cob, cnb) = match (CString::new(ob), CString::new(nb)) {
+        (Ok(a), Ok(b)) => (a, b),
+        _ => {
+            close_both();
+            return Err(libc::EINVAL);
+        }
+    };
+    let rc = unsafe { libc::renameat(opfd, cob.as_ptr(), npfd, cnb.as_ptr()) };
+    let err = last_errno(libc::EIO);
+    close_both();
+    if rc < 0 {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
+/// Create a hard link `new_rel -> old_rel` confined within `root`. The old path
+/// is not dereferenced (no `AT_SYMLINK_FOLLOW`).
+pub(crate) fn linkat_in_root(root: &Path, old_rel: &str, new_rel: &str) -> Result<(), i32> {
+    let (opfd, ob) = parent_dir_in_root(root, old_rel)?;
+    let (npfd, nb) = match parent_dir_in_root(root, new_rel) {
+        Ok(v) => v,
+        Err(e) => {
+            unsafe { libc::close(opfd) };
+            return Err(e);
+        }
+    };
+    let close_both = || unsafe {
+        libc::close(opfd);
+        libc::close(npfd);
+    };
+    let (cob, cnb) = match (CString::new(ob), CString::new(nb)) {
+        (Ok(a), Ok(b)) => (a, b),
+        _ => {
+            close_both();
+            return Err(libc::EINVAL);
+        }
+    };
+    let rc = unsafe { libc::linkat(opfd, cob.as_ptr(), npfd, cnb.as_ptr(), 0) };
+    let err = last_errno(libc::EIO);
+    close_both();
+    if rc < 0 {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
+/// `chmod` a path confined within `root`, following the final symlink (as
+/// `chmod` does) but never escaping the root. Operates through the confined
+/// `O_PATH` handle's `/proc/self/fd` magic link.
+pub(crate) fn chmod_in_root(root: &Path, rel: &str, mode: u32) -> Result<(), i32> {
+    let fd = opath_in_root(root, rel, true)?;
+    let proc = CString::new(format!("/proc/self/fd/{}", fd)).map_err(|_| {
+        unsafe { libc::close(fd) };
+        libc::EINVAL
+    })?;
+    let rc = unsafe { libc::chmod(proc.as_ptr(), mode as libc::mode_t) };
+    let err = last_errno(libc::EIO);
+    unsafe { libc::close(fd) };
+    if rc < 0 {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
+/// `chown` a path confined within `root`, following the final symlink (as
+/// `chown` does) but never escaping the root, via the confined `O_PATH`
+/// handle's `/proc/self/fd` magic link.
+pub(crate) fn chown_in_root(root: &Path, rel: &str, uid: u32, gid: u32) -> Result<(), i32> {
+    let fd = opath_in_root(root, rel, true)?;
+    let proc = CString::new(format!("/proc/self/fd/{}", fd)).map_err(|_| {
+        unsafe { libc::close(fd) };
+        libc::EINVAL
+    })?;
+    let rc = unsafe { libc::chown(proc.as_ptr(), uid, gid) };
+    let err = last_errno(libc::EIO);
+    unsafe { libc::close(fd) };
+    if rc < 0 {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -335,5 +609,96 @@ mod tests {
             statx_in_root(root, "dirlink/group", 0, libc::STATX_BASIC_STATS, &mut buf),
             Err(libc::ENOENT)
         );
+    }
+
+    #[test]
+    fn mkdirp_creates_in_tree_and_refuses_escape() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        if mkdirp_in_root(root, "a/b/c", 0o755) == Err(libc::ENOSYS) {
+            return;
+        }
+        assert!(root.join("a/b/c").is_dir());
+
+        // Under an escaping symlinked parent: refused, and nothing created on host.
+        symlink("/etc", root.join("evil")).unwrap();
+        let r = mkdirp_in_root(root, "evil/sandlock_escape_probe", 0o755);
+        assert!(matches!(r, Err(libc::ENOENT)), "got {:?}", r);
+        assert!(!std::path::Path::new("/etc/sandlock_escape_probe").exists());
+    }
+
+    #[test]
+    fn symlinkat_creates_in_tree_and_refuses_escape() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        if mkdirp_in_root(root, "d", 0o755) == Err(libc::ENOSYS) {
+            return;
+        }
+        symlinkat_in_root(root, "d/link", "target").unwrap();
+        assert_eq!(
+            std::fs::read_link(root.join("d/link")).unwrap(),
+            std::path::Path::new("target")
+        );
+
+        symlink("/etc", root.join("evil")).unwrap();
+        let r = symlinkat_in_root(root, "evil/sandlock_escape_link", "x");
+        assert!(matches!(r, Err(libc::ENOENT)), "got {:?}", r);
+        assert!(!std::path::Path::new("/etc/sandlock_escape_link").is_symlink());
+    }
+
+    #[test]
+    fn unlinkat_and_rename_in_tree() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        if mkdirp_in_root(root, "d", 0o755) == Err(libc::ENOSYS) {
+            return;
+        }
+        std::fs::write(root.join("d/old"), "v").unwrap();
+        renameat_in_root(root, "d/old", "d/new").unwrap();
+        assert!(!root.join("d/old").exists());
+        assert_eq!(std::fs::read_to_string(root.join("d/new")).unwrap(), "v");
+        unlinkat_in_root(root, "d/new", false).unwrap();
+        assert!(!root.join("d/new").exists());
+    }
+
+    #[test]
+    fn remove_dir_all_does_not_follow_symlink_entries() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let outside = TempDir::new().unwrap();
+        std::fs::write(outside.path().join("keep.txt"), "important").unwrap();
+        if mkdirp_in_root(root, "a", 0o755) == Err(libc::ENOSYS) {
+            return;
+        }
+        std::fs::write(root.join("a/file.txt"), "x").unwrap();
+        symlink(outside.path(), root.join("a/lnk")).unwrap();
+
+        remove_dir_all_in_root(root, "a").unwrap();
+        assert!(!root.join("a").exists(), "tree not removed");
+        // The symlink entry was unlinked, never traversed: outside survives.
+        assert!(
+            outside.path().join("keep.txt").exists(),
+            "recursive remove followed a symlink out of the tree"
+        );
+    }
+
+    #[test]
+    fn chmod_in_tree_and_refuses_escape() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join("f"), "x").unwrap();
+        if chmod_in_root(root, "f", 0o600) == Err(libc::ENOSYS) {
+            return;
+        }
+        assert_eq!(
+            std::fs::metadata(root.join("f")).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        symlink("/etc", root.join("evil")).unwrap();
+        assert!(matches!(
+            chmod_in_root(root, "evil/group", 0o777),
+            Err(libc::ENOENT)
+        ));
     }
 }

--- a/crates/sandlock-core/src/sys/fs.rs
+++ b/crates/sandlock-core/src/sys/fs.rs
@@ -83,6 +83,118 @@ pub(crate) fn openat2_in_root(
     }
 }
 
+/// Empty C string for the `AT_EMPTY_PATH` family of calls (operate on the fd).
+const EMPTY: *const libc::c_char = b"\0".as_ptr() as *const libc::c_char;
+
+/// Open a confined `O_PATH` handle to `path` under `root`.
+///
+/// `O_PATH` needs no read permission and does no I/O, so it is the right
+/// handle for metadata operations. `RESOLVE_IN_ROOT` confines every component
+/// of the walk to `root`. When `follow` is false the final component is opened
+/// with `O_NOFOLLOW`, yielding a handle to the symlink itself (lstat
+/// semantics); when true the final symlink is followed, but still confined.
+fn opath_in_root(root: &Path, path: &str, follow: bool) -> Result<RawFd, i32> {
+    let mut flags = libc::O_PATH | libc::O_CLOEXEC;
+    if !follow {
+        flags |= libc::O_NOFOLLOW;
+    }
+    openat2_in_root(root, path, flags, 0)
+}
+
+/// `stat`/`lstat` a path confined within `root`.
+///
+/// `follow` selects `stat` (follow the final symlink) vs `lstat` (stat the
+/// link itself) semantics for the final component; intermediate components are
+/// always confined to `root`.
+pub(crate) fn statat_in_root(root: &Path, path: &str, follow: bool) -> Result<libc::stat, i32> {
+    let fd = opath_in_root(root, path, follow)?;
+    let mut st: libc::stat = unsafe { std::mem::zeroed() };
+    let rc = unsafe { libc::fstatat(fd, EMPTY, &mut st, libc::AT_EMPTY_PATH) };
+    let err = last_errno(libc::EIO);
+    unsafe { libc::close(fd) };
+    if rc < 0 {
+        Err(err)
+    } else {
+        Ok(st)
+    }
+}
+
+/// `statx` a path confined within `root`, writing the raw `struct statx` into
+/// `buf` (must be at least `sizeof(struct statx)`, 256 bytes). The child's
+/// `AT_SYMLINK_NOFOLLOW` in `flags` selects follow vs nofollow; other `flags`
+/// bits (sync hints) are preserved.
+pub(crate) fn statx_in_root(
+    root: &Path,
+    path: &str,
+    flags: i32,
+    mask: u32,
+    buf: &mut [u8],
+) -> Result<(), i32> {
+    let follow = (flags & libc::AT_SYMLINK_NOFOLLOW) == 0;
+    let fd = opath_in_root(root, path, follow)?;
+    // statx the handle itself via AT_EMPTY_PATH; follow/nofollow is already
+    // baked into how the fd was opened, so drop AT_SYMLINK_NOFOLLOW here.
+    let stx_flags = (flags & !libc::AT_SYMLINK_NOFOLLOW) | libc::AT_EMPTY_PATH;
+    let rc = unsafe {
+        libc::syscall(libc::SYS_statx, fd, EMPTY, stx_flags, mask, buf.as_mut_ptr())
+    };
+    let err = last_errno(libc::EIO);
+    unsafe { libc::close(fd) };
+    if rc < 0 {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
+/// Set timestamps on a path confined within `root`.
+///
+/// Resolves a confined `O_PATH` handle, then stamps it through its
+/// `/proc/self/fd/N` magic link. The kernel cannot take an `O_PATH` fd
+/// directly for `utimensat` (EBADF), but the magic link jumps straight to the
+/// already-confined inode, so resolution cannot escape. `follow` selects
+/// whether the final symlink is followed or stamped in place (baked into how
+/// the handle is opened).
+pub(crate) fn utimensat_in_root(
+    root: &Path,
+    path: &str,
+    times: *const libc::timespec,
+    follow: bool,
+) -> Result<(), i32> {
+    let fd = opath_in_root(root, path, follow)?;
+    let proc = CString::new(format!("/proc/self/fd/{}", fd)).map_err(|_| {
+        unsafe { libc::close(fd) };
+        libc::EINVAL
+    })?;
+    let rc = unsafe { libc::utimensat(libc::AT_FDCWD, proc.as_ptr(), times, 0) };
+    let err = last_errno(libc::EIO);
+    unsafe { libc::close(fd) };
+    if rc < 0 {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
+/// Read a symlink's target confined within `root`. Returns the raw target
+/// bytes. `Err(EINVAL)` means the final component is not a symlink.
+pub(crate) fn readlink_in_root(root: &Path, path: &str) -> Result<Vec<u8>, i32> {
+    // O_PATH|O_NOFOLLOW opens the link itself; readlinkat with an empty path
+    // then reads its target. The parent walk is confined to root.
+    let fd = opath_in_root(root, path, false)?;
+    let mut buf = vec![0u8; 4096];
+    let n = unsafe {
+        libc::readlinkat(fd, EMPTY, buf.as_mut_ptr() as *mut libc::c_char, buf.len())
+    };
+    let err = last_errno(libc::EIO);
+    unsafe { libc::close(fd) };
+    if n < 0 {
+        return Err(err);
+    }
+    buf.truncate(n as usize);
+    Ok(buf)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -125,5 +237,98 @@ mod tests {
             }
             Err(e) => panic!("unexpected error: {}", e),
         }
+    }
+
+    // Skip a test body cleanly on kernels without openat2.
+    macro_rules! skip_if_nosys {
+        ($e:expr) => {
+            match $e {
+                Err(libc::ENOSYS) => return,
+                other => other,
+            }
+        };
+    }
+
+    #[test]
+    fn statat_lstat_does_not_follow_escaping_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        symlink("/etc/group", root.join("evil")).unwrap();
+
+        // lstat: stat the link itself, confined; must report a symlink, never
+        // the host /etc/group it points at.
+        let st = skip_if_nosys!(statat_in_root(root, "evil", false)).unwrap();
+        assert_eq!(st.st_mode & libc::S_IFMT, libc::S_IFLNK, "expected a symlink");
+
+        // stat (follow): the absolute target is clamped to <root>/etc/group,
+        // which does not exist, so the host file is never reached.
+        assert_eq!(statat_in_root(root, "evil", true), Err(libc::ENOENT));
+    }
+
+    #[test]
+    fn statat_confines_symlinked_parent() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        symlink("/etc", root.join("dirlink")).unwrap();
+        // dirlink/group would be /etc/group on the host; confined it is absent.
+        assert_eq!(
+            skip_if_nosys!(statat_in_root(root, "dirlink/group", true)),
+            Err(libc::ENOENT)
+        );
+    }
+
+    #[test]
+    fn readlink_confined_reads_in_tree_link_but_not_through_escaping_parent() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        symlink("/etc/group", root.join("evil")).unwrap();
+        symlink("/etc", root.join("dirlink")).unwrap();
+
+        // The link's own target string is the child's data: returning it is fine.
+        let target = skip_if_nosys!(readlink_in_root(root, "evil")).unwrap();
+        assert_eq!(target, b"/etc/group");
+
+        // But a link reached through an escaping parent is not visible.
+        assert_eq!(readlink_in_root(root, "dirlink/group"), Err(libc::ENOENT));
+    }
+
+    #[test]
+    fn utimensat_confined_stamps_in_tree_and_refuses_escape() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join("f"), "x").unwrap();
+        symlink("/etc", root.join("dirlink")).unwrap();
+
+        let times = [
+            libc::timespec { tv_sec: 1_000_000, tv_nsec: 0 },
+            libc::timespec { tv_sec: 1_000_000, tv_nsec: 0 },
+        ];
+        // In-tree file: stamp succeeds and takes effect.
+        skip_if_nosys!(utimensat_in_root(root, "f", times.as_ptr(), true)).unwrap();
+        let meta = std::fs::metadata(root.join("f")).unwrap();
+        use std::os::unix::fs::MetadataExt;
+        assert_eq!(meta.mtime(), 1_000_000);
+
+        // Escaping parent: refused, so the host /etc/group is never stamped.
+        assert_eq!(
+            utimensat_in_root(root, "dirlink/group", times.as_ptr(), true),
+            Err(libc::ENOENT)
+        );
+    }
+
+    #[test]
+    fn statx_confines_symlinked_parent() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join("f"), "data").unwrap();
+        symlink("/etc", root.join("dirlink")).unwrap();
+        let mut buf = vec![0u8; 256];
+
+        // In-tree file resolves; escaping parent does not.
+        skip_if_nosys!(statx_in_root(root, "f", 0, libc::STATX_BASIC_STATS, &mut buf)).unwrap();
+        assert_eq!(
+            statx_in_root(root, "dirlink/group", 0, libc::STATX_BASIC_STATS, &mut buf),
+            Err(libc::ENOENT)
+        );
     }
 }

--- a/crates/sandlock-core/src/sys/fs.rs
+++ b/crates/sandlock-core/src/sys/fs.rs
@@ -130,6 +130,11 @@ pub(crate) fn statx_in_root(
     mask: u32,
     buf: &mut [u8],
 ) -> Result<(), i32> {
+    // The kernel writes sizeof(struct statx) = 256 bytes; refuse a short buffer
+    // rather than risk a heap overflow if a future caller passes a smaller one.
+    if buf.len() < 256 {
+        return Err(libc::EINVAL);
+    }
     let follow = (flags & libc::AT_SYMLINK_NOFOLLOW) == 0;
     let fd = opath_in_root(root, path, follow)?;
     // statx the handle itself via AT_EMPTY_PATH; follow/nofollow is already

--- a/crates/sandlock-core/src/sys/mod.rs
+++ b/crates/sandlock-core/src/sys/mod.rs
@@ -1,2 +1,3 @@
+pub mod fs;
 pub mod structs;
 pub mod syscall;


### PR DESCRIPTION
## Problem

In seccomp COW mode the supervisor runs in the parent process with full
filesystem access, outside the child's Landlock ruleset, and serves file
operations on the child's behalf. It resolved child-controlled paths lexically
and then performed symlink-following `libc::open` / `std::fs` calls. A symlink
inside the workdir (final component or an intermediate directory component)
whose target points outside the upper/lower roots became a deterministic read
and write channel to that target, bypassing Landlock. No race is required.

Found by @1lann while reviewing the filesystem-resolution concern from #27.

## Approach

Route every point where the COW supervisor turns a child-controlled path into a
real filesystem access through the kernel's confined resolver, `openat2(2)` with
`RESOLVE_IN_ROOT`, anchored at the relevant layer root (`upper` or `workdir`).
This is the exact mechanism the chroot supervisor already used; this PR hoists
it into a shared `crate::sys::fs` module and brings the COW supervisor up to the
same standard, rather than inventing a parallel scheme. `RESOLVE_IN_ROOT`
clamps symlinks and `..` to the root in place, so it needs no fallback control
flow.

## What changed

- Hoisted `openat2_in_root` into `crate::sys::fs` so both supervisors share one
  confined-open primitive.
- Serving opens (open / exec / chdir) now resolve confined via `open_confined`.
- Copy-up read (`execute_copy`) reads the lower source confined instead of
  `fs::copy`, which followed symlinked parents.
- `commit()` recreates symlinks verbatim instead of dereferencing them (also
  fixes a latent bug where commit silently lost symlinks).
- Metadata ops confined via new `O_PATH`-based helpers: `newfstatat`,
  `faccessat`, `statx`, `utimensat`, `readlink`, and `prepare_copy`'s
  classification and sizing. Closed the `O_EXCL` host-existence oracle and
  guarded the `statx` buffer length.
- Write path confined: `mkdir`, `unlink`, `rmdir`, `rename`, `symlink`,
  `hard_link`, `chmod`, `chown`, `truncate`, the copy-up destination, and the
  `commit()` merge all resolve their parent confined and act via an `*at` /
  `O_NOFOLLOW` primitive. The recursive remove never follows symlink entries.

## Testing

`cargo test -p sandlock-core --lib`: 431 passed, 0 failed, clean build. New unit
tests cover each helper (escape refusal through symlinked parents, lstat not
following, recursive remove not traversing symlinks) plus branch-level
regression tests for the copy-up, commit, O_EXCL, and upper-write escape paths.

## Follow-up (not in this PR)

A few read-side existence and type decision probes (`needs_read_intercept`, the
`O_DIRECTORY` branch of `prepare_open`, and `handle_unlink`'s type pre-checks)
still use lexical `upper.join(rel)`. They are reads (a type or existence oracle
at worst, no content leak and no write) feeding a terminal op that is already
confined, so they are tracked separately rather than fixed here.

Fixes #112.
