### PR TITLE
fix(landlock): tolerate missing read/exec grant paths instead of aborting

### DIFF
--- a/crates/sandlock-core/src/landlock.rs
+++ b/crates/sandlock-core/src/landlock.rs
@@ -156,13 +156,33 @@ fn add_path_rule(ruleset_fd: &OwnedFd, path: &Path, access: u64) -> Result<(), C
     // on a FIFO or a write-only/no-read path neither hangs nor fails here. An
     // O_PATH fd still supports fstat (the file-type check below) and serves as a
     // valid parent_fd for landlock_add_rule.
-    let file = std::fs::OpenOptions::new()
+    let file = match std::fs::OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_PATH | libc::O_CLOEXEC)
         .open(path)
-        .map_err(|e| {
-            ConfinementError::Landlock(format!("open path {:?} failed: {}", path, e))
-        })?;
+    {
+        Ok(f) => f,
+        // A read/exec grant naming an absent subtree is vacuous: Landlock is
+        // default-deny, so skipping it adds no allowance and leaves confinement
+        // at least as strict (there are no files under a path that does not
+        // exist to grant). This lets one base policy list /lib, /lib64,
+        // /usr/lib, /usr/lib64, ... and take whatever subset a given host or
+        // arch actually has (e.g. RISC-V glibc and musl have no /lib64). The
+        // skip is warned, not silent, and a genuine typo still surfaces as the
+        // loud runtime failure of a program that cannot find its files. A
+        // missing WRITE target stays a hard error: the caller means it to exist.
+        Err(e)
+            if e.kind() == std::io::ErrorKind::NotFound && (access & !READ_ACCESS) == 0 =>
+        {
+            eprintln!("sandlock: read grant for missing path {path:?} skipped");
+            return Ok(());
+        }
+        Err(e) => {
+            return Err(ConfinementError::Landlock(format!(
+                "open path {path:?} failed: {e}"
+            )));
+        }
+    };
 
     // Directory-only access rights (READ_DIR, MAKE_*, REMOVE_*, REFER) make
     // landlock_add_rule fail with EINVAL on a non-directory path. Mask the
@@ -877,5 +897,23 @@ mod mask_contract_tests {
         let (mask, wildcard) = compute_net_mask(6, &pol, &sb, true);
         assert_eq!(mask, 0, "net_deny + bind-all leaves no handled net access");
         assert!(wildcard, "net_deny must still set the wildcard flag");
+    }
+
+    #[test]
+    fn add_path_rule_skips_missing_read_but_fails_missing_write() {
+        let dummy = std::os::fd::OwnedFd::from(std::fs::File::open("/dev/null").unwrap());
+        let missing = std::path::Path::new("/nonexistent-sandlock-portability-probe");
+        assert!(!missing.exists(), "probe path must be absent for this test");
+
+        assert!(
+            add_path_rule(&dummy, missing, READ_ACCESS).is_ok(),
+            "a read/exec grant for a missing subtree must be skipped, not fatal"
+        );
+
+        let write_mask = LANDLOCK_ACCESS_FS_WRITE_FILE | LANDLOCK_ACCESS_FS_READ_FILE;
+        assert!(
+            add_path_rule(&dummy, missing, write_mask).is_err(),
+            "a write grant for a missing target must remain a hard error"
+        );
     }
 }


### PR DESCRIPTION
## Problem

A Landlock read/exec grant that names a path **absent on the host** made `add_path_rule` hard-fail the `O_PATH` open, which aborted confinement and took the whole sandbox launch down with it:

```
confinement failed: landlock error: open path "/lib64" failed: No such file or directory
```

`/lib64` is an x86-64 glibc multilib convention. On RISC-V glibc (loader at `/lib/ld-linux-riscv64-lp64d.so.1`) and on musl there is no `/lib64` at all, so a base policy that lists the standard library dirs cannot be portable across distros/arches. Concretely, every `sandlock-cli` test that grants `-r /lib64` fails on RISC-V (11 failures), and this is the same `/lib64` sharp edge previously worked around in the alpine/musl policy.

## Fix

`add_path_rule` now **skips** a read/exec grant whose path does not exist, with a warning, instead of failing. One base policy can then list `/lib`, `/lib64`, `/usr/lib`, `/usr/lib64`, ... and each host takes whatever subset it actually has.

Scoped narrowly:
- **ENOENT only.** Any other open error (`EACCES`, ...) still hard-fails.
- **Read/exec grants only** (`(access & !READ_ACCESS) == 0`). A missing **write** target stays a hard error, since a caller naming a write path means it to exist.
- The skip is **warned, not silent**, and a genuine typo still surfaces as the loud runtime failure of a program that cannot find its files.

## Why it is security-neutral

Landlock is default-deny with **allow-only** rules; there are no deny rules to weaken. `add_path_rule` only ever *widens* access, so skipping a grant only ever *narrows* it. For a nonexistent path there is nothing beneath it to grant, so the reachable-file set is identical. Adversarial cases resolve in the safe (deny) direction:

- **Path appears later / TOCTOU:** the process was never granted it, so it stays denied.
- **Dangling symlink:** `O_PATH` follows to a missing target -> ENOENT -> skipped; the grant would have been for the missing target anyway.
- **Attacker deletes a required dir before launch:** worst case the process fails to run (DoS), not a confinement bypass.

The only behavioral change is launch-time: a missing grant no longer aborts the launch; the process runs confined by a strict subset of the intended grants. It can only do less, never more.

## Tests

- New unit test `add_path_rule_skips_missing_read_but_fails_missing_write` pins the contract (both branches return before the ruleset fd is touched, so it needs no Landlock kernel support).
- x86 unaffected: all 22 `cli_test` cases and all landlock unit tests pass (`/lib64` exists there, so the skip branch is not even exercised). On RISC-V the previously-failing tests now pass.