### PR TITLE
fix(net): cap child-controlled sockaddr length before reading it

### DIFF
--- a/crates/sandlock-core/src/network/connect.rs
+++ b/crates/sandlock-core/src/network/connect.rs
@@ -8,7 +8,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::Arc;
 
 use crate::seccomp::ctx::SupervisorCtx;
-use crate::seccomp::notif::{read_child_mem, NotifAction};
+use crate::seccomp::notif::NotifAction;
 use crate::sys::structs::{SeccompNotif, ECONNREFUSED};
 
 use super::materialize::{
@@ -42,9 +42,9 @@ pub(super) async fn connect_on_behalf(
 
     // 1. Copy sockaddr from child memory
     let addr_bytes =
-        match read_child_mem(notif_fd, notif.id, notif.pid, addr_ptr, addr_len as usize) {
+        match super::read_sockaddr(notif_fd, notif.id, notif.pid, addr_ptr, addr_len as usize) {
             Ok(b) => b,
-            Err(_) => return NotifAction::Errno(libc::EIO),
+            Err(e) => return NotifAction::Errno(e),
         };
 
     // 2. Check destination against the per-protocol endpoint allowlist.

--- a/crates/sandlock-core/src/network/mod.rs
+++ b/crates/sandlock-core/src/network/mod.rs
@@ -25,7 +25,7 @@ use std::os::unix::io::RawFd;
 use std::sync::Arc;
 
 use crate::seccomp::ctx::SupervisorCtx;
-use crate::seccomp::notif::NotifAction;
+use crate::seccomp::notif::{read_child_mem, NotifAction};
 use crate::sys::structs::SeccompNotif;
 
 mod connect;
@@ -47,6 +47,37 @@ pub use rules::{
 
 use connect::connect_on_behalf;
 use send::{sendmmsg_on_behalf, sendmsg_on_behalf, sendto_on_behalf};
+
+/// Largest sockaddr length we copy from the child when gating a `connect`/
+/// `sendto`/`sendmsg` destination. The seccomp-notify trap fires at syscall
+/// entry, *before* the kernel's own `addrlen > sizeof(sockaddr_storage)`
+/// (`EINVAL`) check, so a child can pass `addr_len`/`msg_namelen` up to
+/// `u32::MAX`. Reading that verbatim into `vec![0u8; len]` would let the child
+/// force a multi-GiB supervisor allocation (OOM / alloc-abort of the monitor)
+/// for an address that is at most this many bytes. Every legitimate sockaddr
+/// fits in `sizeof(sockaddr_storage)`, so a larger length is rejected before the
+/// read (see [`read_sockaddr`]).
+const MAX_SOCKADDR_LEN: usize = std::mem::size_of::<libc::sockaddr_storage>();
+
+/// Copy a sockaddr from child memory, rejecting an oversized length *before* the
+/// allocation. `len` is child-controlled (`addr_len` / `msg_namelen`, a `u32`),
+/// and the trap fires before the kernel's `addrlen > sizeof(sockaddr_storage)`
+/// check, so an uncapped read would let the child force a multi-GiB supervisor
+/// allocation. A length larger than a `sockaddr_storage` cannot address a valid
+/// sockaddr, so it fails closed with `EINVAL` (matching what the kernel would
+/// return) rather than being silently truncated; a read fault maps to `EIO`.
+pub(super) fn read_sockaddr(
+    notif_fd: RawFd,
+    id: u64,
+    pid: u32,
+    ptr: u64,
+    len: usize,
+) -> Result<Vec<u8>, i32> {
+    if len > MAX_SOCKADDR_LEN {
+        return Err(libc::EINVAL);
+    }
+    read_child_mem(notif_fd, id, pid, ptr, len).map_err(|_| libc::EIO)
+}
 
 // ============================================================
 // query_socket_protocol — derive the rule Protocol from a fd via getsockopt

--- a/crates/sandlock-core/src/network/send.rs
+++ b/crates/sandlock-core/src/network/send.rs
@@ -61,9 +61,9 @@ pub(super) async fn sendto_on_behalf(
 
     // 1. Copy sockaddr from child memory (small: 16-28 bytes)
     let addr_bytes =
-        match read_child_mem(notif_fd, notif.id, notif.pid, addr_ptr, addr_len as usize) {
+        match super::read_sockaddr(notif_fd, notif.id, notif.pid, addr_ptr, addr_len as usize) {
             Ok(b) => b,
-            Err(_) => return NotifAction::Errno(libc::EIO),
+            Err(e) => return NotifAction::Errno(e),
         };
 
     // 2. Check (ip, port) against the per-protocol endpoint allowlist.
@@ -241,9 +241,9 @@ fn prescan_msghdr(
     if hdr.connected() {
         return PrescanResult::ContinueWholeCall;
     }
-    let addr_bytes = match read_child_mem(notif_fd, notif.id, notif.pid, hdr.name_ptr, hdr.namelen as usize) {
+    let addr_bytes = match super::read_sockaddr(notif_fd, notif.id, notif.pid, hdr.name_ptr, hdr.namelen as usize) {
         Ok(b) => b,
-        Err(_) => return PrescanResult::Errno(libc::EIO),
+        Err(e) => return PrescanResult::Errno(e),
     };
     if parse_ip_from_sockaddr(&addr_bytes).is_none() {
         return PrescanResult::ContinueWholeCall;
@@ -291,9 +291,9 @@ async fn send_msghdr_on_behalf(
     let addr_bytes = if connected {
         Vec::new()
     } else {
-        match read_child_mem(notif_fd, notif.id, notif.pid, hdr.name_ptr, hdr.namelen as usize) {
+        match super::read_sockaddr(notif_fd, notif.id, notif.pid, hdr.name_ptr, hdr.namelen as usize) {
             Ok(b) => b,
-            Err(_) => return Err(libc::EIO),
+            Err(e) => return Err(e),
         }
     };
     if !connected {

--- a/crates/sandlock-core/src/network/unix.rs
+++ b/crates/sandlock-core/src/network/unix.rs
@@ -175,7 +175,7 @@ pub(super) fn unix_sendmsg_gate(
         return None; // connected socket: no address to gate
     }
     let addr_bytes =
-        read_child_mem(notif_fd, notif.id, notif.pid, hdr.name_ptr, hdr.namelen as usize).ok()?;
+        super::read_sockaddr(notif_fd, notif.id, notif.pid, hdr.name_ptr, hdr.namelen as usize).ok()?;
     // None unless this is a NAMED AF_UNIX target; IP/abstract fall through.
     let path = named_unix_socket_path(&addr_bytes)?;
 
@@ -271,7 +271,7 @@ pub(super) fn mmsg_entry_named_unix_path(
         return None;
     }
     let addr_bytes =
-        read_child_mem(notif_fd, notif.id, notif.pid, hdr.name_ptr, hdr.namelen as usize).ok()?;
+        super::read_sockaddr(notif_fd, notif.id, notif.pid, hdr.name_ptr, hdr.namelen as usize).ok()?;
     named_unix_socket_path(&addr_bytes)
 }
 

--- a/crates/sandlock-core/tests/integration/test_network.rs
+++ b/crates/sandlock-core/tests/integration/test_network.rs
@@ -62,6 +62,59 @@ async fn test_udp_rule_scopes_destination_by_host() {
     assert_eq!(blocked, "ERR:111", "sendto to disallowed host should ECONNREFUSED");
 }
 
+/// Regression for the uncapped-sockaddr-length DoS: a child can pass
+/// `addr_len = 0xFFFFFFFF` to `sendto`. The seccomp-notify trap fires before the
+/// kernel's `addrlen > sizeof(sockaddr_storage) -> EINVAL` check, so without the
+/// `read_sockaddr` guard the supervisor did `vec![0u8; 0xFFFFFFFF]` (~4 GiB) and
+/// could OOM/abort, taking down every sandbox. The child sends with a bogus 4 GiB
+/// `addr_len` via raw `libc.sendto`. The supervisor must (a) survive — the whole
+/// run completes — and (b) reject the oversized length with `EINVAL` (22),
+/// matching the kernel, rather than reading it (or silently truncating). The
+/// destination gate never runs, so both the allowed and blocked host fail the
+/// same way.
+#[tokio::test]
+async fn test_sendto_huge_addrlen_rejected_with_einval() {
+    let out = temp_file("huge-addrlen");
+
+    let policy = base_policy()
+        .net_allow("udp://127.0.0.1:53")
+        .build()
+        .unwrap();
+
+    let script = format!(concat!(
+        "import ctypes, socket, struct, os\n",
+        "libc = ctypes.CDLL('libc.so.6', use_errno=True)\n",
+        "libc.sendto.restype = ctypes.c_ssize_t\n",
+        "def sai(ip, port):\n",
+        "    return struct.pack('<H', socket.AF_INET) + struct.pack('!H', port) + socket.inet_aton(ip) + b'\\x00'*8\n",
+        "s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n",
+        "buf = ctypes.create_string_buffer(b'x')\n",
+        "def send(ip):\n",
+        "    a = ctypes.create_string_buffer(sai(ip, 53))\n",
+        // addrlen = 0xFFFFFFFF: without the clamp this forces a ~4 GiB supervisor alloc.
+        "    ctypes.set_errno(0)\n",
+        "    r = libc.sendto(s.fileno(), buf, 1, 0, a, 0xFFFFFFFF)\n",
+        "    return 'OK' if r >= 0 else f'ERR:{{ctypes.get_errno()}}'\n",
+        "allowed = send('127.0.0.1')\n",
+        "blocked = send('1.1.1.1')\n",
+        "open('{out}', 'w').write(allowed + '|' + blocked)\n",
+        "s.close()\n",
+    ), out = out.display());
+
+    let result = policy.clone().with_name("test").run_interactive(&["python3", "-c", &script])
+        .await.unwrap();
+    // The run completing at all is the core assertion: an OOM-aborted supervisor
+    // would kill the child instead of letting it finish.
+    assert!(result.success(), "supervisor should survive a 4 GiB addr_len; exit={:?}", result.code());
+
+    let got = std::fs::read_to_string(&out).unwrap_or_default();
+    let _ = std::fs::remove_file(&out);
+    // EINVAL (22) for both: the oversized addr_len is rejected before the
+    // destination gate, so allowed vs blocked is never reached.
+    assert_eq!(got, "ERR:22|ERR:22",
+        "a bogus 4 GiB addr_len must be rejected with EINVAL, matching the kernel");
+}
+
 /// `udp://*:*` is the "any UDP destination" gate — it should not regress
 /// after Phase 2's per-protocol routing. Both sendtos succeed.
 #[tokio::test]


### PR DESCRIPTION
## Problem

A sandboxed child can force a multi-GiB allocation in the supervisor by passing an oversized sockaddr length. `connect`/`sendto`/`sendmsg`/`sendmmsg` take the address length straight from child-controlled args (`addr_len` = `args[5]`, `msg_namelen`, both `u32` up to `0xFFFFFFFF`). The seccomp-notify trap fires at syscall *entry*, before the kernel's own `addrlen > sizeof(sockaddr_storage)` → `EINVAL` check, so the length reached `read_child_mem` uncapped and `read_child_mem_vm` did `vec![0u8; len]`.

Repro (any active net interception):

```c
int fd = socket(AF_INET, SOCK_DGRAM, 0);
sendto(fd, buf, 1, 0, &valid_sockaddr_in, 0xFFFFFFFF);
```

The supervisor allocates ~4 GiB for a sockaddr that is at most 128 bytes. Under default overcommit this is a repeatable transient memory-amplification; under `RLIMIT_AS` / `overcommit_memory=2` / low RAM the Rust allocation fails and `handle_alloc_error` aborts the **whole supervisor** — a fail-open crash of the security monitor that takes down every sandbox it runs.

Every other child-controlled read is already bounded (`MAX_SEND_BUF` 64 MiB, `MAX_CONTROL_BUF` 16 KiB, iovlen 1024, vlen 256). The sockaddr length was the one uncapped read.

## Fix

Clamp each of the six sockaddr reads to `MAX_SOCKADDR_LEN` = `size_of::<sockaddr_storage>()` (128). The gate only needs the family and address bytes, and the actual send is either re-run by the kernel (`Continue`) or performed on-behalf with our own correctly-sized sockaddr, so no legitimate call (a real sockaddr is ≤ 128 bytes) is affected.

## Test

`cargo build` clean; full `sandlock-core` lib suite green (444), including the network tests.

## Notes

- Found while reviewing #128; this targets `main` directly since the bug is live there. If #128 lands first, the same clamp applies to the split `network/` modules (trivial rebase).
- A separate follow-up will address the AF_UNIX datagram gating asymmetry noted in the #128 review — that one needs an `SO_DOMAIN`-gated change across `sendmsg`/`sendmmsg`/`sendto` and is kept out of this focused security fix.