### PR TITLE
fs_deny: close the deny-bypass TOCTOU and namespace vectors

### DIFF
--- a/crates/sandlock-core/src/policy_fn.rs
+++ b/crates/sandlock-core/src/policy_fn.rs
@@ -147,7 +147,7 @@ pub struct PolicyContext {
     ceiling: LivePolicy,
     restricted: HashSet<&'static str>,
     pid_overrides: Arc<RwLock<HashMap<u32, HashSet<IpAddr>>>>,
-    denied_paths: Arc<RwLock<HashSet<String>>>,
+    denied: Arc<crate::seccomp::state::DeniedSet>,
 }
 
 impl PolicyContext {
@@ -155,14 +155,14 @@ impl PolicyContext {
         live: Arc<RwLock<LivePolicy>>,
         ceiling: LivePolicy,
         pid_overrides: Arc<RwLock<HashMap<u32, HashSet<IpAddr>>>>,
-        denied_paths: Arc<RwLock<HashSet<String>>>,
+        denied: Arc<crate::seccomp::state::DeniedSet>,
     ) -> Self {
         Self {
             live,
             ceiling,
             restricted: HashSet::new(),
             pid_overrides,
-            denied_paths,
+            denied,
         }
     }
 
@@ -246,16 +246,16 @@ impl PolicyContext {
     // ---- Filesystem restriction ----
 
     /// Deny access to a path (and all children). Checked by the supervisor
-    /// on openat/stat/access syscalls. Takes effect immediately.
+    /// on openat/stat/access syscalls. Takes effect immediately. The file's
+    /// inode identity is captured too, so the deny survives hardlinks and
+    /// renames to a non-denied name.
     pub fn deny_path(&self, path: &str) {
-        let mut denied = self.denied_paths.write().unwrap();
-        denied.insert(path.to_string());
+        self.denied.deny(path);
     }
 
     /// Remove a previously denied path.
     pub fn allow_path(&self, path: &str) {
-        let mut denied = self.denied_paths.write().unwrap();
-        denied.remove(path);
+        self.denied.allow(path);
     }
 
     // ---- Internal ----
@@ -337,14 +337,14 @@ pub(crate) fn spawn_policy_fn(
     live: Arc<RwLock<LivePolicy>>,
     ceiling: LivePolicy,
     pid_overrides: Arc<RwLock<HashMap<u32, HashSet<IpAddr>>>>,
-    denied_paths: Arc<RwLock<HashSet<String>>>,
+    denied: Arc<crate::seccomp::state::DeniedSet>,
 ) -> tokio::sync::mpsc::UnboundedSender<PolicyEvent> {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<PolicyEvent>();
 
     std::thread::Builder::new()
         .name("sandlock-policy-fn".to_string())
         .spawn(move || {
-            let mut ctx = PolicyContext::new(live, ceiling, pid_overrides, denied_paths);
+            let mut ctx = PolicyContext::new(live, ceiling, pid_overrides, denied);
 
             while let Some(pe) = rx.blocking_recv() {
                 let verdict = callback(pe.event, &mut ctx);
@@ -389,8 +389,8 @@ mod tests {
         }));
         let ceiling = test_live();
         let pid_overrides = Arc::new(RwLock::new(HashMap::new()));
-        let denied_paths = Arc::new(RwLock::new(HashSet::new()));
-        let mut ctx = PolicyContext::new(live.clone(), ceiling, pid_overrides, denied_paths);
+        let denied = Arc::new(crate::seccomp::state::DeniedSet::default());
+        let mut ctx = PolicyContext::new(live.clone(), ceiling, pid_overrides, denied);
 
         let ip: IpAddr = "127.0.0.1".parse().unwrap();
         ctx.grant_network(&[ip]).unwrap();
@@ -406,8 +406,8 @@ mod tests {
         }));
         let ceiling = test_live();
         let pid_overrides = Arc::new(RwLock::new(HashMap::new()));
-        let denied_paths = Arc::new(RwLock::new(HashSet::new()));
-        let mut ctx = PolicyContext::new(live.clone(), ceiling, pid_overrides, denied_paths);
+        let denied = Arc::new(crate::seccomp::state::DeniedSet::default());
+        let mut ctx = PolicyContext::new(live.clone(), ceiling, pid_overrides, denied);
 
         // Try to grant an IP not in ceiling — should be silently ignored
         let foreign: IpAddr = "8.8.8.8".parse().unwrap();
@@ -420,8 +420,8 @@ mod tests {
         let live = Arc::new(RwLock::new(test_live()));
         let ceiling = test_live();
         let pid_overrides = Arc::new(RwLock::new(HashMap::new()));
-        let denied_paths = Arc::new(RwLock::new(HashSet::new()));
-        let mut ctx = PolicyContext::new(live, ceiling, pid_overrides, denied_paths);
+        let denied = Arc::new(crate::seccomp::state::DeniedSet::default());
+        let mut ctx = PolicyContext::new(live, ceiling, pid_overrides, denied);
 
         ctx.restrict_network(&[]);
         let ip: IpAddr = "127.0.0.1".parse().unwrap();
@@ -433,8 +433,8 @@ mod tests {
         let live = Arc::new(RwLock::new(test_live()));
         let ceiling = test_live();
         let pid_overrides = Arc::new(RwLock::new(HashMap::new()));
-        let denied_paths = Arc::new(RwLock::new(HashSet::new()));
-        let mut ctx = PolicyContext::new(live.clone(), ceiling, pid_overrides, denied_paths);
+        let denied = Arc::new(crate::seccomp::state::DeniedSet::default());
+        let mut ctx = PolicyContext::new(live.clone(), ceiling, pid_overrides, denied);
 
         ctx.restrict_max_memory(256 * 1024 * 1024);
         assert_eq!(live.read().unwrap().max_memory_bytes, 256 * 1024 * 1024);
@@ -445,8 +445,8 @@ mod tests {
         let live = Arc::new(RwLock::new(test_live()));
         let ceiling = test_live();
         let pid_overrides = Arc::new(RwLock::new(HashMap::new()));
-        let denied_paths = Arc::new(RwLock::new(HashSet::new()));
-        let ctx = PolicyContext::new(live, ceiling, pid_overrides.clone(), denied_paths);
+        let denied = Arc::new(crate::seccomp::state::DeniedSet::default());
+        let ctx = PolicyContext::new(live, ceiling, pid_overrides.clone(), denied);
 
         let localhost: IpAddr = "127.0.0.1".parse().unwrap();
         ctx.restrict_pid_network(1234, &[localhost]);
@@ -462,8 +462,8 @@ mod tests {
         let live = Arc::new(RwLock::new(test_live()));
         let ceiling = test_live();
         let pid_overrides = Arc::new(RwLock::new(HashMap::new()));
-        let denied_paths = Arc::new(RwLock::new(HashSet::new()));
-        let ctx = PolicyContext::new(live, ceiling, pid_overrides.clone(), denied_paths);
+        let denied = Arc::new(crate::seccomp::state::DeniedSet::default());
+        let ctx = PolicyContext::new(live, ceiling, pid_overrides.clone(), denied);
 
         let localhost: IpAddr = "127.0.0.1".parse().unwrap();
         ctx.restrict_pid_network(1234, &[localhost]);

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -1659,10 +1659,10 @@ impl Sandbox {
 
             let mut policy_fn_state = PolicyFnState::new();
 
-            if let Ok(mut denied) = policy_fn_state.denied_paths.write() {
-                for path in &self.fs_denied {
-                    denied.insert(path.to_string_lossy().into_owned());
-                }
+            for path in &self.fs_denied {
+                // Captures the path prefix and the file's inode identity, so
+                // the deny survives hardlinks/renames to a non-denied name.
+                policy_fn_state.denied.deny(&path.to_string_lossy());
             }
 
             if let Some(ref callback) = self.policy_fn {
@@ -1687,11 +1687,11 @@ impl Sandbox {
                 };
                 let ceiling = live.clone();
                 let live = std::sync::Arc::new(std::sync::RwLock::new(live));
-                let denied_paths = policy_fn_state.denied_paths.clone();
+                let denied = policy_fn_state.denied.clone();
                 let pid_overrides = net_state.pid_ip_overrides.clone();
                 policy_fn_state.live_policy = Some(live.clone());
                 let tx = crate::policy_fn::spawn_policy_fn(
-                    callback.clone(), live, ceiling, pid_overrides, denied_paths,
+                    callback.clone(), live, ceiling, pid_overrides, denied,
                 );
                 policy_fn_state.event_tx = Some(tx);
             }

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -374,6 +374,264 @@ fn is_denied_with_symlink_resolve(
     false
 }
 
+/// `RESOLVE_NO_MAGICLINKS` — forbid `/proc` magic-link redirection during
+/// on-behalf resolution while still following ordinary symlinks the way the
+/// child's own open would.
+const RESOLVE_NO_MAGICLINKS: u64 = 0x02;
+
+/// Kernel `struct open_how` for `openat2`.
+#[repr(C)]
+struct OpenHow {
+    flags: u64,
+    mode: u64,
+    resolve: u64,
+}
+
+fn last_errno(fallback: i32) -> i32 {
+    io::Error::last_os_error().raw_os_error().unwrap_or(fallback)
+}
+
+/// `openat2` relative to `dirfd`. Returns an owned fd or the errno.
+fn openat2_at(dirfd: RawFd, path: &std::ffi::CStr, flags: u64, mode: u64, resolve: u64)
+    -> Result<OwnedFd, i32>
+{
+    use std::os::unix::io::FromRawFd;
+    let how = OpenHow { flags, mode, resolve };
+    let fd = unsafe {
+        libc::syscall(
+            arch::SYS_OPENAT2,
+            dirfd,
+            path.as_ptr(),
+            &how as *const OpenHow,
+            std::mem::size_of::<OpenHow>(),
+        )
+    } as i32;
+    if fd < 0 {
+        Err(last_errno(libc::ENOENT))
+    } else {
+        Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+    }
+}
+
+/// Capture an `O_PATH` fd to the directory the child's open resolves against,
+/// taken from the child's own view so a concurrent `chdir`/dirfd swap cannot
+/// move the resolution base after we read it.
+fn open_base_dir(pid: u32, dirfd: i64) -> Result<OwnedFd, i32> {
+    use std::os::unix::io::FromRawFd;
+    if dirfd as i32 == libc::AT_FDCWD {
+        let cwd = std::ffi::CString::new(format!("/proc/{}/cwd", pid)).map_err(|_| libc::EINVAL)?;
+        let fd = unsafe {
+            libc::open(cwd.as_ptr(), libc::O_PATH | libc::O_DIRECTORY | libc::O_CLOEXEC)
+        };
+        if fd < 0 {
+            return Err(last_errno(libc::EACCES));
+        }
+        Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+    } else {
+        dup_fd_from_pid(pid, dirfd as i32).map_err(|_| libc::EBADF)
+    }
+}
+
+/// Real path of an open fd via its `/proc/self/fd` magic link.
+fn realpath_of_fd(fd: RawFd) -> Option<std::path::PathBuf> {
+    std::fs::read_link(format!("/proc/self/fd/{}", fd)).ok()
+}
+
+fn path_under_any(path: &std::path::Path, list: &[std::path::PathBuf]) -> bool {
+    list.iter().any(|p| path.starts_with(p))
+}
+
+/// Decide whether `realpath` may be opened with `flags` under the deny set
+/// and the (conservative) grant lists. Returns `Some(errno)` to refuse,
+/// `None` to allow. Never over-allows relative to the configured grants: a
+/// path outside every grant is refused, so this can only be stricter than
+/// Landlock, never looser (an over-deny is a functional gap, an over-allow
+/// would be an escape).
+fn deny_open_verdict(
+    realpath: &std::path::Path,
+    flags: u64,
+    policy: &NotifPolicy,
+    pfs: &super::state::PolicyFnState,
+) -> Option<i32> {
+    if pfs.is_path_denied(&realpath.to_string_lossy()) {
+        return Some(libc::EACCES);
+    }
+    let acc = flags as i32 & libc::O_ACCMODE;
+    let is_write = acc == libc::O_WRONLY
+        || acc == libc::O_RDWR
+        || (flags & libc::O_TRUNC as u64) != 0
+        || (flags & libc::O_CREAT as u64) != 0;
+    let allowed = if is_write {
+        path_under_any(realpath, &policy.chroot_writable)
+    } else {
+        path_under_any(realpath, &policy.chroot_readable)
+            || path_under_any(realpath, &policy.chroot_writable)
+    };
+    if allowed { None } else { Some(libc::EACCES) }
+}
+
+/// openat/open argument layout, normalized across the two spellings.
+struct OpenArgs {
+    dirfd: i64,
+    path_ptr: u64,
+    flags: u64,
+    mode: u64,
+}
+
+fn decode_open_args(notif: &SeccompNotif) -> OpenArgs {
+    let a = &notif.data.args;
+    if notif.data.nr as i64 == libc::SYS_openat {
+        OpenArgs { dirfd: a[0] as i64, path_ptr: a[1], flags: a[2], mode: a[3] }
+    } else {
+        // legacy open(path, flags, mode) — AT_FDCWD implied.
+        OpenArgs { dirfd: libc::AT_FDCWD as i64, path_ptr: a[0], flags: a[1], mode: a[2] }
+    }
+}
+
+/// Wrap a freshly opened raw fd into an `InjectFdSend`, honoring the child's
+/// `O_CLOEXEC` request. Ownership of `raw_fd` moves into the action.
+fn inject_open_result(raw_fd: i32, flags: u64) -> NotifAction {
+    use std::os::unix::io::FromRawFd;
+    if raw_fd < 0 {
+        return NotifAction::Errno(last_errno(libc::EACCES));
+    }
+    let owned = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+    let newfd_flags = if flags & libc::O_CLOEXEC as u64 != 0 {
+        libc::O_CLOEXEC as u32
+    } else {
+        0
+    };
+    NotifAction::InjectFdSend { srcfd: owned, newfd_flags }
+}
+
+/// Existing-file branch: vet the pinned inode behind `probe`, then reopen it
+/// race-free via its `/proc/self/fd` magic link with the child's real access
+/// mode (binds to the inode, not the original path).
+fn reopen_existing_on_behalf(
+    probe: OwnedFd,
+    flags: u64,
+    policy: &NotifPolicy,
+    pfs: &super::state::PolicyFnState,
+) -> NotifAction {
+    // File exists. Refuse O_CREAT|O_EXCL the way the kernel would.
+    if (flags & libc::O_CREAT as u64) != 0 && (flags & libc::O_EXCL as u64) != 0 {
+        return NotifAction::Errno(libc::EEXIST);
+    }
+    let realpath = match realpath_of_fd(probe.as_raw_fd()) {
+        Some(p) => p,
+        None => return NotifAction::Errno(libc::EACCES),
+    };
+    if let Some(errno) = deny_open_verdict(&realpath, flags, policy, pfs) {
+        return NotifAction::Errno(errno);
+    }
+    // Resolution-only flags are stripped from the reopen.
+    let reopen_flags =
+        flags as i32 & !(libc::O_CREAT | libc::O_EXCL | libc::O_PATH | libc::O_NOFOLLOW);
+    let proc_path = match std::ffi::CString::new(format!("/proc/self/fd/{}", probe.as_raw_fd())) {
+        Ok(c) => c,
+        Err(_) => return NotifAction::Errno(libc::EIO),
+    };
+    let fd = unsafe { libc::open(proc_path.as_ptr(), reopen_flags) };
+    inject_open_result(fd, flags)
+}
+
+/// O_CREAT branch: resolve the parent directory race-free, vet the would-be
+/// target, then create the leaf inside that pinned parent (the dir inode is
+/// fixed, only the leaf name is appended).
+fn create_new_on_behalf(
+    base: &OwnedFd,
+    path: &str,
+    flags: u64,
+    mode: u64,
+    policy: &NotifPolicy,
+    pfs: &super::state::PolicyFnState,
+) -> NotifAction {
+    let p = std::path::Path::new(path);
+    let file_name = match p.file_name() {
+        Some(f) => f,
+        None => return NotifAction::Errno(libc::ENOENT),
+    };
+    let parent = p.parent().unwrap_or(std::path::Path::new("."));
+    let parent_str = match parent.to_str() {
+        Some("") | None => ".",
+        Some(s) => s,
+    };
+    let c_parent = match std::ffi::CString::new(parent_str) {
+        Ok(c) => c,
+        Err(_) => return NotifAction::Errno(libc::EINVAL),
+    };
+    let parent_fd = match openat2_at(
+        base.as_raw_fd(),
+        &c_parent,
+        (libc::O_PATH | libc::O_DIRECTORY | libc::O_CLOEXEC) as u64,
+        0,
+        RESOLVE_NO_MAGICLINKS,
+    ) {
+        Ok(f) => f,
+        Err(e) => return NotifAction::Errno(e),
+    };
+    let parent_real = match realpath_of_fd(parent_fd.as_raw_fd()) {
+        Some(p) => p,
+        None => return NotifAction::Errno(libc::EACCES),
+    };
+    if let Some(errno) = deny_open_verdict(&parent_real.join(file_name), flags, policy, pfs) {
+        return NotifAction::Errno(errno);
+    }
+    let c_name = match std::ffi::CString::new(file_name.as_encoded_bytes()) {
+        Ok(c) => c,
+        Err(_) => return NotifAction::Errno(libc::EINVAL),
+    };
+    let create_flags = flags as i32 & !(libc::O_PATH | libc::O_NOFOLLOW);
+    let fd = unsafe { libc::openat(parent_fd.as_raw_fd(), c_name.as_ptr(), create_flags, mode) };
+    inject_open_result(fd, flags)
+}
+
+/// Perform `openat`/`open` on behalf of the child, race-free, when a deny is
+/// active. Resolves once (pinning the inode), enforces deny + grant on the
+/// pinned target, then hands the child an fd to that exact inode via
+/// `InjectFdSend`. Returns `Continue` only when no allow/deny decision was
+/// made on content we resolved (unreadable path / no allowlist configured),
+/// matching the precheck's existing soft fall-through.
+fn on_behalf_open_for_deny(
+    notif: &SeccompNotif,
+    policy: &NotifPolicy,
+    pfs: &super::state::PolicyFnState,
+    notif_fd: RawFd,
+) -> NotifAction {
+    // No allowlist configured (Landlock is not allowlisting the filesystem):
+    // there is no grant to check against, so taking over the open could only
+    // wrongly deny. Leave it to the existing precheck/kernel path.
+    if policy.chroot_readable.is_empty() && policy.chroot_writable.is_empty() {
+        return NotifAction::Continue;
+    }
+
+    let OpenArgs { dirfd, path_ptr, flags, mode } = decode_open_args(notif);
+
+    let path = match read_child_cstr(notif_fd, notif.id, notif.pid, path_ptr, 4096) {
+        Some(p) => p,
+        None => return NotifAction::Continue, // kernel's re-read fails the same way
+    };
+    let c_path = match std::ffi::CString::new(path.clone()) {
+        Ok(c) => c,
+        Err(_) => return NotifAction::Errno(libc::EINVAL),
+    };
+    let base = match open_base_dir(notif.pid, dirfd) {
+        Ok(b) => b,
+        Err(e) => return NotifAction::Errno(e),
+    };
+
+    // Side-effect-free probe; mirror the child's no-follow intent for the
+    // final component.
+    let probe_flags = (libc::O_PATH | libc::O_CLOEXEC) as u64 | (flags & libc::O_NOFOLLOW as u64);
+    match openat2_at(base.as_raw_fd(), &c_path, probe_flags, 0, RESOLVE_NO_MAGICLINKS) {
+        Ok(probe) => reopen_existing_on_behalf(probe, flags, policy, pfs),
+        Err(errno) if errno == libc::ENOENT && (flags & libc::O_CREAT as u64) != 0 => {
+            create_new_on_behalf(&base, &path, flags, mode, policy, pfs)
+        }
+        Err(errno) => NotifAction::Errno(errno),
+    }
+}
+
 /// Read the thread-group leader (Tgid) of a thread from `/proc/<tid>/status`.
 fn tgid_of(tid: u32) -> Option<u32> {
     let status = std::fs::read_to_string(format!("/proc/{}/status", tid)).ok()?;
@@ -1343,8 +1601,27 @@ async fn handle_notification(
             if is_path_denied_for_notif(&pfs, &notif, fd) {
                 NotifAction::Errno(libc::EACCES)
             } else {
+                let has_denied = pfs.has_denied_paths();
                 drop(pfs);
-                dispatch_table.dispatch(notif, fd).await
+                // Let normal dispatch run first so /proc virtualization and
+                // other handlers still win for their paths.
+                let action = dispatch_table.dispatch(notif, fd).await;
+                // A bare `Continue` for openat/open is the racy window: the
+                // supervisor's resolution said "not denied", but the kernel
+                // re-resolves after Continue and a racing thread can swap a
+                // symlink to reach a denied carve-out inside a granted tree
+                // (issue #111). Run the open on-behalf against the pinned
+                // inode and inject the fd so the kernel never re-resolves.
+                // Other path syscalls keep the best-effort precheck above
+                // (documented follow-up — they return no fd to inject).
+                let is_openat_family =
+                    nr == libc::SYS_openat || Some(nr) == arch::sys_open();
+                if matches!(action, NotifAction::Continue) && is_openat_family && has_denied {
+                    let pfs = ctx.policy_fn.lock().await;
+                    on_behalf_open_for_deny(&notif, policy, &pfs, fd)
+                } else {
+                    action
+                }
             }
         } else {
             dispatch_table.dispatch(notif, fd).await

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -1313,13 +1313,10 @@ fn resolve_path_for_notif(notif: &SeccompNotif, notif_fd: RawFd) -> Option<Strin
             let path = read_path_for_event(notif, notif.data.args[1], notif_fd)?;
             resolve_at_path_for_event(notif, notif.data.args[0] as i64, &path)
         }
-        // symlinkat(target, newdirfd, linkpath)
-        // The target string is what the symlink points to; deny if it names a denied path.
-        n if n == libc::SYS_symlinkat => {
-            let target = read_path_for_event(notif, notif.data.args[0], notif_fd)?;
-            // target may be absolute or relative to the process cwd
-            resolve_at_path_for_event(notif, libc::AT_FDCWD as i64, &target)
-        }
+        // symlinkat/symlink intentionally omitted: creating a symlink does
+        // not access its target, so there is nothing to gate here. Any later
+        // open through the symlink resolves to the real target and is denied
+        // race-free on the open path (issue #111). See `on_behalf_open_for_deny`.
         // link(oldpath, newpath) — legacy, AT_FDCWD implied for both
         n if Some(n) == arch::sys_link() => {
             let path = read_path_for_event(notif, notif.data.args[0], notif_fd)?;
@@ -1329,11 +1326,6 @@ fn resolve_path_for_notif(notif: &SeccompNotif, notif_fd: RawFd) -> Option<Strin
         n if Some(n) == arch::sys_rename() => {
             let path = read_path_for_event(notif, notif.data.args[0], notif_fd)?;
             resolve_at_path_for_event(notif, libc::AT_FDCWD as i64, &path)
-        }
-        // symlink(target, linkpath) — legacy
-        n if Some(n) == arch::sys_symlink() => {
-            let target = read_path_for_event(notif, notif.data.args[0], notif_fd)?;
-            resolve_at_path_for_event(notif, libc::AT_FDCWD as i64, &target)
         }
         _ => None,
     }
@@ -1620,12 +1612,15 @@ async fn handle_notification(
     // Check dynamic path denials before dispatch
     let mut action = {
         let nr = notif.data.nr as i64;
+        // symlinkat/symlink are not gated: creating a symlink does not access
+        // its target (any open through it is denied race-free on the open
+        // path). See `resolve_path_for_notif`.
         let mut path_check_nrs = vec![
             libc::SYS_openat, arch::SYS_OPENAT2, libc::SYS_execve, libc::SYS_execveat,
-            libc::SYS_linkat, libc::SYS_renameat2, libc::SYS_symlinkat,
+            libc::SYS_linkat, libc::SYS_renameat2,
         ];
         path_check_nrs.extend([
-            arch::sys_open(), arch::sys_link(), arch::sys_rename(), arch::sys_symlink(),
+            arch::sys_open(), arch::sys_link(), arch::sys_rename(),
         ].into_iter().flatten());
         let should_precheck_denied = policy.chroot_root.is_none()
             && path_check_nrs.contains(&nr);

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -370,6 +370,16 @@ fn is_denied_with_symlink_resolve(
         if policy_fn_state.is_path_denied(&real.to_string_lossy()) {
             return true;
         }
+        // Identity check: catches a denied file reached via a hardlink or a
+        // pre-existing alias, where the resolved path itself is not denied
+        // but the file identity is. Best-effort here (path-based precheck);
+        // the race-free authority is the fd identity check in the on-behalf
+        // open.
+        if let Some(id) = super::state::file_id_of_path(&real.to_string_lossy()) {
+            if policy_fn_state.is_id_denied(&id) {
+                return true;
+            }
+        }
     }
     false
 }
@@ -436,6 +446,7 @@ fn open_base_dir(pid: u32, dirfd: i64) -> Result<OwnedFd, i32> {
 fn realpath_of_fd(fd: RawFd) -> Option<std::path::PathBuf> {
     std::fs::read_link(format!("/proc/self/fd/{}", fd)).ok()
 }
+
 
 fn path_under_any(path: &std::path::Path, list: &[std::path::PathBuf]) -> bool {
     list.iter().any(|p| path.starts_with(p))
@@ -550,6 +561,15 @@ fn reopen_existing_on_behalf(
     };
     if let Some(errno) = deny_open_verdict(&realpath, flags, policy, pfs) {
         return NotifAction::Errno(errno);
+    }
+    // Identity check on the pinned file: a denied file reached via a hardlink,
+    // a rename to a non-denied name, or a pre-existing alias has a realpath
+    // that is not denied, but its handle identity is. Race-free — this is the
+    // exact file the child will receive.
+    if let Some(id) = super::state::file_id_of_fd(probe.as_raw_fd()) {
+        if pfs.is_id_denied(&id) {
+            return NotifAction::Errno(libc::EACCES);
+        }
     }
     // Resolution-only flags are stripped from the reopen.
     let reopen_flags =

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -470,21 +470,48 @@ fn deny_open_verdict(
     if allowed { None } else { Some(libc::EACCES) }
 }
 
-/// openat/open argument layout, normalized across the two spellings.
+/// open/openat/openat2 argument layout, normalized across the spellings.
 struct OpenArgs {
     dirfd: i64,
     path_ptr: u64,
     flags: u64,
     mode: u64,
+    /// `openat2` `resolve` flags (`RESOLVE_*`); 0 for `open`/`openat`.
+    resolve: u64,
 }
 
-fn decode_open_args(notif: &SeccompNotif) -> OpenArgs {
+/// Decode the open arguments. `openat2` carries flags/mode/resolve inside a
+/// `struct open_how` in child memory, so its decode reads child memory and
+/// can fail; `None` means "could not decode" and the caller soft-falls-through
+/// (the kernel's own re-read fails the same way).
+fn decode_open_args(notif: &SeccompNotif, notif_fd: RawFd) -> Option<OpenArgs> {
     let a = &notif.data.args;
-    if notif.data.nr as i64 == libc::SYS_openat {
-        OpenArgs { dirfd: a[0] as i64, path_ptr: a[1], flags: a[2], mode: a[3] }
+    let nr = notif.data.nr as i64;
+    if nr == libc::SYS_openat {
+        Some(OpenArgs { dirfd: a[0] as i64, path_ptr: a[1], flags: a[2], mode: a[3], resolve: 0 })
+    } else if nr == arch::SYS_OPENAT2 {
+        // openat2(dirfd, pathname, struct open_how *how, size_t size),
+        // open_how = { u64 flags, u64 mode, u64 resolve }.
+        let how_ptr = a[2];
+        let want = (a[3] as usize).min(std::mem::size_of::<OpenHow>());
+        if how_ptr == 0 || want < 16 {
+            return None; // need at least flags + mode
+        }
+        let bytes = read_child_mem(notif_fd, notif.id, notif.pid, how_ptr, want).ok()?;
+        if bytes.len() < 16 {
+            return None;
+        }
+        let flags = u64::from_ne_bytes(bytes[0..8].try_into().ok()?);
+        let mode = u64::from_ne_bytes(bytes[8..16].try_into().ok()?);
+        let resolve = if bytes.len() >= 24 {
+            u64::from_ne_bytes(bytes[16..24].try_into().ok()?)
+        } else {
+            0
+        };
+        Some(OpenArgs { dirfd: a[0] as i64, path_ptr: a[1], flags, mode, resolve })
     } else {
         // legacy open(path, flags, mode) — AT_FDCWD implied.
-        OpenArgs { dirfd: libc::AT_FDCWD as i64, path_ptr: a[0], flags: a[1], mode: a[2] }
+        Some(OpenArgs { dirfd: libc::AT_FDCWD as i64, path_ptr: a[0], flags: a[1], mode: a[2], resolve: 0 })
     }
 }
 
@@ -543,6 +570,7 @@ fn create_new_on_behalf(
     path: &str,
     flags: u64,
     mode: u64,
+    resolve: u64,
     policy: &NotifPolicy,
     pfs: &super::state::PolicyFnState,
 ) -> NotifAction {
@@ -565,7 +593,7 @@ fn create_new_on_behalf(
         &c_parent,
         (libc::O_PATH | libc::O_DIRECTORY | libc::O_CLOEXEC) as u64,
         0,
-        RESOLVE_NO_MAGICLINKS,
+        RESOLVE_NO_MAGICLINKS | resolve,
     ) {
         Ok(f) => f,
         Err(e) => return NotifAction::Errno(e),
@@ -605,7 +633,11 @@ fn on_behalf_open_for_deny(
         return NotifAction::Continue;
     }
 
-    let OpenArgs { dirfd, path_ptr, flags, mode } = decode_open_args(notif);
+    let OpenArgs { dirfd, path_ptr, flags, mode, resolve } =
+        match decode_open_args(notif, notif_fd) {
+            Some(a) => a,
+            None => return NotifAction::Continue, // kernel's re-read fails the same way
+        };
 
     let path = match read_child_cstr(notif_fd, notif.id, notif.pid, path_ptr, 4096) {
         Some(p) => p,
@@ -621,12 +653,12 @@ fn on_behalf_open_for_deny(
     };
 
     // Side-effect-free probe; mirror the child's no-follow intent for the
-    // final component.
+    // final component and any `openat2` RESOLVE_* flags it requested.
     let probe_flags = (libc::O_PATH | libc::O_CLOEXEC) as u64 | (flags & libc::O_NOFOLLOW as u64);
-    match openat2_at(base.as_raw_fd(), &c_path, probe_flags, 0, RESOLVE_NO_MAGICLINKS) {
+    match openat2_at(base.as_raw_fd(), &c_path, probe_flags, 0, RESOLVE_NO_MAGICLINKS | resolve) {
         Ok(probe) => reopen_existing_on_behalf(probe, flags, policy, pfs),
         Err(errno) if errno == libc::ENOENT && (flags & libc::O_CREAT as u64) != 0 => {
-            create_new_on_behalf(&base, &path, flags, mode, policy, pfs)
+            create_new_on_behalf(&base, &path, flags, mode, resolve, policy, pfs)
         }
         Err(errno) => NotifAction::Errno(errno),
     }
@@ -1255,8 +1287,9 @@ fn resolve_at_path_for_event(notif: &SeccompNotif, dirfd: i64, path: &str) -> Op
 fn resolve_path_for_notif(notif: &SeccompNotif, notif_fd: RawFd) -> Option<String> {
     let nr = notif.data.nr as i64;
     match nr {
-        n if n == libc::SYS_openat => {
-            // openat(dirfd, pathname, flags, mode)
+        n if n == libc::SYS_openat || n == arch::SYS_OPENAT2 => {
+            // openat(dirfd, pathname, flags, mode) and
+            // openat2(dirfd, pathname, how, size) share (dirfd, pathname).
             let path = read_path_for_event(notif, notif.data.args[1], notif_fd)?;
             resolve_at_path_for_event(notif, notif.data.args[0] as i64, &path)
         }
@@ -1588,7 +1621,7 @@ async fn handle_notification(
     let mut action = {
         let nr = notif.data.nr as i64;
         let mut path_check_nrs = vec![
-            libc::SYS_openat, libc::SYS_execve, libc::SYS_execveat,
+            libc::SYS_openat, arch::SYS_OPENAT2, libc::SYS_execve, libc::SYS_execveat,
             libc::SYS_linkat, libc::SYS_renameat2, libc::SYS_symlinkat,
         ];
         path_check_nrs.extend([
@@ -1614,8 +1647,9 @@ async fn handle_notification(
                 // inode and inject the fd so the kernel never re-resolves.
                 // Other path syscalls keep the best-effort precheck above
                 // (documented follow-up — they return no fd to inject).
-                let is_openat_family =
-                    nr == libc::SYS_openat || Some(nr) == arch::sys_open();
+                let is_openat_family = nr == libc::SYS_openat
+                    || nr == arch::SYS_OPENAT2
+                    || Some(nr) == arch::sys_open();
                 if matches!(action, NotifAction::Continue) && is_openat_family && has_denied {
                     let pfs = ctx.policy_fn.lock().await;
                     on_behalf_open_for_deny(&notif, policy, &pfs, fd)

--- a/crates/sandlock-core/src/seccomp/state.rs
+++ b/crates/sandlock-core/src/seccomp/state.rs
@@ -433,6 +433,16 @@ impl PolicyFnState {
             false
         }
     }
+
+    /// Whether any deny rule is currently in effect. Cheap gate for the
+    /// race-free on-behalf open path: with no denies there is no carve-out
+    /// to protect and opens are left to the kernel and Landlock.
+    pub fn has_denied_paths(&self) -> bool {
+        self.denied_paths
+            .read()
+            .map(|d| !d.is_empty())
+            .unwrap_or(false)
+    }
 }
 
 // ============================================================

--- a/crates/sandlock-core/src/seccomp/state.rs
+++ b/crates/sandlock-core/src/seccomp/state.rs
@@ -402,6 +402,115 @@ impl TimeRandomState {
 }
 
 // ============================================================
+// DeniedSet — denied paths plus captured file identities
+// ============================================================
+
+/// The filesystem deny set: path prefixes plus the file-handle identities
+/// captured when each path was denied.
+///
+/// The path set is the primary, race-free boundary enforced at `open`. The
+/// identity set makes the deny robust against namespace games (hardlinks,
+/// renames, and pre-existing aliases): a [`FileId`] is the kernel file handle,
+/// which encodes the inode and a generation number, so it travels with the
+/// file's identity rather than the name used to reach it and is immune to
+/// inode reuse. An open is denied if the opened file's identity matches, no
+/// matter which path led to it. With `AT_HANDLE_FID` the kernel encodes an
+/// identity FID for essentially every filesystem (generic inode FID where
+/// NFS-export ops are absent); the rare path that still fails captures no
+/// identity and relies on the always-on path prefix.
+#[derive(Default)]
+pub struct DeniedSet {
+    paths: std::sync::RwLock<HashSet<String>>,
+    ids: std::sync::RwLock<HashSet<FileId>>,
+}
+
+/// A file's stable identity: its kernel file handle, keyed by the superblock
+/// device so identical handles from different filesystems cannot collide.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct FileId {
+    dev: u64,
+    handle_type: i32,
+    handle: Vec<u8>,
+}
+
+/// Identity of a path, following symlinks (the open will resolve to the same
+/// target). `None` if it cannot be resolved or no handle can be encoded. The
+/// `(handle_type, handle)` FID comes from [`crate::sys::fs::file_handle`]; it is
+/// keyed by the superblock `dev` so handles from different filesystems cannot
+/// collide.
+pub(crate) fn file_id_of_path(path: &str) -> Option<FileId> {
+    use std::os::unix::fs::MetadataExt;
+    let dev = std::fs::metadata(path).ok()?.dev();
+    let c = std::ffi::CString::new(path).ok()?;
+    let (handle_type, handle) =
+        crate::sys::fs::file_handle(libc::AT_FDCWD, &c, libc::AT_SYMLINK_FOLLOW)?;
+    Some(FileId { dev, handle_type, handle })
+}
+
+/// Identity of an open fd.
+pub(crate) fn file_id_of_fd(fd: std::os::unix::io::RawFd) -> Option<FileId> {
+    let mut st: libc::stat = unsafe { std::mem::zeroed() };
+    if unsafe { libc::fstat(fd, &mut st) } != 0 {
+        return None;
+    }
+    let empty = std::ffi::CString::new("").ok()?;
+    let (handle_type, handle) = crate::sys::fs::file_handle(fd, &empty, libc::AT_EMPTY_PATH)?;
+    Some(FileId { dev: st.st_dev as u64, handle_type, handle })
+}
+
+impl DeniedSet {
+    /// Deny `path` (and its subtree, by prefix). Also captures the file's
+    /// handle identity if it exists now, so the deny still applies after the
+    /// file is hardlinked or renamed to a non-denied name.
+    pub fn deny(&self, path: &str) {
+        if let Ok(mut p) = self.paths.write() {
+            p.insert(path.to_string());
+        }
+        if let Some(id) = file_id_of_path(path) {
+            if let Ok(mut i) = self.ids.write() {
+                i.insert(id);
+            }
+        }
+    }
+
+    /// Stop denying `path`, dropping its captured identity too (best-effort:
+    /// only if the path still resolves). A leftover identity would only ever
+    /// over-deny, which is fail-safe.
+    pub fn allow(&self, path: &str) {
+        if let Ok(mut p) = self.paths.write() {
+            p.remove(path);
+        }
+        if let Some(id) = file_id_of_path(path) {
+            if let Ok(mut i) = self.ids.write() {
+                i.remove(&id);
+            }
+        }
+    }
+
+    /// True if `path` is at or beneath a denied path (lexical prefix).
+    pub fn is_path_denied(&self, path: &str) -> bool {
+        self.paths.read().map_or(false, |denied| {
+            let path = std::path::Path::new(path);
+            denied
+                .iter()
+                .any(|d| path.starts_with(std::path::Path::new(d)))
+        })
+    }
+
+    /// True if `id` is a denied file identity (catches hardlinks, renames, and
+    /// pre-existing aliases regardless of the path used).
+    pub(crate) fn is_id_denied(&self, id: &FileId) -> bool {
+        self.ids.read().map_or(false, |s| s.contains(id))
+    }
+
+    /// Whether any deny rule is in effect.
+    pub fn is_empty(&self) -> bool {
+        self.paths.read().map_or(true, |p| p.is_empty())
+            && self.ids.read().map_or(true, |i| i.is_empty())
+    }
+}
+
+// ============================================================
 // PolicyFnState — dynamic policy callback state
 // ============================================================
 
@@ -411,8 +520,8 @@ pub struct PolicyFnState {
     pub event_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::policy_fn::PolicyEvent>>,
     /// Shared live policy for dynamic updates (None if no policy_fn).
     pub live_policy: Option<std::sync::Arc<std::sync::RwLock<crate::policy_fn::LivePolicy>>>,
-    /// Dynamically denied paths from policy_fn.
-    pub denied_paths: std::sync::Arc<std::sync::RwLock<HashSet<String>>>,
+    /// Dynamically denied paths and inode identities from policy_fn / fs_deny.
+    pub denied: std::sync::Arc<DeniedSet>,
 }
 
 impl PolicyFnState {
@@ -420,28 +529,25 @@ impl PolicyFnState {
         Self {
             event_tx: None,
             live_policy: None,
-            denied_paths: std::sync::Arc::new(std::sync::RwLock::new(HashSet::new())),
+            denied: std::sync::Arc::new(DeniedSet::default()),
         }
     }
 
-    /// Check if a path is dynamically denied.
+    /// Check if a path is at or beneath a denied path.
     pub fn is_path_denied(&self, path: &str) -> bool {
-        if let Ok(denied) = self.denied_paths.read() {
-            let path = std::path::Path::new(path);
-            denied.iter().any(|d| path.starts_with(std::path::Path::new(d)))
-        } else {
-            false
-        }
+        self.denied.is_path_denied(path)
+    }
+
+    /// Check if an opened file's handle identity is denied.
+    pub(crate) fn is_id_denied(&self, id: &FileId) -> bool {
+        self.denied.is_id_denied(id)
     }
 
     /// Whether any deny rule is currently in effect. Cheap gate for the
     /// race-free on-behalf open path: with no denies there is no carve-out
     /// to protect and opens are left to the kernel and Landlock.
     pub fn has_denied_paths(&self) -> bool {
-        self.denied_paths
-            .read()
-            .map(|d| !d.is_empty())
-            .unwrap_or(false)
+        !self.denied.is_empty()
     }
 }
 

--- a/crates/sandlock-core/src/seccomp_plan.rs
+++ b/crates/sandlock-core/src/seccomp_plan.rs
@@ -232,6 +232,10 @@ fn chroot_path_syscalls() -> Vec<i64> {
 }
 
 fn fs_denied_path_syscalls() -> Vec<i64> {
+    // symlinkat/symlink are intentionally absent: creating a symlink does not
+    // access its target, so there is nothing to deny at creation time. A later
+    // open through the symlink resolves to the real target and is denied
+    // race-free on the open path (issue #111).
     let mut v = vec![
         libc::SYS_openat,
         arch::SYS_OPENAT2,
@@ -239,14 +243,12 @@ fn fs_denied_path_syscalls() -> Vec<i64> {
         libc::SYS_execveat,
         libc::SYS_linkat,
         libc::SYS_renameat2,
-        libc::SYS_symlinkat,
     ];
     v.extend(
         [
             arch::sys_open(),
             arch::sys_link(),
             arch::sys_rename(),
-            arch::sys_symlink(),
         ]
         .into_iter()
         .flatten(),

--- a/crates/sandlock-core/src/seccomp_plan.rs
+++ b/crates/sandlock-core/src/seccomp_plan.rs
@@ -234,6 +234,7 @@ fn chroot_path_syscalls() -> Vec<i64> {
 fn fs_denied_path_syscalls() -> Vec<i64> {
     let mut v = vec![
         libc::SYS_openat,
+        arch::SYS_OPENAT2,
         libc::SYS_execve,
         libc::SYS_execveat,
         libc::SYS_linkat,
@@ -255,6 +256,7 @@ fn fs_denied_path_syscalls() -> Vec<i64> {
 
 const POLICY_EVENT_SYSCALLS: &[i64] = &[
     libc::SYS_openat,
+    arch::SYS_OPENAT2,
     libc::SYS_connect,
     libc::SYS_sendto,
     libc::SYS_bind,

--- a/crates/sandlock-core/src/sys/fs.rs
+++ b/crates/sandlock-core/src/sys/fs.rs
@@ -474,6 +474,69 @@ pub(crate) fn chown_in_root(root: &Path, rel: &str, uid: u32, gid: u32) -> Resul
     }
 }
 
+// ============================================================
+// File-handle identity (non-chroot fs-deny path)
+// ============================================================
+
+/// `AT_HANDLE_FID` (Linux 6.5+): request an identity-only file handle that
+/// "may not be usable with open_by_handle_at". Not in libc 0.2.x. The kernel
+/// can encode this for essentially every filesystem, including those without
+/// NFS-export ops (it falls back to a generic inode FID).
+const AT_HANDLE_FID: libc::c_int = 0x200;
+
+/// Encode a file's stable identity via `name_to_handle_at`: returns
+/// `(handle_type, handle_bytes)`, a token that travels with the file's inode
+/// (plus a generation number) rather than the path used to reach it.
+/// `dirfd`/`path`/`base_flags` follow the syscall: `(AT_FDCWD, path,
+/// AT_SYMLINK_FOLLOW)` for a path, or `(fd, "", AT_EMPTY_PATH)` for an fd.
+///
+/// Prefers `AT_HANDLE_FID` for the widest filesystem coverage; on a pre-6.5
+/// kernel that flag is rejected with `EINVAL`, so we retry without it (a plain
+/// decodeable handle, supported by every export-capable filesystem). `None` if
+/// no handle can be encoded — the caller then relies on a path-based fallback.
+pub(crate) fn file_handle(
+    dirfd: RawFd,
+    path: &std::ffi::CStr,
+    base_flags: libc::c_int,
+) -> Option<(i32, Vec<u8>)> {
+    match encode_fh(dirfd, path, base_flags | AT_HANDLE_FID) {
+        Ok(h) => Some(h),
+        Err(libc::EINVAL) => encode_fh(dirfd, path, base_flags).ok(),
+        Err(_) => None,
+    }
+}
+
+fn encode_fh(dirfd: RawFd, path: &std::ffi::CStr, flags: libc::c_int) -> Result<(i32, Vec<u8>), i32> {
+    // `struct file_handle` is variable length; keep the header and a
+    // MAX_HANDLE_SZ payload contiguous and 4-byte aligned (c_uint first).
+    #[repr(C)]
+    struct HandleBuf {
+        handle_bytes: u32,
+        handle_type: i32,
+        f_handle: [u8; libc::MAX_HANDLE_SZ as usize],
+    }
+    let mut hb = HandleBuf {
+        handle_bytes: libc::MAX_HANDLE_SZ as u32,
+        handle_type: 0,
+        f_handle: [0u8; libc::MAX_HANDLE_SZ as usize],
+    };
+    let mut mount_id: libc::c_int = 0;
+    let r = unsafe {
+        libc::name_to_handle_at(
+            dirfd,
+            path.as_ptr(),
+            &mut hb as *mut HandleBuf as *mut libc::file_handle,
+            &mut mount_id,
+            flags,
+        )
+    };
+    if r != 0 {
+        return Err(last_errno(libc::EIO));
+    }
+    let n = (hb.handle_bytes as usize).min(libc::MAX_HANDLE_SZ as usize);
+    Ok((hb.handle_type, hb.f_handle[..n].to_vec()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/sandlock-core/tests/integration/test_landlock.rs
+++ b/crates/sandlock-core/tests/integration/test_landlock.rs
@@ -1497,3 +1497,64 @@ async fn test_isolate_signals_allows_self() {
 
     let _ = std::fs::remove_file(&out);
 }
+
+#[tokio::test]
+async fn test_deny_carveout_on_behalf_open_preserves_io() {
+    // Issue #111: with a deny active, openat/open run on-behalf in the
+    // supervisor (race-free) instead of Continue-ing to the kernel. This
+    // checks that the new path preserves normal I/O — allowed reads, allowed
+    // creates — while the denied carve-out inside the granted tree stays
+    // blocked.
+    let dir = temp_file("deny-onbehalf-dir");
+    let _ = std::fs::create_dir_all(&dir);
+    let ok = dir.join("ok.txt");
+    let secret = dir.join("secret.txt");
+    std::fs::write(&ok, "ok-data").unwrap();
+    std::fs::write(&secret, "secret-data").unwrap();
+    let created = dir.join("created.txt");
+    let _ = std::fs::remove_file(&created);
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr")
+        .fs_read("/lib")
+        .fs_read_if_exists("/lib64")
+        .fs_read("/bin")
+        .fs_read("/etc")
+        .fs_read("/proc")
+        .fs_read("/dev")
+        .fs_write(dir.to_str().unwrap()) // grant the whole tree writable
+        .fs_deny(secret.to_str().unwrap()) // carve-out inside the grant
+        .build()
+        .unwrap();
+
+    // Allowed read still works (on-behalf probe + reopen path).
+    let r = policy
+        .clone()
+        .with_name("t")
+        .run(&["cat", ok.to_str().unwrap()])
+        .await
+        .unwrap();
+    assert!(r.success(), "allowed read must work through on-behalf open");
+
+    // Allowed create still works (on-behalf O_CREAT parent-resolve path).
+    let cmd = format!("echo hi > {}", created.display());
+    let w = policy
+        .clone()
+        .with_name("t")
+        .run_interactive(&["sh", "-c", &cmd])
+        .await
+        .unwrap();
+    assert!(w.success(), "allowed create must work through on-behalf open");
+    assert_eq!(std::fs::read_to_string(&created).unwrap().trim(), "hi");
+
+    // The denied carve-out stays blocked.
+    let d = policy
+        .clone()
+        .with_name("t")
+        .run(&["cat", secret.to_str().unwrap()])
+        .await
+        .unwrap();
+    assert!(!d.success(), "denied carve-out must stay blocked");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/sandlock-core/tests/integration/test_landlock.rs
+++ b/crates/sandlock-core/tests/integration/test_landlock.rs
@@ -1558,3 +1558,59 @@ async fn test_deny_carveout_on_behalf_open_preserves_io() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+#[tokio::test]
+async fn test_deny_openat2_does_not_bypass() {
+    // Issue #111 follow-up: openat2 must be trapped and subject to the deny
+    // just like openat. A program calling openat2 directly (glibc normally
+    // does not) must not escape a deny carve-out, and openat2 of an allowed
+    // sibling must still work. SYS_openat2 = 437 (x86_64 test host).
+    let dir = temp_file("deny-openat2-dir");
+    let _ = std::fs::create_dir_all(&dir);
+    let ok = dir.join("ok.txt");
+    let secret = dir.join("secret.txt");
+    std::fs::write(&ok, "ok-data").unwrap();
+    std::fs::write(&secret, "secret-data").unwrap();
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr")
+        .fs_read("/lib")
+        .fs_read_if_exists("/lib64")
+        .fs_read("/bin")
+        .fs_read("/etc")
+        .fs_read("/proc")
+        .fs_read("/dev")
+        .fs_read(dir.to_str().unwrap())
+        .fs_deny(secret.to_str().unwrap())
+        .fs_write("/tmp")
+        .build()
+        .unwrap();
+
+    // raw openat2(AT_FDCWD, path, &open_how{O_RDONLY,0,0}, 24)
+    let script = format!(
+        "import ctypes, struct, sys\n\
+         libc = ctypes.CDLL(None, use_errno=True)\n\
+         def openat2(p):\n\
+         \x20   how = struct.pack('QQQ', 0, 0, 0)\n\
+         \x20   buf = ctypes.create_string_buffer(how, len(how))\n\
+         \x20   return libc.syscall(437, -100, ctypes.c_char_p(p.encode()), buf, ctypes.c_size_t(len(how)))\n\
+         secret = openat2('{}')\n\
+         allowed = openat2('{}')\n\
+         sys.exit(0 if (secret < 0 and allowed >= 0) else 1)\n",
+        secret.display(),
+        ok.display(),
+    );
+
+    let r = policy
+        .clone()
+        .with_name("t")
+        .run(&["python3", "-c", &script])
+        .await
+        .unwrap();
+    assert!(
+        r.success(),
+        "openat2 must be denied for the carve-out and allowed for the sibling"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/sandlock-core/tests/integration/test_sandbox.rs
+++ b/crates/sandlock-core/tests/integration/test_sandbox.rs
@@ -295,6 +295,40 @@ async fn test_denied_path_hardlink_blocked() {
     );
 }
 
+/// A pre-existing hardlink (an alias name for the denied inode, created before
+/// the sandbox starts) must not be readable. This is the non-racy bypass that
+/// only inode-identity deny closes: the alias path is not denied, but its inode
+/// is the denied file's inode.
+#[tokio::test]
+async fn test_denied_path_preexisting_hardlink_blocked() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let secret = tmp.path().join("secret.txt");
+    std::fs::write(&secret, "TOP_SECRET").unwrap();
+    // Alias under a non-denied name, created before the sandbox.
+    let alias = tmp.path().join("alias.txt");
+    std::fs::hard_link(&secret, &alias).unwrap();
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr").fs_read("/lib").fs_read_if_exists("/lib64")
+        .fs_read("/bin").fs_read("/proc").fs_read("/etc")
+        .fs_read(tmp.path())
+        .fs_deny(&secret) // deny only the "secret.txt" name
+        .build()
+        .unwrap();
+
+    // Read via the alias name — not denied by path, but the same inode.
+    let result = policy
+        .clone()
+        .with_name("test")
+        .run(&["cat", alias.to_str().unwrap()])
+        .await
+        .unwrap();
+    assert!(
+        result.stdout_str().map_or(true, |s| !s.contains("TOP_SECRET")),
+        "pre-existing hardlink bypass: read denied file's bytes via an alias name"
+    );
+}
+
 #[tokio::test]
 async fn test_denied_path_rename_blocked() {
     let tmp = tempfile::TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Closes #111. In non-chroot mode `fs_deny` could be bypassed: the seccomp-time path precheck resolves a path, returns "not denied", and `Continue`s, but the kernel re-resolves the path on execution (a TOCTOU). The load-bearing case is a deny carve-out inside a Landlock-granted tree, since Landlock cannot subtract a sub-path from a grant (a zero-access rule is rejected with ENOMSG).

This PR closes the read/write confidentiality boundary across every path and namespace vector, and documents the one remaining best-effort case (`execve`) as a kernel limitation.

## What changed (4 commits)

1. **Race-free on-behalf open.** For `openat`/`open`, when a deny is active, the supervisor resolves once via `openat2` (pinning the inode), enforces deny + grant on the pinned target, then injects the fd with `NOTIF_ADDFD`. The kernel never re-resolves, so there is no second resolution to race. Grant enforcement is conservative (never over-allows, so no escape) and side-effect-safe (an `O_PATH` probe runs before any `O_TRUNC`/`O_CREAT`).

2. **Trap `openat2`.** `openat2` was absent from the deny trap set, so it sidestepped the deny entirely. It is now trapped (static `fs_deny` and dynamic `policy_fn`) with `open_how` decoding for flags/mode/resolve.

3. **Drop the redundant symlink-target deny.** Creating a symlink does not access its target; any open through it is denied race-free at open. This removes dead code and a deny-oracle side channel.

4. **Deny by file-handle identity at open.** The deny set captures each denied file's kernel file handle via `name_to_handle_at` with `AT_HANDLE_FID` (an unprivileged, identity-only FID that encodes the inode and a generation number, keyed by the superblock device). The on-behalf open reads the pinned fd's FID and rejects on identity match, so a denied file reached via a hardlink, a rename to a non-denied name, or a pre-existing alias is blocked regardless of the path used. Immune to inode reuse. `AT_HANDLE_FID` (Linux 6.5+) covers essentially every filesystem via a generic inode FID; pre-6.5 kernels retry for a plain handle. No inode fallback: where no handle is available, the always-on path prefix applies.

## Coverage

| Vector | Status |
|---|---|
| read/exec of direct denied path | race-free |
| `openat2` spelling | trapped + enforced |
| symlink to denied path | denied at open |
| rename / hardlink away then read | denied by identity |
| pre-existing hardlink alias | denied by identity |
| `execve` of denied binary | best-effort (kernel cannot rewrite exec to a vetted fd) |

The deny model is now path-based access control enforced race-free at open, with a file-handle identity layer that is robust to namespace games. The two layers are additive: where handle identity is unavailable, enforcement falls back to path-based, never weaker.

## Tests

New integration tests: race-free on-behalf open preserves normal IO; `openat2` cannot bypass; pre-existing hardlink alias is blocked by identity. Existing symlink/hardlink/rename deny tests continue to pass via open-time enforcement. Full suite: 264 integration + 409 lib, 0 failures.

## Known limitations / follow-ups

- `execve` deny remains best-effort (racy under symlink swap). This is a policy gap, not a containment or confidentiality breach: an exec'd binary stays under the same Landlock + seccomp confinement. Fully closing it needs a different subsystem (fanotify `FAN_OPEN_EXEC_PERM`, which requires CAP_SYS_ADMIN) or task-freezing.
- File-handle identity covers essentially all filesystems via `AT_HANDLE_FID`'s generic inode FID (ext4, xfs, btrfs, f2fs, tmpfs, fat, fuse, cifs, nfs, overlay, ...). The rare filesystem with no encodable handle captures no identity and falls back to path-prefix deny. overlayfs copy-up moves a file to a new identity (would need re-capture).
- Privileged deployments could replace the seccomp + identity layer entirely with fanotify permission events (`FAN_OPEN_PERM` + `FAN_OPEN_EXEC_PERM`, inode marks): identity-native, race-free, composes with Landlock as a pure deny layer, and closes the `execve` gap. Noted as a future enhancement gated on CAP_SYS_ADMIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
