### PR TITLE
checkpoint: execve-stub restore path (primitive proof)

### DIFF
--- a/crates/sandlock-core/build.rs
+++ b/crates/sandlock-core/build.rs
@@ -13,7 +13,7 @@ fn main() {
         &repo_root.join("tests/rootfs-helper"),
         &["musl-gcc", "cc"],
         &["-static", "-O2"],
-        "cannot compile tests/rootfs-helper — chroot tests will fail. \
+        "cannot compile tests/rootfs-helper: chroot tests will fail. \
          Install musl-tools or static libc.",
     );
 
@@ -29,7 +29,7 @@ fn main() {
         &stub_bin,
         &["cc"],
         &["-static", "-nostdlib", "-no-pie", "-O2"],
-        "cannot compile restore-stub — M1 restore-stub tests will be skipped.",
+        "cannot compile restore-stub: its restore tests will be skipped.",
     );
     // Emit the path every run (rustc-env is not cached across build-script runs),
     // whether or not the binary was just (re)built.

--- a/crates/sandlock-core/build.rs
+++ b/crates/sandlock-core/build.rs
@@ -1,38 +1,64 @@
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
     let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let repo_root = manifest_dir.join("../..").canonicalize().unwrap();
-    let src = repo_root.join("tests/rootfs-helper.c");
-    let bin = repo_root.join("tests/rootfs-helper");
 
-    // Only rebuild if the source changed.
+    // rootfs-helper: an ordinary static-libc test fixture (chroot tests). It
+    // lives in tests/ and its binary sits beside it (a git-ignored artifact).
+    build_static(
+        &repo_root.join("tests/rootfs-helper.c"),
+        &repo_root.join("tests/rootfs-helper"),
+        &["musl-gcc", "cc"],
+        &["-static", "-O2"],
+        "cannot compile tests/rootfs-helper — chroot tests will fail. \
+         Install musl-tools or static libc.",
+    );
+
+    // restore-stub: a core component of the restore engine (the supervisor execs
+    // it to reconstruct a checkpoint), freestanding, no libc, no PIE. It lives
+    // next to the checkpoint code that owns it; its binary is built into OUT_DIR
+    // and its path is handed to the crate via the RESTORE_STUB_PATH env var.
+    let stub_src = manifest_dir.join("src/checkpoint/restore-stub.c");
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let stub_bin = out_dir.join("restore-stub");
+    build_static(
+        &stub_src,
+        &stub_bin,
+        &["cc"],
+        &["-static", "-nostdlib", "-no-pie", "-O2"],
+        "cannot compile restore-stub — M1 restore-stub tests will be skipped.",
+    );
+    // Emit the path every run (rustc-env is not cached across build-script runs),
+    // whether or not the binary was just (re)built.
+    println!("cargo:rustc-env=RESTORE_STUB_PATH={}", stub_bin.display());
+}
+
+/// Compile `src` to `bin` with the first working compiler in `ccs`, skipping the
+/// work when `bin` is newer than `src`. Emits `warn` (as a cargo warning) if no
+/// compiler succeeds. A missing source is silently skipped (packaged crate).
+fn build_static(src: &Path, bin: &Path, ccs: &[&str], args: &[&str], warn: &str) {
     println!("cargo:rerun-if-changed={}", src.display());
-
     if !src.exists() {
-        return; // Source not present — skip (e.g. packaged crate).
+        return;
     }
-
-    // Already up-to-date?
     if bin.exists() {
-        if let (Ok(src_meta), Ok(bin_meta)) = (src.metadata(), bin.metadata()) {
-            if let (Ok(src_time), Ok(bin_time)) =
-                (src_meta.modified(), bin_meta.modified())
-            {
-                if bin_time >= src_time {
+        if let (Ok(s), Ok(b)) = (src.metadata(), bin.metadata()) {
+            if let (Ok(st), Ok(bt)) = (s.modified(), b.modified()) {
+                if bt >= st {
                     return;
                 }
             }
         }
     }
-
-    // Try musl-gcc (fully static), then cc -static.
-    for cc in &["musl-gcc", "cc"] {
+    for cc in ccs {
         let ok = Command::new(cc)
-            .args(&["-static", "-O2", "-o"])
-            .arg(&bin)
-            .arg(&src)
+            .args(args)
+            .arg("-o")
+            .arg(bin)
+            .arg(src)
             .status()
             .map(|s| s.success())
             .unwrap_or(false);
@@ -40,9 +66,5 @@ fn main() {
             return;
         }
     }
-
-    println!(
-        "cargo:warning=cannot compile tests/rootfs-helper — \
-         chroot tests will fail. Install musl-tools or static libc."
-    );
+    println!("cargo:warning={warn}");
 }

--- a/crates/sandlock-core/src/checkpoint/mod.rs
+++ b/crates/sandlock-core/src/checkpoint/mod.rs
@@ -7,13 +7,24 @@ mod image;
 mod inject;
 mod regs;
 pub(crate) mod resume;
+// The execve-stub restore path (blob serializer, supervisor pager, fd
+// convention) is validated by its own unit tests and the end-to-end
+// `test_restore_stub` integration test, but is not yet wired into the live
+// restore code (which still uses the injection engine). The `allow(dead_code)`
+// stands until the supervisor cutover replaces that path; drop it then.
+#[allow(dead_code)]
 pub(crate) mod restore_blob;
+#[allow(dead_code)]
 pub(crate) mod pager;
 
 /// Fixed inherited-fd convention for the execve restore-stub.
+#[allow(dead_code)]
 pub(crate) const CTRL_FD: i32 = 3;   // control-blob memfd
+#[allow(dead_code)]
 pub(crate) const READY_FD: i32 = 4;  // eventfd: stub -> supervisor ("uffd ready")
+#[allow(dead_code)]
 pub(crate) const GO_FD: i32 = 5;     // eventfd: supervisor -> stub ("pager attached")
+#[allow(dead_code)]
 pub(crate) const UFFD_SLOT: i32 = 6; // stub dup2's its userfaultfd here
 
 pub(crate) use capture::capture;

--- a/crates/sandlock-core/src/checkpoint/mod.rs
+++ b/crates/sandlock-core/src/checkpoint/mod.rs
@@ -7,6 +7,13 @@ mod image;
 mod inject;
 mod regs;
 pub(crate) mod resume;
+pub(crate) mod restore_blob;
+
+/// Fixed inherited-fd convention for the execve restore-stub.
+pub(crate) const CTRL_FD: i32 = 3;   // control-blob memfd
+pub(crate) const READY_FD: i32 = 4;  // eventfd: stub -> supervisor ("uffd ready")
+pub(crate) const GO_FD: i32 = 5;     // eventfd: supervisor -> stub ("pager attached")
+pub(crate) const UFFD_SLOT: i32 = 6; // stub dup2's its userfaultfd here
 
 pub(crate) use capture::capture;
 

--- a/crates/sandlock-core/src/checkpoint/mod.rs
+++ b/crates/sandlock-core/src/checkpoint/mod.rs
@@ -8,6 +8,7 @@ mod inject;
 mod regs;
 pub(crate) mod resume;
 pub(crate) mod restore_blob;
+pub(crate) mod pager;
 
 /// Fixed inherited-fd convention for the execve restore-stub.
 pub(crate) const CTRL_FD: i32 = 3;   // control-blob memfd

--- a/crates/sandlock-core/src/checkpoint/pager.rs
+++ b/crates/sandlock-core/src/checkpoint/pager.rs
@@ -81,7 +81,7 @@ fn copy_page(uffd: i32, image: &PageImage, addr: u64, page: usize) -> io::Result
         Some(s) => s,
         None => {
             // Nothing to serve: zero-fill so the faulting thread makes progress
-            // rather than hanging. (M1 images always cover their faults.)
+            // rather than hanging. (Restore images always cover their faults.)
             let zero = vec![0u8; page];
             let mut c = UffdioCopy {
                 dst: base, src: zero.as_ptr() as u64, len: page as u64, mode: 0, copy: 0,

--- a/crates/sandlock-core/src/checkpoint/pager.rs
+++ b/crates/sandlock-core/src/checkpoint/pager.rs
@@ -1,0 +1,210 @@
+//! Supervisor-side userfaultfd page server. After the restore-stub registers its
+//! anonymous checkpoint regions with a userfaultfd and hands the fd to the
+//! supervisor (via pidfd_getfd), this loop resolves each missing-page fault by
+//! UFFDIO_COPY-ing the page from the in-memory image. Only the anonymous working
+//! set flows through here; file-backed regions are kernel-paged.
+
+use std::io;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+// userfaultfd ioctl request codes (x86_64 _IOWR(0xAA, n, struct)).
+const UFFDIO_API: libc::c_ulong = 0xc018_aa3f;
+const UFFDIO_REGISTER: libc::c_ulong = 0xc020_aa00;
+const UFFDIO_COPY: libc::c_ulong = 0xc028_aa03;
+const UFFD_API: u64 = 0xAA;
+const UFFDIO_REGISTER_MODE_MISSING: u64 = 1;
+const UFFD_EVENT_PAGEFAULT: u8 = 0x12;
+
+#[repr(C)]
+struct UffdioApi { api: u64, features: u64, ioctls: u64 }
+#[repr(C)]
+struct UffdioRange { start: u64, len: u64 }
+#[repr(C)]
+struct UffdioRegister { range: UffdioRange, mode: u64, ioctls: u64 }
+#[repr(C)]
+struct UffdioCopy { dst: u64, src: u64, len: u64, mode: u64, copy: i64 }
+
+// struct uffd_msg is 32 bytes; we only need the fault address at offset 16.
+#[repr(C)]
+struct UffdMsg { event: u8, _pad: [u8; 7], arg: [u64; 3] }
+
+/// In-memory source for the anon working set: `(start, end, bytes)` runs.
+#[derive(Clone)]
+pub(crate) struct PageImage {
+    pub regions: Vec<(u64, u64, Vec<u8>)>,
+}
+
+impl PageImage {
+    /// The `page`-aligned slice of length `page` covering `addr`, or `None`.
+    pub(crate) fn page_at(&self, addr: u64, page: usize) -> Option<&[u8]> {
+        let base = addr & !((page as u64) - 1);
+        for (start, end, bytes) in &self.regions {
+            if base >= *start && base + page as u64 <= *end {
+                let off = (base - *start) as usize;
+                return Some(&bytes[off..off + page]);
+            }
+        }
+        None
+    }
+}
+
+/// Enable the uffd API and register `[start, start+len)` in missing mode.
+/// Used by the pager unit test to stand in for the stub.
+pub(crate) fn register_api_and_range(uffd: i32, start: u64, len: u64) -> io::Result<()> {
+    let mut api = UffdioApi { api: UFFD_API, features: 0, ioctls: 0 };
+    if unsafe { libc::ioctl(uffd, UFFDIO_API, &mut api) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let mut reg = UffdioRegister {
+        range: UffdioRange { start, len },
+        mode: UFFDIO_REGISTER_MODE_MISSING,
+        ioctls: 0,
+    };
+    if unsafe { libc::ioctl(uffd, UFFDIO_REGISTER, &mut reg) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn copy_page(uffd: i32, image: &PageImage, addr: u64, page: usize) -> io::Result<()> {
+    let base = addr & !((page as u64) - 1);
+    let src = match image.page_at(addr, page) {
+        Some(s) => s,
+        None => {
+            // Nothing to serve: zero-fill so the faulting thread makes progress
+            // rather than hanging. (M1 images always cover their faults.)
+            let zero = vec![0u8; page];
+            let mut c = UffdioCopy {
+                dst: base, src: zero.as_ptr() as u64, len: page as u64, mode: 0, copy: 0,
+            };
+            if unsafe { libc::ioctl(uffd, UFFDIO_COPY, &mut c) } < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            return Ok(());
+        }
+    };
+    let mut c = UffdioCopy {
+        dst: base, src: src.as_ptr() as u64, len: page as u64, mode: 0, copy: 0,
+    };
+    if unsafe { libc::ioctl(uffd, UFFDIO_COPY, &mut c) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn poll_once(uffd: i32, timeout_ms: i32) -> io::Result<bool> {
+    let mut pfd = libc::pollfd { fd: uffd, events: libc::POLLIN, revents: 0 };
+    let n = unsafe { libc::poll(&mut pfd, 1, timeout_ms) };
+    if n < 0 {
+        let e = io::Error::last_os_error();
+        if e.kind() == io::ErrorKind::Interrupted { return Ok(false); }
+        return Err(e);
+    }
+    Ok(n > 0 && (pfd.revents & libc::POLLIN) != 0)
+}
+
+fn handle_ready(uffd: i32, image: &PageImage) -> io::Result<bool> {
+    let page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize;
+    let mut msg = UffdMsg { event: 0, _pad: [0; 7], arg: [0; 3] };
+    let n = unsafe {
+        libc::read(uffd, &mut msg as *mut _ as *mut libc::c_void,
+                   std::mem::size_of::<UffdMsg>())
+    };
+    if n == 0 { return Ok(false); } // EOF: all handles closed
+    if n < 0 {
+        let e = io::Error::last_os_error();
+        if e.kind() == io::ErrorKind::WouldBlock { return Ok(true); }
+        return Err(e);
+    }
+    if msg.event == UFFD_EVENT_PAGEFAULT {
+        let addr = msg.arg[2]; // uffd_msg.arg.pagefault.address is the 3rd u64
+        copy_page(uffd, image, addr, page)?;
+    }
+    Ok(true)
+}
+
+/// Poll/serve until the uffd reports all handles closed (EOF).
+pub(crate) fn serve(uffd: i32, image: &PageImage) -> io::Result<()> {
+    loop {
+        if poll_once(uffd, -1)? {
+            if !handle_ready(uffd, image)? { return Ok(()); }
+        }
+    }
+}
+
+/// Poll/serve until `stop` is set. Uses a short poll timeout so it observes the
+/// flag promptly even with no faults arriving.
+pub(crate) fn serve_until(uffd: i32, image: &PageImage, stop: &AtomicBool) {
+    while !stop.load(Ordering::SeqCst) {
+        match poll_once(uffd, 20) {
+            Ok(true) => { let _ = handle_ready(uffd, image); }
+            Ok(false) => {}
+            Err(_) => break,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn page_at_returns_aligned_slice_within_run() {
+        let img = PageImage {
+            regions: vec![(0x1000, 0x3000, {
+                let mut v = vec![0u8; 0x2000];
+                // second page all 0xAB
+                for b in &mut v[0x1000..0x2000] { *b = 0xAB; }
+                v
+            })],
+        };
+        let page = 0x1000usize;
+        // An address in the second page returns that page, all 0xAB.
+        let s = img.page_at(0x2500, page).expect("covered");
+        assert_eq!(s.len(), page);
+        assert!(s.iter().all(|&b| b == 0xAB));
+        // Out of range.
+        assert!(img.page_at(0x9000, page).is_none());
+    }
+
+    #[test]
+    fn serve_copies_faulted_page_into_a_registered_region() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let page = 4096usize;
+        // Map an anon region we will register with uffd in THIS process.
+        let len = page;
+        let addr = unsafe {
+            libc::mmap(std::ptr::null_mut(), len,
+                       libc::PROT_READ | libc::PROT_WRITE,
+                       libc::MAP_PRIVATE | libc::MAP_ANONYMOUS, -1, 0)
+        };
+        assert_ne!(addr, libc::MAP_FAILED);
+        let start = addr as u64;
+
+        let uffd = unsafe { libc::syscall(libc::SYS_userfaultfd, libc::O_CLOEXEC) } as i32;
+        assert!(uffd >= 0, "userfaultfd");
+        register_api_and_range(uffd, start, len as u64).expect("register");
+
+        let img = PageImage { regions: vec![(start, start + len as u64, vec![0x5Au8; len])] };
+        let stop = Arc::new(AtomicBool::new(false));
+
+        // Pager on another thread.
+        let stop2 = stop.clone();
+        let uffd_copy = uffd;
+        let img_copy = img.clone();
+        let h = std::thread::spawn(move || serve_until(uffd_copy, &img_copy, &stop2));
+
+        // Touch the page -> fault -> pager fills with 0x5A.
+        let byte = unsafe { std::ptr::read_volatile(addr as *const u8) };
+        assert_eq!(byte, 0x5A, "faulted page must be filled by the pager");
+
+        stop.store(true, Ordering::SeqCst);
+        // Nudge the poll loop so it observes `stop` (write a dummy fault by
+        // touching another registered page is unnecessary; serve_until uses a
+        // short poll timeout).
+        let _ = h.join();
+        unsafe { libc::munmap(addr, len); }
+    }
+}

--- a/crates/sandlock-core/src/checkpoint/pager.rs
+++ b/crates/sandlock-core/src/checkpoint/pager.rs
@@ -3,6 +3,12 @@
 //! supervisor (via pidfd_getfd), this loop resolves each missing-page fault by
 //! UFFDIO_COPY-ing the page from the in-memory image. Only the anonymous working
 //! set flows through here; file-backed regions are kernel-paged.
+//!
+//! Note: the stub creates the userfaultfd with a plain -> UFFD_USER_MODE_ONLY
+//! fallback (hosts with vm.unprivileged_userfaultfd=0 reject the plain form).
+//! USER_MODE_ONLY serves only user-mode faults; full-fidelity paging of real
+//! programs (kernel-mode faults from syscalls touching unfilled pages) requires
+//! vm.unprivileged_userfaultfd=1 on the node.
 
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -183,8 +189,21 @@ mod tests {
         assert_ne!(addr, libc::MAP_FAILED);
         let start = addr as u64;
 
-        let uffd = unsafe { libc::syscall(libc::SYS_userfaultfd, libc::O_CLOEXEC) } as i32;
-        assert!(uffd >= 0, "userfaultfd");
+        // vm.unprivileged_userfaultfd=0 rejects plain userfaultfd(); UFFD_USER_MODE_ONLY
+        // (0x1) is permitted unprivileged and handles user-mode faults, which is all
+        // this test triggers.
+        const UFFD_USER_MODE_ONLY: libc::c_int = 1;
+        let uffd = {
+            let plain = unsafe { libc::syscall(libc::SYS_userfaultfd, libc::O_CLOEXEC) } as i32;
+            if plain >= 0 {
+                plain
+            } else {
+                (unsafe {
+                    libc::syscall(libc::SYS_userfaultfd, libc::O_CLOEXEC | UFFD_USER_MODE_ONLY)
+                }) as i32
+            }
+        };
+        assert!(uffd >= 0, "userfaultfd (tried plain then USER_MODE_ONLY)");
         register_api_and_range(uffd, start, len as u64).expect("register");
 
         let img = PageImage { regions: vec![(start, start + len as u64, vec![0x5Au8; len])] };

--- a/crates/sandlock-core/src/checkpoint/pager.rs
+++ b/crates/sandlock-core/src/checkpoint/pager.rs
@@ -4,10 +4,13 @@
 //! UFFDIO_COPY-ing the page from the in-memory image. Only the anonymous working
 //! set flows through here; file-backed regions are kernel-paged.
 //!
-//! Note: the stub creates the userfaultfd with a plain -> UFFD_USER_MODE_ONLY
-//! fallback (hosts with vm.unprivileged_userfaultfd=0 reject the plain form).
-//! USER_MODE_ONLY serves only user-mode faults; full-fidelity paging of real
-//! programs (kernel-mode faults from syscalls touching unfilled pages) requires
+//! The userfaultfd MUST be created with O_NONBLOCK: poll()/epoll on a blocking
+//! userfaultfd always reports POLLERR (never POLLIN), so a polling pager would
+//! spin without ever reading a fault. The stub creates it O_CLOEXEC|O_NONBLOCK
+//! with a plain -> UFFD_USER_MODE_ONLY fallback (hosts with
+//! vm.unprivileged_userfaultfd=0 reject the plain form). USER_MODE_ONLY serves
+//! only user-mode faults; full-fidelity paging of real programs (kernel-mode
+//! faults from syscalls touching unfilled pages) requires
 //! vm.unprivileged_userfaultfd=1 on the node.
 
 use std::io;
@@ -123,7 +126,10 @@ fn handle_ready(uffd: i32, image: &PageImage) -> io::Result<bool> {
         return Err(e);
     }
     if msg.event == UFFD_EVENT_PAGEFAULT {
-        let addr = msg.arg[2]; // uffd_msg.arg.pagefault.address is the 3rd u64
+        // struct uffd_msg: 8-byte header (event+reserved), then the pagefault
+        // arm { u64 flags; u64 address; ... }. With the 8-byte header the fault
+        // address is the SECOND u64 of `arg` (byte offset 16), not the third.
+        let addr = msg.arg[1];
         copy_page(uffd, image, addr, page)?;
     }
     Ok(true)
@@ -189,17 +195,20 @@ mod tests {
         assert_ne!(addr, libc::MAP_FAILED);
         let start = addr as u64;
 
+        // O_NONBLOCK is mandatory: poll()/epoll on a *blocking* userfaultfd always
+        // returns POLLERR (never POLLIN), so the pager would spin forever. And
         // vm.unprivileged_userfaultfd=0 rejects plain userfaultfd(); UFFD_USER_MODE_ONLY
         // (0x1) is permitted unprivileged and handles user-mode faults, which is all
         // this test triggers.
         const UFFD_USER_MODE_ONLY: libc::c_int = 1;
+        let flags = libc::O_CLOEXEC | libc::O_NONBLOCK;
         let uffd = {
-            let plain = unsafe { libc::syscall(libc::SYS_userfaultfd, libc::O_CLOEXEC) } as i32;
+            let plain = unsafe { libc::syscall(libc::SYS_userfaultfd, flags) } as i32;
             if plain >= 0 {
                 plain
             } else {
                 (unsafe {
-                    libc::syscall(libc::SYS_userfaultfd, libc::O_CLOEXEC | UFFD_USER_MODE_ONLY)
+                    libc::syscall(libc::SYS_userfaultfd, flags | UFFD_USER_MODE_ONLY)
                 }) as i32
             }
         };

--- a/crates/sandlock-core/src/checkpoint/restore-stub.c
+++ b/crates/sandlock-core/src/checkpoint/restore-stub.c
@@ -1,0 +1,208 @@
+/*
+ * restore-stub — freestanding self-restore stub (x86_64, Milestone 1).
+ *
+ * This is a core component of the checkpoint restore engine, not a test
+ * fixture: the supervisor execs this stub into a fresh, fully-sandboxed process
+ * to reconstruct a checkpoint. It is compiled by build.rs into OUT_DIR and its
+ * path is exposed to the crate via the RESTORE_STUB_PATH env var.
+ *
+ * Built with: cc -static -nostdlib -no-pie -O2 -o restore-stub restore-stub.c
+ *
+ * Reads a control blob (see checkpoint/restore_blob.rs) from CTRL_FD, maps the
+ * checkpoint's anonymous regions, registers them with userfaultfd (missing
+ * mode), hands the uffd to the supervisor at UFFD_SLOT, waits for the supervisor
+ * to attach its pager (GO_FD), then rt_sigreturns into the checkpoint register
+ * context. M1 handles anon regions only: no vDSO relocation, no file-backed
+ * regions, no fd table.
+ *
+ * Exit codes (all _exit): 2 blob read, 3 bad magic/version, 4 mmap region,
+ * 5 userfaultfd, 6 UFFDIO_API, 7 UFFDIO_REGISTER, 8 dup2 uffd, 9 ready write,
+ * 10 go read. rt_sigreturn does not return; if it does, exit 11.
+ */
+#define CTRL_FD 3
+#define READY_FD 4
+#define GO_FD 5
+#define UFFD_SLOT 6
+
+#define SYS_read 0
+#define SYS_write 1
+#define SYS_mmap 9
+#define SYS_ioctl 16
+#define SYS_dup2 33
+#define SYS_exit 60
+#define SYS_rt_sigreturn 15
+#define SYS_userfaultfd 323
+#define SYS_lseek 8
+#define SYS_fstat 5
+
+#define PROT_READ 0x1
+#define PROT_WRITE 0x2
+#define PROT_EXEC 0x4
+#define MAP_PRIVATE 0x2
+#define MAP_ANONYMOUS 0x20
+#define MAP_FIXED 0x10
+#define O_CLOEXEC 02000000
+#define O_NONBLOCK 04000
+#define UFFD_USER_MODE_ONLY 1
+#define SEEK_END 2
+#define SEEK_SET 0
+
+typedef unsigned long u64;
+typedef unsigned int u32;
+typedef long i64;
+
+static i64 sc6(long n, u64 a, u64 b, u64 c, u64 d, u64 e, u64 f) {
+    i64 r;
+    register u64 r10 __asm__("r10") = d;
+    register u64 r8  __asm__("r8")  = e;
+    register u64 r9  __asm__("r9")  = f;
+    __asm__ volatile("syscall" : "=a"(r)
+        : "a"(n), "D"(a), "S"(b), "d"(c), "r"(r10), "r"(r8), "r"(r9)
+        : "rcx", "r11", "memory");
+    return r;
+}
+#define SC0(n) sc6(n,0,0,0,0,0,0)
+#define SC1(n,a) sc6(n,(u64)(a),0,0,0,0,0)
+#define SC2(n,a,b) sc6(n,(u64)(a),(u64)(b),0,0,0,0)
+#define SC3(n,a,b,c) sc6(n,(u64)(a),(u64)(b),(u64)(c),0,0,0)
+#define SC6(n,a,b,c,d,e,f) sc6(n,(u64)(a),(u64)(b),(u64)(c),(u64)(d),(u64)(e),(u64)(f))
+
+static void die(int code) { SC1(SYS_exit, code); for(;;){} }
+
+/* userfaultfd ioctls (x86_64). */
+#define UFFDIO_API      0xc018aa3fUL
+#define UFFDIO_REGISTER 0xc020aa00UL
+#define UFFD_API        0xAAUL
+#define UFFDIO_REGISTER_MODE_MISSING 1UL
+struct uffdio_api { u64 api, features, ioctls; };
+struct uffdio_register { u64 start, len, mode, ioctls; };
+
+/* Blob layout mirror (little-endian; we run on x86_64 LE so struct reads work). */
+struct blob_header {
+    u32 magic, version, n_regions, n_fds;
+    u64 regs_off; u32 regs_len, _pad; u64 anon_data_off;
+};
+struct blob_region {
+    u64 start, end; u32 prot; unsigned char src, _p0[3]; u64 file_off, data_off;
+};
+#define BLOB_MAGIC 0x534c5242u
+#define BLOB_VERSION 1u
+#define NO_DATA 0xFFFFFFFFFFFFFFFFUL
+
+/* ---- x86_64 rt_sigreturn frame -------------------------------------------
+ * rt_sigreturn reads the ucontext at rsp (kernel does frame = rsp - 8; uc is at
+ * frame+8 = rsp). We build a ucontext, set rsp to &uc, and syscall rt_sigreturn.
+ * mcontext gregs order (x86_64): see REG_* below.
+ */
+enum { R8=0,R9,R10,R11,R12,R13,R14,R15,RDI,RSI,RBP,RBX,RDX,RAX,RCX,RSP,RIP,
+       EFL,CSGSFS,ERR,TRAPNO,OLDMASK,CR2 }; /* 23 gregs */
+struct sigctx { u64 gregs[23]; u64 fpstate; u64 reserved[8]; };
+struct uctx {
+    u64 uc_flags;      /* 0 */
+    u64 uc_link;       /* 8 */
+    u64 ss_sp; u32 ss_flags; u32 _pad; u64 ss_size; /* uc_stack @16, 24 bytes */
+    struct sigctx mc;  /* uc_mcontext @40 */
+    u64 uc_sigmask[16];/* 128-byte sigset */
+};
+
+/* Captured user_regs_struct order (27 u64), matching capture::ptrace_getregs. */
+enum { UR_R15=0,UR_R14,UR_R13,UR_R12,UR_RBP,UR_RBX,UR_R11,UR_R10,UR_R9,UR_R8,
+       UR_RAX,UR_RCX,UR_RDX,UR_RSI,UR_RDI,UR_ORIG_RAX,UR_RIP,UR_CS,UR_EFLAGS,
+       UR_RSP,UR_SS,UR_FS_BASE,UR_GS_BASE,UR_DS,UR_ES,UR_FS,UR_GS };
+
+/* `used`: the only reference is the module-level asm `call _start_c`, which the
+ * optimizer cannot see, so without this -O2 would eliminate the function. */
+__attribute__((used, noinline))
+static void _start_c(void) {
+    /* 1. Size the blob via lseek, mmap it. */
+    i64 sz = SC3(SYS_lseek, CTRL_FD, 0, SEEK_END);
+    if (sz <= 0) die(2);
+    SC3(SYS_lseek, CTRL_FD, 0, SEEK_SET);
+    void *blob = (void*)SC6(SYS_mmap, 0, sz, PROT_READ, MAP_PRIVATE, CTRL_FD, 0);
+    if ((i64)blob < 0) die(2);
+    struct blob_header *h = (struct blob_header*)blob;
+    if (h->magic != BLOB_MAGIC || h->version != BLOB_VERSION) die(3);
+
+    struct blob_region *regs_tbl =
+        (struct blob_region*)((char*)blob + sizeof(struct blob_header));
+    unsigned char *anon = (unsigned char*)blob + h->anon_data_off;
+    u64 *gp = (u64*)((char*)blob + h->regs_off);
+
+    /* 2. Map each anon region MAP_FIXED. (M1: all regions are anon.) */
+    for (u32 i = 0; i < h->n_regions; i++) {
+        struct blob_region *r = &regs_tbl[i];
+        u64 len = r->end - r->start;
+        i64 p = SC6(SYS_mmap, r->start, len, PROT_READ|PROT_WRITE,
+                    MAP_PRIVATE|MAP_ANONYMOUS|MAP_FIXED, -1, 0);
+        if ((u64)p != r->start) die(4);
+    }
+
+    /* 3. userfaultfd + API + register anon regions (missing mode).
+     * O_NONBLOCK is mandatory: the supervisor pager polls this fd, and poll()
+     * on a *blocking* userfaultfd always reports POLLERR (never POLLIN), so the
+     * pager would spin and never serve a page. Hosts with
+     * vm.unprivileged_userfaultfd=0 reject the plain form; retry with
+     * UFFD_USER_MODE_ONLY (user-mode faults only, sufficient for the M1 proof). */
+    i64 uffd = SC1(SYS_userfaultfd, O_CLOEXEC | O_NONBLOCK);
+    if (uffd < 0) uffd = SC1(SYS_userfaultfd, O_CLOEXEC | O_NONBLOCK | UFFD_USER_MODE_ONLY);
+    if (uffd < 0) die(5);
+    struct uffdio_api api = { UFFD_API, 0, 0 };
+    if (SC3(SYS_ioctl, uffd, UFFDIO_API, &api) < 0) die(6);
+    for (u32 i = 0; i < h->n_regions; i++) {
+        struct blob_region *r = &regs_tbl[i];
+        if (r->data_off == NO_DATA) continue; /* M2: file-backed, kernel-paged */
+        struct uffdio_register reg = {
+            r->start, r->end - r->start, UFFDIO_REGISTER_MODE_MISSING, 0 };
+        if (SC3(SYS_ioctl, uffd, UFFDIO_REGISTER, &reg) < 0) die(7);
+    }
+    (void)anon; /* pages are served by the supervisor pager, not memcpy'd here */
+
+    /* 4. Expose uffd at the agreed slot; signal READY; wait for GO. */
+    if (SC2(SYS_dup2, uffd, UFFD_SLOT) != UFFD_SLOT) die(8);
+    u64 one = 1;
+    if (SC3(SYS_write, READY_FD, &one, 8) != 8) die(9);
+    u64 got = 0;
+    if (SC3(SYS_read, GO_FD, &got, 8) != 8) die(10);
+
+    /* 5. Build the rt_sigframe on our current stack and rt_sigreturn.
+     * The frame must be readable when the kernel consumes it; our stub stack is
+     * a plain (non-uffd) mapping, so it always is. */
+    struct uctx uc;
+    for (unsigned k = 0; k < sizeof(uc); k++) ((char*)&uc)[k] = 0;
+    struct sigctx *m = &uc.mc;
+    m->gregs[R8]  = gp[UR_R8];  m->gregs[R9]  = gp[UR_R9];
+    m->gregs[R10] = gp[UR_R10]; m->gregs[R11] = gp[UR_R11];
+    m->gregs[R12] = gp[UR_R12]; m->gregs[R13] = gp[UR_R13];
+    m->gregs[R14] = gp[UR_R14]; m->gregs[R15] = gp[UR_R15];
+    m->gregs[RDI] = gp[UR_RDI]; m->gregs[RSI] = gp[UR_RSI];
+    m->gregs[RBP] = gp[UR_RBP]; m->gregs[RBX] = gp[UR_RBX];
+    m->gregs[RDX] = gp[UR_RDX]; m->gregs[RAX] = gp[UR_RAX];
+    m->gregs[RCX] = gp[UR_RCX]; m->gregs[RSP] = gp[UR_RSP];
+    m->gregs[RIP] = gp[UR_RIP]; m->gregs[EFL] = gp[UR_EFLAGS];
+    /* CSGSFS packs cs(0:15), gs(16:31), fs(32:47), ss(48:63). */
+    m->gregs[CSGSFS] = (gp[UR_CS] & 0xffff)
+                     | ((gp[UR_GS] & 0xffff) << 16)
+                     | ((gp[UR_FS] & 0xffff) << 32)
+                     | ((gp[UR_SS] & 0xffff) << 48);
+    m->fpstate = 0; /* M1: no FP restore */
+
+    /* Set rsp = &uc, then syscall rt_sigreturn. */
+    register u64 rax __asm__("rax") = SYS_rt_sigreturn;
+    __asm__ volatile(
+        "mov %0, %%rsp\n\t"
+        "syscall\n\t"
+        :
+        : "r"(&uc), "r"(rax)
+        : "memory");
+    die(11); /* rt_sigreturn must not return */
+}
+
+/* No libc: provide the ELF entry. Align the stack and call into C. */
+__asm__(
+    ".global _start\n"
+    "_start:\n"
+    "   xor %rbp, %rbp\n"
+    "   and $-16, %rsp\n"
+    "   call _start_c\n"
+    "   hlt\n"
+);

--- a/crates/sandlock-core/src/checkpoint/restore-stub.c
+++ b/crates/sandlock-core/src/checkpoint/restore-stub.c
@@ -1,5 +1,5 @@
 /*
- * restore-stub — freestanding self-restore stub (x86_64).
+ * restore-stub: freestanding self-restore stub (x86_64).
  *
  * This is a core component of the checkpoint restore engine, not a test
  * fixture: the supervisor execs this stub into a fresh, fully-sandboxed process

--- a/crates/sandlock-core/src/checkpoint/restore-stub.c
+++ b/crates/sandlock-core/src/checkpoint/restore-stub.c
@@ -1,5 +1,5 @@
 /*
- * restore-stub — freestanding self-restore stub (x86_64, Milestone 1).
+ * restore-stub — freestanding self-restore stub (x86_64).
  *
  * This is a core component of the checkpoint restore engine, not a test
  * fixture: the supervisor execs this stub into a fresh, fully-sandboxed process
@@ -12,8 +12,8 @@
  * checkpoint's anonymous regions, registers them with userfaultfd (missing
  * mode), hands the uffd to the supervisor at UFFD_SLOT, waits for the supervisor
  * to attach its pager (GO_FD), then rt_sigreturns into the checkpoint register
- * context. M1 handles anon regions only: no vDSO relocation, no file-backed
- * regions, no fd table.
+ * context. This first cut handles anonymous regions only: no vDSO relocation,
+ * no file-backed regions, no fd table (those come later).
  *
  * Exit codes (all _exit): 2 blob read, 3 bad magic/version, 4 mmap region,
  * 5 userfaultfd, 6 UFFDIO_API, 7 UFFDIO_REGISTER, 8 dup2 uffd, 9 ready write,
@@ -128,11 +128,15 @@ static void _start_c(void) {
     unsigned char *anon = (unsigned char*)blob + h->anon_data_off;
     u64 *gp = (u64*)((char*)blob + h->regs_off);
 
-    /* 2. Map each anon region MAP_FIXED. (M1: all regions are anon.) */
+    /* 2. Map each anon region MAP_FIXED with its captured prot. (For now all
+     * regions are anon.) The prot must match the checkpoint: an executable region mapped
+     * without PROT_EXEC would fault as a protection violation (SIGSEGV) on the
+     * instruction fetch rather than a uffd missing-page fault the pager can
+     * serve. r->prot already holds standard PROT_* bits (see restore_blob.rs). */
     for (u32 i = 0; i < h->n_regions; i++) {
         struct blob_region *r = &regs_tbl[i];
         u64 len = r->end - r->start;
-        i64 p = SC6(SYS_mmap, r->start, len, PROT_READ|PROT_WRITE,
+        i64 p = SC6(SYS_mmap, r->start, len, r->prot,
                     MAP_PRIVATE|MAP_ANONYMOUS|MAP_FIXED, -1, 0);
         if ((u64)p != r->start) die(4);
     }
@@ -142,7 +146,7 @@ static void _start_c(void) {
      * on a *blocking* userfaultfd always reports POLLERR (never POLLIN), so the
      * pager would spin and never serve a page. Hosts with
      * vm.unprivileged_userfaultfd=0 reject the plain form; retry with
-     * UFFD_USER_MODE_ONLY (user-mode faults only, sufficient for the M1 proof). */
+     * UFFD_USER_MODE_ONLY (user-mode faults only, sufficient here). */
     i64 uffd = SC1(SYS_userfaultfd, O_CLOEXEC | O_NONBLOCK);
     if (uffd < 0) uffd = SC1(SYS_userfaultfd, O_CLOEXEC | O_NONBLOCK | UFFD_USER_MODE_ONLY);
     if (uffd < 0) die(5);
@@ -150,7 +154,7 @@ static void _start_c(void) {
     if (SC3(SYS_ioctl, uffd, UFFDIO_API, &api) < 0) die(6);
     for (u32 i = 0; i < h->n_regions; i++) {
         struct blob_region *r = &regs_tbl[i];
-        if (r->data_off == NO_DATA) continue; /* M2: file-backed, kernel-paged */
+        if (r->data_off == NO_DATA) continue; /* file-backed: kernel-paged (handled later) */
         struct uffdio_register reg = {
             r->start, r->end - r->start, UFFDIO_REGISTER_MODE_MISSING, 0 };
         if (SC3(SYS_ioctl, uffd, UFFDIO_REGISTER, &reg) < 0) die(7);
@@ -184,7 +188,7 @@ static void _start_c(void) {
                      | ((gp[UR_GS] & 0xffff) << 16)
                      | ((gp[UR_FS] & 0xffff) << 32)
                      | ((gp[UR_SS] & 0xffff) << 48);
-    m->fpstate = 0; /* M1: no FP restore */
+    m->fpstate = 0; /* no FP restore yet */
 
     /* Set rsp = &uc, then syscall rt_sigreturn. */
     register u64 rax __asm__("rax") = SYS_rt_sigreturn;

--- a/crates/sandlock-core/src/checkpoint/restore_blob.rs
+++ b/crates/sandlock-core/src/checkpoint/restore_blob.rs
@@ -1,9 +1,9 @@
 //! Compact binary control blob handed to the freestanding restore-stub through
 //! an inherited memfd. Carries region/fd metadata, the checkpoint's GP register
 //! file, and the anonymous page bytes; file-backed region bytes are NOT included
-//! (the stub maps those from their files in Milestone 2). Little-endian,
-//! versioned, append-only. The C stub in `tests/restore-stub.c` mirrors this
-//! layout byte-for-byte.
+//! (the stub maps those from their files in a later pass). Little-endian,
+//! versioned, append-only. The C stub in `checkpoint/restore-stub.c` mirrors
+//! this layout byte-for-byte.
 
 use crate::checkpoint::Checkpoint;
 
@@ -18,7 +18,7 @@ const NO_DATA: u64 = u64::MAX;
 pub(crate) fn serialize(cp: &Checkpoint) -> Vec<u8> {
     let ps = &cp.process_state;
 
-    // Only anonymous, captured regions carry bytes in M1. A region is "anon with
+    // Only anonymous, captured regions carry bytes. A region is "anon with
     // data" when a MemorySegment exists at its start.
     let n_regions = ps.memory_maps.len() as u32;
 
@@ -34,7 +34,7 @@ pub(crate) fn serialize(cp: &Checkpoint) -> Vec<u8> {
     out.extend_from_slice(&BLOB_MAGIC.to_le_bytes());
     out.extend_from_slice(&BLOB_VERSION.to_le_bytes());
     out.extend_from_slice(&n_regions.to_le_bytes());
-    out.extend_from_slice(&0u32.to_le_bytes()); // n_fds (M1: none)
+    out.extend_from_slice(&0u32.to_le_bytes()); // n_fds (none yet)
     out.extend_from_slice(&(regs_off as u64).to_le_bytes());
     out.extend_from_slice(&regs_len.to_le_bytes());
     out.extend_from_slice(&0u32.to_le_bytes()); // _pad
@@ -51,7 +51,7 @@ pub(crate) fn serialize(cp: &Checkpoint) -> Vec<u8> {
                 anon_blob.extend_from_slice(&s.data);
                 (0u8, off) // anon with data
             }
-            None => (1u8, NO_DATA), // file-backed / no captured data (M2 fills)
+            None => (1u8, NO_DATA), // file-backed / no captured data (filled from files later)
         };
         let prot = prot_bits(&m.perms);
         out.extend_from_slice(&m.start.to_le_bytes());

--- a/crates/sandlock-core/src/checkpoint/restore_blob.rs
+++ b/crates/sandlock-core/src/checkpoint/restore_blob.rs
@@ -1,0 +1,149 @@
+//! Compact binary control blob handed to the freestanding restore-stub through
+//! an inherited memfd. Carries region/fd metadata, the checkpoint's GP register
+//! file, and the anonymous page bytes; file-backed region bytes are NOT included
+//! (the stub maps those from their files in Milestone 2). Little-endian,
+//! versioned, append-only. The C stub in `tests/restore-stub.c` mirrors this
+//! layout byte-for-byte.
+
+use crate::checkpoint::Checkpoint;
+
+pub(crate) const BLOB_MAGIC: u32 = 0x534c_5242; // "SLRB"
+pub(crate) const BLOB_VERSION: u32 = 1;
+
+const HEADER_LEN: usize = 40;
+const REGION_ENTRY_LEN: usize = 40;
+const NO_DATA: u64 = u64::MAX;
+
+/// Serialize `cp` into the control-blob wire format (see module docs).
+pub(crate) fn serialize(cp: &Checkpoint) -> Vec<u8> {
+    let ps = &cp.process_state;
+
+    // Only anonymous, captured regions carry bytes in M1. A region is "anon with
+    // data" when a MemorySegment exists at its start.
+    let regions: Vec<&crate::checkpoint::MemoryMap> = ps.memory_maps.iter().collect();
+    let n_regions = regions.len() as u32;
+
+    let regs_len = (ps.regs.len() * 8) as u32;
+
+    // Layout: header | region table | regs | anon data
+    let region_table_len = regions.len() * REGION_ENTRY_LEN;
+    let regs_off = HEADER_LEN + region_table_len;
+    let anon_data_off = regs_off + regs_len as usize;
+
+    let mut out = Vec::with_capacity(anon_data_off);
+    // Header (fill region-table + regs + anon after).
+    out.extend_from_slice(&BLOB_MAGIC.to_le_bytes());
+    out.extend_from_slice(&BLOB_VERSION.to_le_bytes());
+    out.extend_from_slice(&n_regions.to_le_bytes());
+    out.extend_from_slice(&0u32.to_le_bytes()); // n_fds (M1: none)
+    out.extend_from_slice(&(regs_off as u64).to_le_bytes());
+    out.extend_from_slice(&regs_len.to_le_bytes());
+    out.extend_from_slice(&0u32.to_le_bytes()); // _pad
+    out.extend_from_slice(&(anon_data_off as u64).to_le_bytes());
+    debug_assert_eq!(out.len(), HEADER_LEN);
+
+    // Region table. Compute each region's data_off into the anon blob as we go.
+    let mut anon_blob: Vec<u8> = Vec::new();
+    for m in &regions {
+        let seg = ps.memory_data.iter().find(|s| s.start == m.start);
+        let (src, data_off) = match seg {
+            Some(s) => {
+                let off = anon_blob.len() as u64;
+                anon_blob.extend_from_slice(&s.data);
+                (0u8, off) // anon with data
+            }
+            None => (1u8, NO_DATA), // file-backed / no captured data (M2 fills)
+        };
+        let prot = prot_bits(&m.perms);
+        out.extend_from_slice(&m.start.to_le_bytes());
+        out.extend_from_slice(&m.end.to_le_bytes());
+        out.extend_from_slice(&prot.to_le_bytes());
+        out.push(src);
+        out.extend_from_slice(&[0u8; 3]); // _pad0
+        out.extend_from_slice(&m.offset.to_le_bytes()); // file_off
+        out.extend_from_slice(&data_off.to_le_bytes());
+    }
+    debug_assert_eq!(out.len(), regs_off);
+
+    // GP register area.
+    for r in &ps.regs {
+        out.extend_from_slice(&r.to_le_bytes());
+    }
+    debug_assert_eq!(out.len(), anon_data_off);
+
+    // Anon data.
+    out.extend_from_slice(&anon_blob);
+    out
+}
+
+fn prot_bits(perms: &str) -> u32 {
+    let b = perms.as_bytes();
+    let mut p = 0u32;
+    if b.first() == Some(&b'r') { p |= libc::PROT_READ as u32; }
+    if b.get(1) == Some(&b'w') { p |= libc::PROT_WRITE as u32; }
+    if b.get(2) == Some(&b'x') { p |= libc::PROT_EXEC as u32; }
+    p
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{serialize, BLOB_MAGIC, BLOB_VERSION};
+    use crate::checkpoint::{Checkpoint, MemoryMap, MemorySegment, ProcessState};
+    use crate::sandbox::Sandbox;
+
+    fn tiny_checkpoint() -> Checkpoint {
+        Checkpoint {
+            name: String::new(),
+            policy: Sandbox::builder().build().unwrap(),
+            process_state: ProcessState {
+                pid: 1234,
+                cwd: "/".into(),
+                exe: "/x".into(),
+                regs: (0..27u64).collect(),          // recognizable
+                fpregs: Vec::new(),
+                memory_maps: vec![MemoryMap {
+                    start: 0x4500_0000_0000,
+                    end: 0x4500_0000_1000,
+                    perms: "rwxp".into(),
+                    offset: 0,
+                    path: None,
+                }],
+                memory_data: vec![MemorySegment {
+                    start: 0x4500_0000_0000,
+                    data: vec![0xC7u8; 0x1000],
+                }],
+            },
+            fd_table: Vec::new(),
+            cow_snapshot: None,
+            app_state: None,
+        }
+    }
+
+    #[test]
+    fn blob_header_and_region_roundtrip() {
+        let cp = tiny_checkpoint();
+        let blob = serialize(&cp);
+
+        // Header magic/version.
+        assert_eq!(u32::from_le_bytes(blob[0..4].try_into().unwrap()), BLOB_MAGIC);
+        assert_eq!(u32::from_le_bytes(blob[4..8].try_into().unwrap()), BLOB_VERSION);
+        // One region, zero fds.
+        assert_eq!(u32::from_le_bytes(blob[8..12].try_into().unwrap()), 1);
+        assert_eq!(u32::from_le_bytes(blob[12..16].try_into().unwrap()), 0);
+
+        // GP register area holds the 27 recognizable values.
+        let regs_off = u64::from_le_bytes(blob[16..24].try_into().unwrap()) as usize;
+        let regs_len = u32::from_le_bytes(blob[24..28].try_into().unwrap()) as usize;
+        assert_eq!(regs_len, 27 * 8);
+        for i in 0..27u64 {
+            let v = u64::from_le_bytes(
+                blob[regs_off + i as usize * 8..regs_off + i as usize * 8 + 8]
+                    .try_into().unwrap());
+            assert_eq!(v, i);
+        }
+
+        // Anon data for the single region is all 0xC7, length 0x1000.
+        let anon_off = u64::from_le_bytes(blob[32..40].try_into().unwrap()) as usize;
+        assert_eq!(&blob[anon_off..anon_off + 0x1000], &[0xC7u8; 0x1000][..]);
+    }
+}

--- a/crates/sandlock-core/src/checkpoint/restore_blob.rs
+++ b/crates/sandlock-core/src/checkpoint/restore_blob.rs
@@ -20,13 +20,12 @@ pub(crate) fn serialize(cp: &Checkpoint) -> Vec<u8> {
 
     // Only anonymous, captured regions carry bytes in M1. A region is "anon with
     // data" when a MemorySegment exists at its start.
-    let regions: Vec<&crate::checkpoint::MemoryMap> = ps.memory_maps.iter().collect();
-    let n_regions = regions.len() as u32;
+    let n_regions = ps.memory_maps.len() as u32;
 
     let regs_len = (ps.regs.len() * 8) as u32;
 
     // Layout: header | region table | regs | anon data
-    let region_table_len = regions.len() * REGION_ENTRY_LEN;
+    let region_table_len = ps.memory_maps.len() * REGION_ENTRY_LEN;
     let regs_off = HEADER_LEN + region_table_len;
     let anon_data_off = regs_off + regs_len as usize;
 
@@ -44,7 +43,7 @@ pub(crate) fn serialize(cp: &Checkpoint) -> Vec<u8> {
 
     // Region table. Compute each region's data_off into the anon blob as we go.
     let mut anon_blob: Vec<u8> = Vec::new();
-    for m in &regions {
+    for m in &ps.memory_maps {
         let seg = ps.memory_data.iter().find(|s| s.start == m.start);
         let (src, data_off) = match seg {
             Some(s) => {
@@ -130,6 +129,16 @@ mod tests {
         // One region, zero fds.
         assert_eq!(u32::from_le_bytes(blob[8..12].try_into().unwrap()), 1);
         assert_eq!(u32::from_le_bytes(blob[12..16].try_into().unwrap()), 0);
+
+        // Region-table entry (40 bytes at offset 40): the single region, byte-exact.
+        let r0 = 40usize;
+        assert_eq!(u64::from_le_bytes(blob[r0..r0 + 8].try_into().unwrap()), 0x4500_0000_0000, "region.start");
+        assert_eq!(u64::from_le_bytes(blob[r0 + 8..r0 + 16].try_into().unwrap()), 0x4500_0000_1000, "region.end");
+        assert_eq!(u32::from_le_bytes(blob[r0 + 16..r0 + 20].try_into().unwrap()),
+                   (libc::PROT_READ | libc::PROT_WRITE | libc::PROT_EXEC) as u32, "region.prot");
+        assert_eq!(blob[r0 + 20], 0, "region.src = anon (has captured data)");
+        assert_eq!(u64::from_le_bytes(blob[r0 + 24..r0 + 32].try_into().unwrap()), 0, "region.file_off");
+        assert_eq!(u64::from_le_bytes(blob[r0 + 32..r0 + 40].try_into().unwrap()), 0, "region.data_off");
 
         // GP register area holds the 27 recognizable values.
         let regs_off = u64::from_le_bytes(blob[16..24].try_into().unwrap()) as usize;

--- a/crates/sandlock-core/src/checkpoint/resume.rs
+++ b/crates/sandlock-core/src/checkpoint/resume.rs
@@ -157,7 +157,7 @@ fn prot_from_perms(perms: &str) -> libc::c_int {
 /// MUST kill and reap it.
 /// Limitation: file-backed regions are restored `MAP_PRIVATE` from the on-disk
 /// file, so a checkpointed `MAP_SHARED` mapping is restored as private
-/// (documented M1 limitation).
+/// (a documented limitation for now).
 /// vDSO handling: the kernel-provided `[vdso]`/`[vvar]`/`[vvar_vclock]` mappings
 /// are relocated onto the checkpoint-recorded bases (see `plan_vdso_moves`), so
 /// libc/glibc programs whose cached vDSO pointers (e.g. `clock_gettime`) target
@@ -310,8 +310,8 @@ pub(crate) fn restore_into(
         }
         if opened as i32 != f.fd {
             // dup2 may clobber an inherited stub fd at this number; that is
-            // acceptable -- inherited stub fds are disposable. Documented M1
-            // limitation, alongside the W^X trampoline constraint.
+            // acceptable -- inherited stub fds are disposable. A documented
+            // limitation for now, alongside the W^X trampoline constraint.
             let d = inject::inject_syscall_at(pid, tramp, DUP2, [opened as u64, f.fd as u64, 0, 0, 0, 0])
                 .map_err(|e| err(format!("restore dup2 {opened}->{}: {e}", f.fd)))?;
             if d < 0 { return Err(err(format!("restore dup2 {} -> {} failed: {d}", opened, f.fd))); }

--- a/crates/sandlock-core/tests/integration.rs
+++ b/crates/sandlock-core/tests/integration.rs
@@ -67,5 +67,8 @@ mod test_http_inject_ca;
 #[path = "integration/test_restore.rs"]
 mod test_restore;
 
+#[path = "integration/test_restore_stub.rs"]
+mod test_restore_stub;
+
 #[path = "integration/test_popen.rs"]
 mod test_popen;

--- a/crates/sandlock-core/tests/integration/test_restore_stub.rs
+++ b/crates/sandlock-core/tests/integration/test_restore_stub.rs
@@ -132,6 +132,17 @@ fn memfd_with(bytes: &[u8]) -> RawFd {
 fn restore_stub_trivial_image_runs() {
     if cfg!(not(target_arch = "x86_64")) { eprintln!("skip: x86_64 only"); return; }
     let stub = stub_binary();
+    // Skip gracefully (like the other cc-dependent tests) if build.rs could not
+    // compile the stub, e.g. no C compiler on the host.
+    if !stub.exists() {
+        eprintln!("skip: restore-stub not built ({})", stub.display());
+        return;
+    }
+    // Build the execve path BEFORE fork: CString::new allocates, and allocating
+    // between fork() and execve() in a multithreaded process (the test harness)
+    // can deadlock on the allocator lock. The child then only calls
+    // async-signal-safe dup2/execve. The pointers stay valid across fork.
+    let stub_path = std::ffi::CString::new(stub.to_str().unwrap()).unwrap();
 
     let blob = build_blob();
     let ctrl = memfd_with(&blob);
@@ -147,16 +158,17 @@ fn restore_stub_trivial_image_runs() {
     assert!(child >= 0, "fork");
     if child == 0 {
         // Child: place inherited fds at the fixed numbers, clear CLOEXEC, execve.
+        // Only async-signal-safe calls here (no allocation): stub_path is
+        // already built, and the argv/envp arrays are stack-only pointer arrays.
         unsafe {
             libc::dup2(ctrl, CTRL_FD);
             libc::dup2(ready, READY_FD);
             libc::dup2(go, GO_FD);
             libc::dup2(pipe_w, OUT_FD);
             // Ensure the fixed fds survive execve (dup2 clears CLOEXEC already).
-            let path = std::ffi::CString::new(stub.to_str().unwrap()).unwrap();
-            let argv = [path.as_ptr(), std::ptr::null()];
+            let argv = [stub_path.as_ptr(), std::ptr::null()];
             let envp = [std::ptr::null()];
-            libc::execve(path.as_ptr(), argv.as_ptr(), envp.as_ptr());
+            libc::execve(stub_path.as_ptr(), argv.as_ptr(), envp.as_ptr());
             libc::_exit(127);
         }
     }

--- a/crates/sandlock-core/tests/integration/test_restore_stub.rs
+++ b/crates/sandlock-core/tests/integration/test_restore_stub.rs
@@ -115,7 +115,7 @@ fn eventfd() -> RawFd {
 
 fn memfd_with(bytes: &[u8]) -> RawFd {
     let name = b"restore-blob\0";
-    let fd = unsafe { libc::memfd_create(name.as_ptr() as *const i8, 0) } as i32;
+    let fd = unsafe { libc::memfd_create(name.as_ptr() as *const libc::c_char, 0) } as i32;
     assert!(fd >= 0, "memfd_create");
     let mut off = 0usize;
     while off < bytes.len() {

--- a/crates/sandlock-core/tests/integration/test_restore_stub.rs
+++ b/crates/sandlock-core/tests/integration/test_restore_stub.rs
@@ -1,0 +1,277 @@
+//! Primitive proof of the execve-stub restore path: restore a trivial
+//! single-anon-region "program" via the restore-stub + userfaultfd pager,
+//! WITHOUT Landlock. The
+//! "program" is a hand-assembled code payload that writes a sentinel byte to an
+//! inherited pipe then exits; it lives in an anon region the supervisor pager
+//! serves on fault. Success (reading the sentinel) proves: the stub mapped the
+//! region, registered uffd, rt_sigreturn'd to the checkpoint rip/rsp, and the
+//! pager filled the faulting code page.
+
+use std::os::unix::io::RawFd;
+use std::path::PathBuf;
+
+const CTRL_FD: i32 = 3;
+const READY_FD: i32 = 4;
+const GO_FD: i32 = 5;
+const UFFD_SLOT: i32 = 6;
+
+const CODE_ADDR: u64 = 0x4500_0000_0000;
+const STACK_ADDR: u64 = 0x4500_0001_0000;
+const OUT_FD: i32 = 10; // sentinel pipe write end, inherited by the child
+const SENTINEL: u8 = 0x5A;
+
+/// The stub is a core restore component compiled by build.rs into OUT_DIR; its
+/// path is handed to us via the RESTORE_STUB_PATH env var (set in build.rs).
+fn stub_binary() -> PathBuf {
+    PathBuf::from(env!("RESTORE_STUB_PATH"))
+}
+
+/// x86_64: write(OUT_FD, &sentinel, 1); exit(0). Sentinel byte is at CODE_ADDR+64.
+fn code_payload() -> Vec<u8> {
+    // mov edi, OUT_FD ; mov rsi, CODE_ADDR+64 ; mov edx, 1 ; mov eax, 1 ; syscall
+    // xor edi, edi ; mov eax, 60 ; syscall
+    let mut c = Vec::new();
+    c.extend_from_slice(&[0xbf]); c.extend_from_slice(&(OUT_FD as u32).to_le_bytes()); // mov edi, imm32
+    c.extend_from_slice(&[0x48, 0xbe]); c.extend_from_slice(&(CODE_ADDR + 64).to_le_bytes()); // mov rsi, imm64
+    c.extend_from_slice(&[0xba, 0x01, 0x00, 0x00, 0x00]); // mov edx, 1
+    c.extend_from_slice(&[0xb8, 0x01, 0x00, 0x00, 0x00]); // mov eax, 1 (write)
+    c.extend_from_slice(&[0x0f, 0x05]);                   // syscall
+    c.extend_from_slice(&[0x31, 0xff]);                   // xor edi, edi
+    c.extend_from_slice(&[0xb8, 0x3c, 0x00, 0x00, 0x00]); // mov eax, 60 (exit)
+    c.extend_from_slice(&[0x0f, 0x05]);                   // syscall
+    c
+}
+
+/// The two region page images (code + stack) the pager serves, identical to the
+/// bytes placed in the blob. Kept in one place so the blob and the pager agree.
+fn region_pages() -> [(u64, Vec<u8>); 2] {
+    let page = 0x1000usize;
+    let mut code_page = vec![0u8; page];
+    let payload = code_payload();
+    code_page[..payload.len()].copy_from_slice(&payload);
+    code_page[64] = SENTINEL;
+    let stack_page = vec![0u8; page];
+    [(CODE_ADDR, code_page), (STACK_ADDR, stack_page)]
+}
+
+/// Build the control blob (mirrors restore_blob.rs layout) for the trivial image:
+/// one RWX anon region at CODE_ADDR (page) containing the code payload + sentinel,
+/// plus a stack region at STACK_ADDR; regs.rip=CODE_ADDR, regs.rsp=STACK_ADDR+0xF00.
+fn build_blob() -> Vec<u8> {
+    let page = 0x1000usize;
+    let pages = region_pages();
+
+    // 27-entry user_regs_struct; only rip/rsp/eflags/cs/ss matter here.
+    let mut regs = vec![0u64; 27];
+    regs[16] = CODE_ADDR;              // rip
+    regs[19] = STACK_ADDR + 0xF00;     // rsp
+    regs[18] = 0x202;                  // eflags (IF set)
+    regs[17] = 0x33;                   // cs (user 64-bit)
+    regs[20] = 0x2b;                   // ss (user data)
+
+    let regions = [
+        (CODE_ADDR, CODE_ADDR + page as u64, pages[0].1.clone()),
+        (STACK_ADDR, STACK_ADDR + page as u64, pages[1].1.clone()),
+    ];
+
+    const HEADER_LEN: usize = 40;
+    const REGION_ENTRY_LEN: usize = 40;
+    let region_table_len = regions.len() * REGION_ENTRY_LEN;
+    let regs_off = HEADER_LEN + region_table_len;
+    let anon_data_off = regs_off + regs.len() * 8;
+
+    let mut out = Vec::new();
+    out.extend_from_slice(&0x534c_5242u32.to_le_bytes()); // magic
+    out.extend_from_slice(&1u32.to_le_bytes());           // version
+    out.extend_from_slice(&(regions.len() as u32).to_le_bytes());
+    out.extend_from_slice(&0u32.to_le_bytes());           // n_fds
+    out.extend_from_slice(&(regs_off as u64).to_le_bytes());
+    out.extend_from_slice(&((regs.len() * 8) as u32).to_le_bytes());
+    out.extend_from_slice(&0u32.to_le_bytes());           // _pad
+    out.extend_from_slice(&(anon_data_off as u64).to_le_bytes());
+
+    let mut anon = Vec::new();
+    for (start, end, bytes) in &regions {
+        let data_off = anon.len() as u64;
+        anon.extend_from_slice(bytes);
+        out.extend_from_slice(&start.to_le_bytes());
+        out.extend_from_slice(&end.to_le_bytes());
+        out.extend_from_slice(&(0x7u32).to_le_bytes());   // prot RWX
+        out.push(0u8);                                    // src=anon
+        out.extend_from_slice(&[0u8; 3]);
+        out.extend_from_slice(&0u64.to_le_bytes());       // file_off
+        out.extend_from_slice(&data_off.to_le_bytes());
+    }
+    for r in &regs { out.extend_from_slice(&r.to_le_bytes()); }
+    out.extend_from_slice(&anon);
+    out
+}
+
+fn eventfd() -> RawFd {
+    let fd = unsafe { libc::eventfd(0, 0) };
+    assert!(fd >= 0, "eventfd");
+    fd
+}
+
+fn memfd_with(bytes: &[u8]) -> RawFd {
+    let name = b"restore-blob\0";
+    let fd = unsafe { libc::memfd_create(name.as_ptr() as *const i8, 0) } as i32;
+    assert!(fd >= 0, "memfd_create");
+    let mut off = 0usize;
+    while off < bytes.len() {
+        let n = unsafe {
+            libc::write(fd, bytes[off..].as_ptr() as *const libc::c_void, bytes.len() - off)
+        };
+        assert!(n > 0, "write blob");
+        off += n as usize;
+    }
+    fd
+}
+
+#[test]
+fn restore_stub_trivial_image_runs() {
+    if cfg!(not(target_arch = "x86_64")) { eprintln!("skip: x86_64 only"); return; }
+    let stub = stub_binary();
+
+    let blob = build_blob();
+    let ctrl = memfd_with(&blob);
+    let ready = eventfd();
+    let go = eventfd();
+
+    // Sentinel pipe: child writes SENTINEL to OUT_FD, parent reads it.
+    let mut pipefd = [0i32; 2];
+    assert_eq!(unsafe { libc::pipe(pipefd.as_mut_ptr()) }, 0);
+    let (pipe_r, pipe_w) = (pipefd[0], pipefd[1]);
+
+    let child = unsafe { libc::fork() };
+    assert!(child >= 0, "fork");
+    if child == 0 {
+        // Child: place inherited fds at the fixed numbers, clear CLOEXEC, execve.
+        unsafe {
+            libc::dup2(ctrl, CTRL_FD);
+            libc::dup2(ready, READY_FD);
+            libc::dup2(go, GO_FD);
+            libc::dup2(pipe_w, OUT_FD);
+            // Ensure the fixed fds survive execve (dup2 clears CLOEXEC already).
+            let path = std::ffi::CString::new(stub.to_str().unwrap()).unwrap();
+            let argv = [path.as_ptr(), std::ptr::null()];
+            let envp = [std::ptr::null()];
+            libc::execve(path.as_ptr(), argv.as_ptr(), envp.as_ptr());
+            libc::_exit(127);
+        }
+    }
+
+    // Parent = supervisor.
+    unsafe { libc::close(pipe_w); }
+    let childfd = unsafe { libc::syscall(libc::SYS_pidfd_open, child, 0) } as i32;
+    assert!(childfd >= 0, "pidfd_open");
+
+    // Diagnose a stub that died before READY: report its die(code) exit status.
+    let diagnose_dead_child = |child: i32| -> String {
+        let mut st = 0i32;
+        let r = unsafe { libc::waitpid(child, &mut st, libc::WNOHANG) };
+        if r == child {
+            if libc::WIFEXITED(st) {
+                format!("stub exited with die code {}", libc::WEXITSTATUS(st))
+            } else if libc::WIFSIGNALED(st) {
+                format!("stub killed by signal {}", libc::WTERMSIG(st))
+            } else {
+                format!("stub status {st:#x}")
+            }
+        } else {
+            "stub still running (hung before READY)".to_string()
+        }
+    };
+
+    // Wait (bounded) for the stub's READY (uffd registered). Poll so a stub that
+    // dies early cannot hang the test in an unbounded eventfd read.
+    let mut rpfd = libc::pollfd { fd: ready, events: libc::POLLIN, revents: 0 };
+    let rpn = unsafe { libc::poll(&mut rpfd, 1, 5000) };
+    if rpn <= 0 || (rpfd.revents & libc::POLLIN) == 0 {
+        let why = diagnose_dead_child(child);
+        unsafe { libc::kill(child, libc::SIGKILL); libc::waitpid(child, &mut 0, 0); }
+        panic!("stub never signalled READY within 5s: {why}");
+    }
+    let mut buf = [0u8; 8];
+    let n = unsafe { libc::read(ready, buf.as_mut_ptr() as *mut libc::c_void, 8) };
+    assert_eq!(n, 8, "stub READY");
+
+    // Acquire the stub's uffd via pidfd_getfd(UFFD_SLOT), start a minimal pager.
+    let uffd = unsafe { libc::syscall(libc::SYS_pidfd_getfd, childfd, UFFD_SLOT, 0) } as i32;
+    assert!(uffd >= 0, "pidfd_getfd uffd");
+
+    // Minimal inline pager: serve the two region pages from the blob's anon data.
+    // The stub created the uffd O_NONBLOCK (poll() on a *blocking* uffd reports
+    // POLLERR), so we keep it non-blocking and drive it with poll() + a stop
+    // flag. Relying on read() returning EOF once the child's mm is gone is
+    // unreliable across kernels; an explicit stop flag terminates the thread
+    // deterministically once the parent is done.
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    let page = 0x1000usize;
+    let regions = region_pages();
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let uffd_thread = uffd;
+    let stop_thread = stop.clone();
+    let pager = std::thread::spawn(move || {
+        // UFFDIO_COPY ioctl in the parent (which shares the child's registered mm
+        // view through the acquired uffd).
+        #[repr(C)] struct Copy { dst: u64, src: u64, len: u64, mode: u64, copy: i64 }
+        const UFFDIO_COPY: libc::c_ulong = 0xc028_aa03;
+        while !stop_thread.load(Ordering::SeqCst) {
+            let mut pfd = libc::pollfd { fd: uffd_thread, events: libc::POLLIN, revents: 0 };
+            let pn = unsafe { libc::poll(&mut pfd, 1, 20) };
+            if pn <= 0 || (pfd.revents & libc::POLLIN) == 0 { continue; }
+            let mut msg = [0u8; 32];
+            let n = unsafe {
+                libc::read(uffd_thread, msg.as_mut_ptr() as *mut libc::c_void, 32) };
+            if n <= 0 { continue; } // EAGAIN (non-blocking) or EOF: re-check stop
+            if msg[0] != 0x12 { continue; } // UFFD_EVENT_PAGEFAULT
+            // struct uffd_msg: 8-byte header, then pagefault { u64 flags; u64
+            // address; ... }. The fault address is the SECOND u64 (offset 16),
+            // not the third: arg[2]/offset 24 is the ptid.
+            let addr = u64::from_le_bytes(msg[16..24].try_into().unwrap());
+            let base = addr & !((page as u64) - 1);
+            let src = regions.iter().find(|(s, _)| *s == base).map(|(_, b)| b);
+            let zero = vec![0u8; page];
+            let bytes = src.map(|b| b.as_slice()).unwrap_or(&zero);
+            let mut c = Copy { dst: base, src: bytes.as_ptr() as u64,
+                               len: page as u64, mode: 0, copy: 0 };
+            let r = unsafe { libc::ioctl(uffd_thread, UFFDIO_COPY, &mut c) };
+            if r < 0 { break; }
+        }
+    });
+
+    // Pager is attached and polling (blocked in read); release the stub.
+    let one: u64 = 1;
+    let w = unsafe { libc::write(go, &one as *const u64 as *const libc::c_void, 8) };
+    assert_eq!(w, 8, "GO");
+
+    // Read the sentinel the restored code writes, bounded by a watchdog so a
+    // failed restore (child SIGSEGVs / dies via die(code)) cannot hang the test.
+    let mut got = [0u8; 1];
+    let mut pfd = libc::pollfd { fd: pipe_r, events: libc::POLLIN, revents: 0 };
+    let pn = unsafe { libc::poll(&mut pfd, 1, 5000) };
+    let n = if pn > 0 && (pfd.revents & libc::POLLIN) != 0 {
+        unsafe { libc::read(pipe_r, got.as_mut_ptr() as *mut libc::c_void, 1) }
+    } else {
+        0 // timeout or hangup: treat as "no sentinel"
+    };
+
+    // Reap and clean up. Kill first so a stuck child cannot linger, then the
+    // uffd hangs up and the pager's blocking read returns 0 (thread ends).
+    unsafe { libc::kill(child, libc::SIGKILL); }
+    let mut status = 0i32;
+    unsafe { libc::waitpid(child, &mut status, 0); }
+    stop.store(true, Ordering::SeqCst);
+    let _ = pager.join();
+    unsafe {
+        libc::close(pipe_r); libc::close(uffd); libc::close(childfd);
+        libc::close(ctrl); libc::close(ready); libc::close(go);
+    }
+
+    assert_eq!(n, 1, "restored code must write exactly one sentinel byte");
+    assert_eq!(got[0], SENTINEL,
+        "restored code ran and wrote the sentinel (rt_sigreturn + uffd paging worked)");
+}


### PR DESCRIPTION
## Summary

Introduces the execve-stub restore path: a checkpoint is restored by exec-ing a freestanding stub into a fresh process that self-reconstructs its address space, rather than driving a puppet through ptrace injection. This first cut proves the primitive end to end for a trivial single-region program, entirely unprivileged (no sysctl, no `CAP_SYS_PTRACE`).

## How it works

1. The supervisor serializes the checkpoint into a compact control blob (region table, GP register file, anonymous page bytes) on a memfd.
2. It exec's `restore-stub` (a freestanding, no-libc, no-PIE binary) with the blob and two eventfds on fixed inherited fds.
3. The stub maps each anonymous region `MAP_FIXED` with its captured prot, registers them with userfaultfd (missing mode), exposes the uffd to the supervisor, signals READY, waits for GO, then `rt_sigreturn`s into the checkpoint register context.
4. The supervisor acquires the stub's uffd via `pidfd_getfd` and serves each faulting page with `UFFDIO_COPY` from the blob.

## What is proven

The end-to-end test restores a hand-assembled program (write a sentinel byte to an inherited pipe, then exit) whose code lives in an anonymous region served on fault. Reading the sentinel proves the stub mapped the region, registered uffd, `rt_sigreturn`d to the checkpoint rip/rsp, and the pager filled the faulting code page.

## Notable correctness points

- The userfaultfd is created `O_NONBLOCK`: `poll()` on a blocking uffd always reports `POLLERR`, so a polling pager would never see a fault.
- On hosts with `vm.unprivileged_userfaultfd=0`, creation falls back to `UFFD_USER_MODE_ONLY`, which serves the user-mode faults this path relies on without privilege.
- Region prot is honored (an executable region mapped without `PROT_EXEC` would fault as a protection violation rather than a serviceable missing-page fault).

## Known limitations (follow-up)

- The stub is `-no-pie` and links low; restoring a real program whose own text occupies that range would clobber the running stub. The next phase relocates the stub out of the way.
- Only anonymous regions are handled: no file-backed regions, no in-stub vDSO relocation, no FP/xstate, no fd-table reopen yet.
- `USER_MODE_ONLY` cannot serve kernel-mode faults (a syscall touching an unfilled page); the planned solution is prefaulting pointer args from the seccomp-notify supervisor.

## Testing

- `checkpoint` unit tests (blob round-trip, pager page service): pass.
- New `test_restore_stub` end-to-end integration test: pass.
- Existing injection-based restore test: pass (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
