### PR TITLE
feat(go): Protection opt-out parity — AllowDegraded / Disable

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -5,8 +5,9 @@ lightweight Linux process sandbox built on Landlock, seccomp-bpf, and seccomp
 user notification. No root, no Docker, no namespaces.
 
 The bindings bind the sandlock C ABI (`libsandlock_ffi`) via cgo, mirroring the
-Python SDK's `Sandbox` surface. **Linux only**; the runtime requires Linux
-6.12+ (Landlock ABI v6).
+Python SDK's `Sandbox` surface. **Linux only**; by default the runtime requires
+Linux 6.12+ (Landlock ABI v6), but the `AllowDegraded` / `Disable` fields let a
+sandbox run on older kernels by degrading or disabling the v6-only protections.
 
 ```go
 import sandlock "github.com/multikernel/sandlock/go"

--- a/go/sandbox.go
+++ b/go/sandbox.go
@@ -3,8 +3,10 @@
 // notification. It binds the sandlock C ABI (libsandlock_ffi) via cgo and
 // mirrors the Python SDK's Sandbox surface.
 //
-// The bindings are Linux-only. The runtime requires Linux 6.12+ (Landlock
-// ABI v6); see the project README for the full kernel feature matrix.
+// The bindings are Linux-only. By default the runtime requires Linux 6.12+
+// (Landlock ABI v6); use the AllowDegraded or Disable fields to run on older
+// kernels by degrading or disabling the v6-only protections. See the project
+// README for the full kernel feature matrix.
 //
 // # Building
 //
@@ -150,6 +152,20 @@ type PolicyContext struct {
 // activity, so captured state should be synchronized when mutated.
 type PolicyFunc func(event SyscallEvent, ctx *PolicyContext) PolicyDecision
 
+// Protection identifies a single Landlock protection whose enforcement
+// posture can be opted out of via the Sandbox AllowDegraded / Disable fields.
+// The values match the sandlock C ABI discriminants.
+type Protection uint32
+
+const (
+	ProtectionFSRefer                 Protection = 0 // file reparenting (Landlock ABI v2)
+	ProtectionFSTruncate              Protection = 1 // truncate(2) (ABI v3)
+	ProtectionNetTCP                  Protection = 2 // TCP bind/connect (ABI v4)
+	ProtectionFSIoctlDev              Protection = 3 // device ioctl(2) (ABI v5)
+	ProtectionSignalScope             Protection = 4 // signal scoping (ABI v6)
+	ProtectionAbstractUnixSocketScope Protection = 5 // abstract UNIX socket scoping (ABI v6)
+)
+
 // Sandbox holds the policy configuration for confining a process. Every field
 // is optional; an unset field means "no restriction" unless documented
 // otherwise. sandlock's default syscall blocklist is always applied.
@@ -171,6 +187,20 @@ type Sandbox struct {
 	// FSMount maps virtual paths inside the chroot to host directories,
 	// like a bind mount without kernel mounts or root.
 	FSMount map[string]string
+
+	// Protection opt-out (Landlock per-protection posture).
+	//
+	// By default every protection is enforced strictly, which requires the
+	// host kernel to support it (the highest floor is ABI v6); on an older
+	// kernel a strict protection it cannot satisfy makes the build fail.
+	// AllowDegraded marks protections to enforce where the host supports them
+	// and silently skip otherwise; Disable turns them off entirely. Together
+	// they let a sandbox run on a kernel below the default v6 floor.
+	//
+	// A protection listed in both fields is disabled: Disable is applied
+	// last and takes precedence.
+	AllowDegraded []Protection
+	Disable       []Protection
 
 	// Network.
 	//

--- a/go/sandlock_linux.go
+++ b/go/sandlock_linux.go
@@ -242,6 +242,14 @@ func (s *Sandbox) buildPolicy() (*C.sandlock_sandbox_t, error) {
 		b = C.sandlock_sandbox_builder_port_remap(b, cbool(true))
 	}
 
+	// Protection opt-out (Landlock per-protection posture).
+	for _, p := range s.AllowDegraded {
+		b = C.sandlock_sandbox_builder_allow_degraded(b, C.uint32_t(p))
+	}
+	for _, p := range s.Disable {
+		b = C.sandlock_sandbox_builder_disable(b, C.uint32_t(p))
+	}
+
 	// HTTP ACL.
 	for _, r := range s.HTTPAllow {
 		str(func(b *C.sandlock_builder_t, c *C.char) *C.sandlock_builder_t {
@@ -753,6 +761,13 @@ func LandlockABIVersion() int { return int(C.sandlock_landlock_abi_version()) }
 
 // MinLandlockABI returns the minimum Landlock ABI version this build requires.
 func MinLandlockABI() int { return int(C.sandlock_min_landlock_abi()) }
+
+// ProtectionMinABI returns the minimum Landlock ABI version the host kernel
+// must support for the given protection to be available, or 0 for an unknown
+// protection value.
+func ProtectionMinABI(p Protection) int {
+	return int(C.sandlock_protection_min_abi(C.uint32_t(p)))
+}
 
 // SyscallNr resolves a syscall name (e.g. "openat") to its kernel syscall
 // number for the host architecture. It returns an error for names sandlock

--- a/go/sandlock_linux_test.go
+++ b/go/sandlock_linux_test.go
@@ -251,3 +251,63 @@ func TestConfineRejectsSupervisorConfig(t *testing.T) {
 		t.Logf("Confine rejected with: %v", err)
 	}
 }
+
+func TestProtectionMinABI(t *testing.T) {
+	// Also pins the Protection discriminants: a wrong value would resolve to a
+	// different protection (or 0 for unknown) and fail these expectations.
+	cases := []struct {
+		p    sandlock.Protection
+		want int
+	}{
+		{sandlock.ProtectionFSRefer, 2},
+		{sandlock.ProtectionFSTruncate, 3},
+		{sandlock.ProtectionNetTCP, 4},
+		{sandlock.ProtectionFSIoctlDev, 5},
+		{sandlock.ProtectionSignalScope, 6},
+		{sandlock.ProtectionAbstractUnixSocketScope, 6},
+	}
+	for _, c := range cases {
+		if got := sandlock.ProtectionMinABI(c.p); got != c.want {
+			t.Errorf("ProtectionMinABI(%d) = %d, want %d", c.p, got, c.want)
+		}
+	}
+}
+
+// TestRunDegradedBelowV6 exercises the Protection opt-out end to end: a
+// fully-degradable policy must build and confine on any Landlock-capable
+// kernel, degrading the protections the host cannot provide instead of failing
+// the build the way the default strict posture does below ABI v6. It runs on
+// the low-ABI CI image where the strict suite is skipped.
+func TestRunDegradedBelowV6(t *testing.T) {
+	if sandlock.LandlockABIVersion() < 1 {
+		t.Skip("Landlock unavailable on this host")
+	}
+	// Negative control: below the v6 floor the default strict policy must fail
+	// to build, so the degraded run's success is attributable to the opt-out
+	// rather than to the protections being satisfiable on this host anyway.
+	// On a v6+ host strict would succeed, so the contrast only applies below v6.
+	if sandlock.LandlockABIVersion() < 6 {
+		strict := &sandlock.Sandbox{FSReadable: rootfs}
+		if _, err := strict.Run(context.Background(), "echo", "ok"); err == nil {
+			t.Fatalf("default strict policy unexpectedly succeeded on Landlock ABI v%d (< v6); the degraded assertion would prove nothing", sandlock.LandlockABIVersion())
+		}
+	}
+	sb := &sandlock.Sandbox{
+		FSReadable: rootfs,
+		AllowDegraded: []sandlock.Protection{
+			sandlock.ProtectionFSRefer,
+			sandlock.ProtectionFSTruncate,
+			sandlock.ProtectionNetTCP,
+			sandlock.ProtectionFSIoctlDev,
+			sandlock.ProtectionSignalScope,
+			sandlock.ProtectionAbstractUnixSocketScope,
+		},
+	}
+	res, err := sb.Run(context.Background(), "echo", "ok")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !res.Success || strings.TrimSpace(string(res.Stdout)) != "ok" {
+		t.Fatalf("degraded run failed: exit=%d stdout=%q stderr=%q", res.ExitCode, res.Stdout, res.Stderr)
+	}
+}


### PR DESCRIPTION
Brings the Go SDK to parity with the Protection opt-out added in #71 and
already exposed by the Python SDK (#46/#54), closing the gap tracked in #108.

## What

By default every Landlock protection is enforced strictly, so the build
fails on a kernel below the protection's floor (the highest being ABI v6).
This lets a Go sandbox run below v6 by degrading or disabling the v6-only
protections, mirroring the Python `allow_degraded` / `disable` surface:

- `Protection` type with the six C-ABI discriminants (`ProtectionFSRefer` …
  `ProtectionAbstractUnixSocketScope`).
- `Sandbox.AllowDegraded` / `Sandbox.Disable` fields, wired through the
  builder in `buildPolicy`. `Disable` is applied last, so it wins when a
  protection appears in both lists (documented on the fields).
- `ProtectionMinABI` exposes `sandlock_protection_min_abi` for capability
  checks.

No new C ABI — this binds the existing `sandlock_sandbox_builder_allow_degraded`,
`sandlock_sandbox_builder_disable`, and `sandlock_protection_min_abi`.

## Tests

- `TestProtectionMinABI` pins the discriminants against the live FFI: a
  wrong constant value would resolve to a different protection (or unknown)
  and fail the expected `min_abi` (2/3/4/5/6/6).
- `TestRunDegradedBelowV6` confines and runs a fully-degradable policy end
  to end. Below v6 it first asserts the default strict policy fails to build,
  so the degraded run's success is attributable to the opt-out rather than
  to the host satisfying the protections anyway. Self-skips without Landlock.

`go vet -tags sandlock_repo ./...` and `go test -tags sandlock_repo ./...`
pass; `gofmt` clean.