### PR TITLE
fix: RISC-V test portability and exec fd-redirect argv[0] preservation

### DIFF
--- a/crates/sandlock-cli/tests/cli_test.rs
+++ b/crates/sandlock-cli/tests/cli_test.rs
@@ -6,6 +6,27 @@ fn sandlock_bin() -> Command {
     cmd
 }
 
+/// Drop `-r /lib64` from a CLI argument list when the host has no `/lib64`
+/// (RISC-V glibc and musl put the loader under `/lib`, with no `/lib64` at
+/// all). `-r` maps to a mandatory `fs_read`, so requiring `/lib64` on such a
+/// host aborts confinement; this mirrors `fs_read_if_exists` at the CLI layer.
+/// On hosts that have `/lib64` (x86-64) the arguments pass through unchanged.
+fn args_for_host(args: &[&str]) -> Vec<String> {
+    let has_lib64 = std::path::Path::new("/lib64").exists();
+    let mut out: Vec<String> = Vec::with_capacity(args.len());
+    for a in args {
+        if *a == "/lib64" && !has_lib64 {
+            // Also drop the `-r` we just pushed for this now-omitted path.
+            if out.last().map(|s| s == "-r").unwrap_or(false) {
+                out.pop();
+            }
+            continue;
+        }
+        out.push((*a).to_string());
+    }
+    out
+}
+
 #[test]
 fn test_check_command() {
     let output = sandlock_bin()
@@ -20,7 +41,7 @@ fn test_check_command() {
 #[test]
 fn test_run_echo() {
     let output = sandlock_bin()
-        .args(["run", "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "-r", "/etc", "--", "echo", "test123"])
+        .args(args_for_host(&["run", "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "-r", "/etc", "--", "echo", "test123"]))
         .output()
         .expect("failed to run sandlock");
     assert!(output.status.success(), "Exit status: {:?}, stderr: {}", output.status, String::from_utf8_lossy(&output.stderr));
@@ -31,7 +52,7 @@ fn test_run_echo() {
 #[test]
 fn test_run_exit_code() {
     let output = sandlock_bin()
-        .args(["run", "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "--", "sh", "-c", "exit 42"])
+        .args(args_for_host(&["run", "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "--", "sh", "-c", "exit 42"]))
         .output()
         .expect("failed to run");
     assert_eq!(output.status.code(), Some(42));
@@ -40,7 +61,7 @@ fn test_run_exit_code() {
 #[test]
 fn test_run_denied_path() {
     let output = sandlock_bin()
-        .args(["run", "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "--", "cat", "/etc/group"])
+        .args(args_for_host(&["run", "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "--", "cat", "/etc/group"]))
         .output()
         .expect("failed to run");
     assert!(!output.status.success(), "Should fail without /etc readable");
@@ -52,7 +73,7 @@ fn test_run_hostname_virtualized() {
     // even when /etc is not in fs_read, and should return the sandbox hostname
     // (not the host's).
     let output = sandlock_bin()
-        .args(["run", "--name", "mybox", "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "--", "cat", "/etc/hostname"])
+        .args(args_for_host(&["run", "--name", "mybox", "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "--", "cat", "/etc/hostname"]))
         .output()
         .expect("failed to run");
     assert!(output.status.success(), "virtualized /etc/hostname should be readable: stderr={}", String::from_utf8_lossy(&output.stderr));
@@ -105,7 +126,7 @@ fn test_status_fd_flag_accepted() {
 #[test]
 fn test_time_start_fakes_year() {
     let output = sandlock_bin()
-        .args([
+        .args(args_for_host(&[
             "run",
             "-r", "/usr",
             "-r", "/lib",
@@ -115,7 +136,7 @@ fn test_time_start_fakes_year() {
             "--time-start", "2000-06-15T00:00:00Z",
             "--",
             "date", "+%Y",
-        ])
+        ]))
         .output()
         .expect("failed to run sandlock with --time-start");
     assert!(
@@ -134,7 +155,7 @@ fn test_time_start_fakes_year() {
 #[test]
 fn test_no_supervisor_echo() {
     let output = sandlock_bin()
-        .args(["run", "--no-supervisor", "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "-r", "/etc", "--", "echo", "no-supervisor-test"])
+        .args(args_for_host(&["run", "--no-supervisor", "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "-r", "/etc", "--", "echo", "no-supervisor-test"]))
         .output()
         .expect("failed to run sandlock --no-supervisor");
     assert!(output.status.success(), "Exit status: {:?}, stderr: {}", output.status, String::from_utf8_lossy(&output.stderr));
@@ -145,7 +166,7 @@ fn test_no_supervisor_echo() {
 #[test]
 fn test_no_supervisor_blocks_denied_path() {
     let output = sandlock_bin()
-        .args(["run", "--no-supervisor", "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "--", "cat", "/etc/hostname"])
+        .args(args_for_host(&["run", "--no-supervisor", "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "--", "cat", "/etc/hostname"]))
         .output()
         .expect("failed to run");
     assert!(!output.status.success(), "Should fail without /etc readable");
@@ -200,8 +221,8 @@ fn test_no_supervisor_rejects_incompatible_flags() {
 #[test]
 fn test_no_supervisor_writable_path() {
     let output = sandlock_bin()
-        .args(["run", "--no-supervisor", "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "-w", "/tmp", "--",
-               "sh", "-c", "echo no-supervisor-write > /tmp/sandlock-no-supervisor-test && cat /tmp/sandlock-no-supervisor-test"])
+        .args(args_for_host(&["run", "--no-supervisor", "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "-w", "/tmp", "--",
+               "sh", "-c", "echo no-supervisor-write > /tmp/sandlock-no-supervisor-test && cat /tmp/sandlock-no-supervisor-test"]))
         .output()
         .expect("failed to run");
     assert!(output.status.success(), "Exit status: {:?}, stderr: {}", output.status, String::from_utf8_lossy(&output.stderr));
@@ -215,13 +236,13 @@ fn test_no_supervisor_nested_sandbox() {
     let sandlock_path = env!("CARGO_BIN_EXE_sandlock");
     let sandlock_dir = std::path::Path::new(sandlock_path).parent().unwrap().to_str().unwrap();
     let output = sandlock_bin()
-        .args(["run", "--no-supervisor",
+        .args(args_for_host(&["run", "--no-supervisor",
                "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "-r", "/etc",
                "-r", "/proc", "-r", "/dev", "-w", "/tmp",
                "-r", sandlock_dir,
                "--", sandlock_path, "run",
                "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "-r", "/etc",
-               "--", "echo", "nested-works"])
+               "--", "echo", "nested-works"]))
         .output()
         .expect("failed to run nested sandbox");
     assert!(output.status.success(), "Exit status: {:?}, stderr: {}", output.status, String::from_utf8_lossy(&output.stderr));
@@ -232,7 +253,7 @@ fn test_no_supervisor_nested_sandbox() {
 #[test]
 fn test_no_supervisor_exit_code() {
     let output = sandlock_bin()
-        .args(["run", "--no-supervisor", "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "--", "sh", "-c", "exit 42"])
+        .args(args_for_host(&["run", "--no-supervisor", "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "--", "sh", "-c", "exit 42"]))
         .output()
         .expect("failed to run");
     assert_eq!(output.status.code(), Some(42));
@@ -255,13 +276,13 @@ fn test_cow_commit_runs_on_cli_exit() {
 
     let cmd = format!("echo committed > {}", sentinel.display());
     let output = sandlock_bin()
-        .args([
+        .args(args_for_host(&[
             "run",
             "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "-r", "/etc",
             "-w", workdir.path().to_str().unwrap(),
             "--workdir", workdir.path().to_str().unwrap(),
             "--", "sh", "-c", &cmd,
-        ])
+        ]))
         .output()
         .expect("failed to run sandlock");
     assert!(
@@ -290,12 +311,12 @@ fn test_uid_mapping_fakes_root() {
     // `id -u` reports the in-namespace UID. Passing --user 0:0 should make
     // the child see UID 0 (fake root) regardless of the host UID.
     let output = sandlock_bin()
-        .args([
+        .args(args_for_host(&[
             "run",
             "--user", "0:0",
             "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "-r", "/etc",
             "--", "id", "-u",
-        ])
+        ]))
         .output()
         .expect("failed to run sandlock");
     assert!(
@@ -315,12 +336,12 @@ fn test_uid_mapping_fakes_root() {
 fn test_uid_mapping_arbitrary_uid() {
     // Arbitrary --user value should also map cleanly (not just 0).
     let output = sandlock_bin()
-        .args([
+        .args(args_for_host(&[
             "run",
             "--user", "1234:1234",
             "-r", "/usr", "-r", "/lib", "-r", "/lib64", "-r", "/bin", "-r", "/etc",
             "--", "id", "-u",
-        ])
+        ]))
         .output()
         .expect("failed to run sandlock");
     assert!(

--- a/crates/sandlock-cli/tests/profile_integration.rs
+++ b/crates/sandlock-cli/tests/profile_integration.rs
@@ -4,17 +4,30 @@ fn sandlock_bin() -> Command {
     Command::new(env!("CARGO_BIN_EXE_sandlock"))
 }
 
+/// The `[filesystem]` `read` list for a test profile, including `/lib64` only
+/// when the host has it. RISC-V glibc and musl have no `/lib64` (the loader
+/// lives under `/lib`), and a profile `read` entry is a mandatory grant, so
+/// requiring `/lib64` on such a host aborts confinement. Mirrors
+/// `fs_read_if_exists` for the profile layer.
+fn read_list() -> &'static str {
+    if std::path::Path::new("/lib64").exists() {
+        r#"read = ["/usr", "/lib", "/lib64", "/bin", "/etc"]"#
+    } else {
+        r#"read = ["/usr", "/lib", "/bin", "/etc"]"#
+    }
+}
+
 #[test]
 fn profile_program_section_supplies_command() {
     let tmp = tempfile::tempdir().unwrap();
     let profile_path = tmp.path().join("p.toml");
-    std::fs::write(&profile_path, r#"
+    std::fs::write(&profile_path, format!(r#"
         [program]
         exec = "/bin/true"
 
         [filesystem]
-        read = ["/usr", "/lib", "/lib64", "/bin", "/etc"]
-    "#).unwrap();
+        {read}
+    "#, read = read_list())).unwrap();
 
     let out = sandlock_bin()
         .args(["run", "--profile-file", profile_path.to_str().unwrap()])
@@ -29,13 +42,13 @@ fn trailing_command_overrides_profile_program_section() {
     let tmp = tempfile::tempdir().unwrap();
     let profile_path = tmp.path().join("p.toml");
     // Profile says exec = "/bin/false" — should be overridden by CLI command.
-    std::fs::write(&profile_path, r#"
+    std::fs::write(&profile_path, format!(r#"
         [program]
         exec = "/bin/false"
 
         [filesystem]
-        read = ["/usr", "/lib", "/lib64", "/bin", "/etc"]
-    "#).unwrap();
+        {read}
+    "#, read = read_list())).unwrap();
 
     let out = sandlock_bin()
         .args(["run", "--profile-file", profile_path.to_str().unwrap(), "--", "/bin/true"])
@@ -49,14 +62,14 @@ fn trailing_command_overrides_profile_program_section() {
 fn profile_with_args_are_passed_to_command() {
     let tmp = tempfile::tempdir().unwrap();
     let profile_path = tmp.path().join("p.toml");
-    std::fs::write(&profile_path, r#"
+    std::fs::write(&profile_path, format!(r#"
         [program]
         exec = "/bin/sh"
         args = ["-c", "exit 0"]
 
         [filesystem]
-        read = ["/usr", "/lib", "/lib64", "/bin", "/etc"]
-    "#).unwrap();
+        {read}
+    "#, read = read_list())).unwrap();
 
     let out = sandlock_bin()
         .args(["run", "--profile-file", profile_path.to_str().unwrap()])
@@ -96,13 +109,13 @@ fn profile_by_name_loads_program_section() {
     let profiles_dir = tmp.path().join("sandlock").join("profiles");
     std::fs::create_dir_all(&profiles_dir).unwrap();
     let profile_path = profiles_dir.join("by-name-test.toml");
-    std::fs::write(&profile_path, r#"
+    std::fs::write(&profile_path, format!(r#"
         [program]
         exec = "/bin/true"
 
         [filesystem]
-        read = ["/usr", "/lib", "/lib64", "/bin", "/etc"]
-    "#).unwrap();
+        {read}
+    "#, read = read_list())).unwrap();
 
     let out = std::process::Command::new(env!("CARGO_BIN_EXE_sandlock"))
         .env("XDG_CONFIG_HOME", tmp.path())
@@ -121,16 +134,16 @@ fn profile_by_name_loads_program_section() {
 fn no_supervisor_rejects_supervisor_only_profile_fields() {
     let tmp = tempfile::tempdir().unwrap();
     let profile_path = tmp.path().join("p.toml");
-    std::fs::write(&profile_path, r#"
+    std::fs::write(&profile_path, format!(r#"
         [program]
         exec = "/bin/true"
 
         [filesystem]
-        read = ["/usr", "/lib", "/lib64", "/bin", "/etc"]
+        {read}
 
         [network]
         allow = ["example.com:443"]
-    "#).unwrap();
+    "#, read = read_list())).unwrap();
 
     let out = sandlock_bin()
         .args(["run", "--no-supervisor", "--profile-file", profile_path.to_str().unwrap()])

--- a/crates/sandlock-core/examples/openat_audit.rs
+++ b/crates/sandlock-core/examples/openat_audit.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let policy = Sandbox::builder()
         .fs_read("/usr")
         .fs_read("/lib")
-        .fs_read("/lib64")
+        .fs_read_if_exists("/lib64")
         .fs_read("/etc")
         .fs_read("/proc")
         .fs_write("/tmp")

--- a/crates/sandlock-core/src/chroot/dispatch.rs
+++ b/crates/sandlock-core/src/chroot/dispatch.rs
@@ -721,10 +721,10 @@ pub(crate) async fn handle_chroot_exec(
     ctx: &ChrootCtx<'_>,
 ) -> NotifAction {
     let nr = notif.data.nr as i64;
-    let (dirfd, path_ptr, argv_ptr) = if nr == libc::SYS_execveat {
-        (notif.data.args[0] as i64, notif.data.args[1], notif.data.args[2])
+    let (dirfd, path_ptr, argv_ptr, envp_ptr) = if nr == libc::SYS_execveat {
+        (notif.data.args[0] as i64, notif.data.args[1], notif.data.args[2], notif.data.args[3])
     } else {
-        (libc::AT_FDCWD as i64, notif.data.args[0], notif.data.args[1])
+        (libc::AT_FDCWD as i64, notif.data.args[0], notif.data.args[1], notif.data.args[2])
     };
 
     let rel_path = match read_path(notif, path_ptr, notif_fd) {
@@ -875,7 +875,7 @@ pub(crate) async fn handle_chroot_exec(
     // guard needed — execve replaces the address space on success, so a write
     // past the original buffer is harmless.
     if crate::seccomp::notif::rewrite_exec_path_to_fd(
-        notif_fd, notif.id, notif.pid, path_ptr, argv_ptr, child_fd,
+        notif_fd, notif.id, notif.pid, path_ptr, argv_ptr, envp_ptr, child_fd,
     )
     .is_err()
     {

--- a/crates/sandlock-core/src/chroot/dispatch.rs
+++ b/crates/sandlock-core/src/chroot/dispatch.rs
@@ -721,10 +721,10 @@ pub(crate) async fn handle_chroot_exec(
     ctx: &ChrootCtx<'_>,
 ) -> NotifAction {
     let nr = notif.data.nr as i64;
-    let (dirfd, path_ptr) = if nr == libc::SYS_execveat {
-        (notif.data.args[0] as i64, notif.data.args[1])
+    let (dirfd, path_ptr, argv_ptr) = if nr == libc::SYS_execveat {
+        (notif.data.args[0] as i64, notif.data.args[1], notif.data.args[2])
     } else {
-        (libc::AT_FDCWD as i64, notif.data.args[0])
+        (libc::AT_FDCWD as i64, notif.data.args[0], notif.data.args[1])
     };
 
     let rel_path = match read_path(notif, path_ptr, notif_fd) {
@@ -868,12 +868,17 @@ pub(crate) async fn handle_chroot_exec(
         return NotifAction::Errno(libc::EIO);
     }
 
-    // Force-write past read-only page protections: the child commonly passes a
-    // .rodata path literal to execve, which process_vm_writev can't overwrite.
-    // No length guard needed — execve replaces the address space on success, so
-    // a write past the original buffer is harmless.
-    let fd_path = format!("/proc/self/fd/{}\0", child_fd);
-    if write_child_mem_force(notif_fd, notif.id, notif.pid, path_ptr, fd_path.as_bytes()).is_err() {
+    // Rewrite the path to /proc/self/fd/N, relocating argv[0] when it aliases
+    // the path buffer (see rewrite_exec_path_to_fd). Force-writes past
+    // read-only page protections: the child commonly passes a .rodata path
+    // literal to execve, which process_vm_writev can't overwrite. No length
+    // guard needed — execve replaces the address space on success, so a write
+    // past the original buffer is harmless.
+    if crate::seccomp::notif::rewrite_exec_path_to_fd(
+        notif_fd, notif.id, notif.pid, path_ptr, argv_ptr, child_fd,
+    )
+    .is_err()
+    {
         return NotifAction::Errno(libc::EFAULT);
     }
 

--- a/crates/sandlock-core/src/cow/dispatch.rs
+++ b/crates/sandlock-core/src/cow/dispatch.rs
@@ -936,12 +936,12 @@ pub(crate) async fn handle_cow_exec(
     notif_fd: RawFd,
 ) -> NotifAction {
     let nr = notif.data.nr as i64;
-    // execve(path, argv, envp):        args[0] = path
-    // execveat(dirfd, path, argv, ..): args[0]=dirfd, args[1]=path
-    let (dirfd, path_ptr, argv_ptr) = if nr == libc::SYS_execveat {
-        (notif.data.args[0] as i64, notif.data.args[1], notif.data.args[2])
+    // execve(path, argv, envp):              args[0]=path,  args[1]=argv, args[2]=envp
+    // execveat(dirfd, path, argv, envp, ..): args[1]=path, args[2]=argv, args[3]=envp
+    let (dirfd, path_ptr, argv_ptr, envp_ptr) = if nr == libc::SYS_execveat {
+        (notif.data.args[0] as i64, notif.data.args[1], notif.data.args[2], notif.data.args[3])
     } else {
-        (libc::AT_FDCWD as i64, notif.data.args[0], notif.data.args[1])
+        (libc::AT_FDCWD as i64, notif.data.args[0], notif.data.args[1], notif.data.args[2])
     };
 
     let rel_path = match read_path(notif, path_ptr, notif_fd) {
@@ -1018,7 +1018,7 @@ pub(crate) async fn handle_cow_exec(
     // address space on success, so a write past the original buffer is
     // harmless.
     if crate::seccomp::notif::rewrite_exec_path_to_fd(
-        notif_fd, notif.id, notif.pid, path_ptr, argv_ptr, child_fd,
+        notif_fd, notif.id, notif.pid, path_ptr, argv_ptr, envp_ptr, child_fd,
     )
     .is_err()
     {

--- a/crates/sandlock-core/src/cow/dispatch.rs
+++ b/crates/sandlock-core/src/cow/dispatch.rs
@@ -938,10 +938,10 @@ pub(crate) async fn handle_cow_exec(
     let nr = notif.data.nr as i64;
     // execve(path, argv, envp):        args[0] = path
     // execveat(dirfd, path, argv, ..): args[0]=dirfd, args[1]=path
-    let (dirfd, path_ptr) = if nr == libc::SYS_execveat {
-        (notif.data.args[0] as i64, notif.data.args[1])
+    let (dirfd, path_ptr, argv_ptr) = if nr == libc::SYS_execveat {
+        (notif.data.args[0] as i64, notif.data.args[1], notif.data.args[2])
     } else {
-        (libc::AT_FDCWD as i64, notif.data.args[0])
+        (libc::AT_FDCWD as i64, notif.data.args[0], notif.data.args[1])
     };
 
     let rel_path = match read_path(notif, path_ptr, notif_fd) {
@@ -1012,14 +1012,16 @@ pub(crate) async fn handle_cow_exec(
     }
 
     // Rewrite the path argument to /proc/self/fd/N so the kernel execs the
-    // injected fd. execve replaces the whole address space on success, so
-    // (unlike chdir) writing past the original buffer is harmless — the
-    // only memory the kernel still reads is argv/envp, which sit elsewhere.
-    // Force-write past read-only protections (a .rodata exec path literal). No
-    // length guard: execve replaces the address space on success (see above), so
-    // a write past the original buffer is harmless.
-    let fd_path = format!("/proc/self/fd/{}\0", child_fd);
-    if write_child_mem_force(notif_fd, notif.id, notif.pid, path_ptr, fd_path.as_bytes()).is_err() {
+    // injected fd, relocating argv[0] when it aliases the path buffer (see
+    // rewrite_exec_path_to_fd). Force-writes past read-only protections (a
+    // .rodata exec path literal). No length guard: execve replaces the
+    // address space on success, so a write past the original buffer is
+    // harmless.
+    if crate::seccomp::notif::rewrite_exec_path_to_fd(
+        notif_fd, notif.id, notif.pid, path_ptr, argv_ptr, child_fd,
+    )
+    .is_err()
+    {
         return NotifAction::Errno(libc::EFAULT);
     }
 

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -1176,64 +1176,249 @@ fn write_child_mem_proc(pid: u32, addr: u64, data: &[u8]) -> Result<(), NotifErr
     Ok(())
 }
 
+/// Kernel limit on a single argv/envp string (MAX_ARG_STRLEN, 32 pages).
+/// A longer string makes execve fail with E2BIG, so no string that could
+/// matter to a successful exec exceeds this.
+const EXEC_MAX_ARG_STRLEN: usize = 32 * 4096;
+
+/// Upper bound on argv/envp entries scanned. The kernel's argument budget
+/// (pointers count toward it) keeps any exec that could succeed far below
+/// this; it only stops a runaway scan of a corrupt, unterminated array,
+/// whose exec the kernel would fail anyway.
+const EXEC_MAX_PTR_ENTRIES: usize = 1 << 20;
+
+/// Byte range `[start, end)` that the path rewrite will overwrite in the
+/// child, plus the relocation buffer being assembled for it.
+struct ExecRewritePlan {
+    /// Bytes to write at the path pointer: the fd path, then every
+    /// relocated string, all NUL-terminated.
+    buf: Vec<u8>,
+    /// Pointer-slot patches: (slot address in the argv/envp array,
+    /// relocated string address).
+    patches: Vec<(u64, u64)>,
+}
+
+/// Read a NULL-terminated pointer array (argv or envp) from child memory.
+/// Chunked at page boundaries because a single straddling read fails whole
+/// if any page is unmapped, and mappings are page-granular.
+fn read_exec_ptr_array(
+    read: &mut impl FnMut(u64, usize) -> Result<Vec<u8>, NotifError>,
+    base: u64,
+) -> Result<Vec<u64>, NotifError> {
+    if base == 0 {
+        return Ok(Vec::new());
+    }
+    const PAGE: u64 = 4096;
+    let mut ptrs = Vec::new();
+    let mut pending: Vec<u8> = Vec::new();
+    let mut cur = base;
+    loop {
+        let chunk = (PAGE - cur % PAGE) as usize;
+        let bytes = read(cur, chunk)?;
+        cur += chunk as u64;
+        pending.extend_from_slice(&bytes);
+        let mut consumed = 0;
+        while pending.len() - consumed >= 8 {
+            let ptr = u64::from_ne_bytes(pending[consumed..consumed + 8].try_into().unwrap());
+            consumed += 8;
+            if ptr == 0 {
+                return Ok(ptrs);
+            }
+            ptrs.push(ptr);
+            if ptrs.len() >= EXEC_MAX_PTR_ENTRIES {
+                return Ok(ptrs);
+            }
+        }
+        pending.drain(..consumed);
+    }
+}
+
+/// Read exactly `len` bytes starting at `addr`, chunked at page boundaries.
+fn read_exec_range(
+    read: &mut impl FnMut(u64, usize) -> Result<Vec<u8>, NotifError>,
+    addr: u64,
+    len: usize,
+) -> Result<Vec<u8>, NotifError> {
+    let mut out = Vec::with_capacity(len);
+    let mut cur = addr;
+    while out.len() < len {
+        let chunk = ((4096 - cur % 4096) as usize).min(len - out.len());
+        out.extend_from_slice(&read(cur, chunk)?);
+        cur += chunk as u64;
+    }
+    Ok(out)
+}
+
+/// Read a NUL-terminated string (NUL excluded) of at most
+/// `EXEC_MAX_ARG_STRLEN` bytes, chunked at page boundaries.
+fn read_exec_cstr(
+    read: &mut impl FnMut(u64, usize) -> Result<Vec<u8>, NotifError>,
+    addr: u64,
+) -> Result<Vec<u8>, NotifError> {
+    let mut out = Vec::new();
+    let mut cur = addr;
+    while out.len() < EXEC_MAX_ARG_STRLEN {
+        let chunk = ((4096 - cur % 4096) as usize).min(EXEC_MAX_ARG_STRLEN - out.len());
+        let bytes = read(cur, chunk)?;
+        if let Some(n) = bytes.iter().position(|&b| b == 0) {
+            out.extend_from_slice(&bytes[..n]);
+            return Ok(out);
+        }
+        out.extend_from_slice(&bytes);
+        cur += chunk as u64;
+    }
+    Err(NotifError::Supervisor(format!(
+        "exec arg string at {addr:#x} exceeds MAX_ARG_STRLEN"
+    )))
+}
+
+/// Compute the write buffer and pointer patches for rewriting an exec path
+/// to `fd_path` without corrupting any argv/envp string.
+///
+/// The rewrite overwrites `[path_ptr, path_ptr + buf.len())`. Any argv/envp
+/// string overlapping that window is appended to the buffer (preserving its
+/// original bytes, read before any write happens) and every pointer slot
+/// referencing it is patched to the relocated copy. Appending grows the
+/// window, which can pull further strings in, hence the fixpoint loop.
+///
+/// Overlap comes in two shapes:
+/// - a string starting inside the window (the common shell aliasing where
+///   path == argv[0]);
+/// - a string starting below `path_ptr` whose tail reaches it (the caller
+///   passed a path pointer into the middle of a longer string). Reaching
+///   means no NUL between its start and `path_ptr`; candidates are walked
+///   downward so each gap segment is read once, and once a NUL is seen every
+///   lower string is known to terminate before the window.
+///
+/// Fails if the argv/envp pointer arrays themselves fall inside the final
+/// window: the kernel reads those arrays after we return, and they cannot be
+/// moved because their addresses live in syscall registers.
+fn plan_exec_rewrite(
+    read: &mut impl FnMut(u64, usize) -> Result<Vec<u8>, NotifError>,
+    path_ptr: u64,
+    fd_path: &[u8],
+    argv_ptr: u64,
+    envp_ptr: u64,
+) -> Result<ExecRewritePlan, NotifError> {
+    let argv = read_exec_ptr_array(read, argv_ptr)?;
+    let envp = read_exec_ptr_array(read, envp_ptr)?;
+    let slots: Vec<(u64, u64)> = argv
+        .iter()
+        .enumerate()
+        .map(|(i, &p)| (argv_ptr + 8 * i as u64, p))
+        .chain(envp.iter().enumerate().map(|(i, &p)| (envp_ptr + 8 * i as u64, p)))
+        .collect();
+
+    let mut buf = fd_path.to_vec();
+    let mut relocated: std::collections::BTreeMap<u64, u64> = std::collections::BTreeMap::new();
+    let mut relocate = |buf: &mut Vec<u8>,
+                        relocated: &mut std::collections::BTreeMap<u64, u64>,
+                        read: &mut dyn FnMut(u64, usize) -> Result<Vec<u8>, NotifError>,
+                        ptr: u64|
+     -> Result<(), NotifError> {
+        let s = read_exec_cstr(&mut |a, l| read(a, l), ptr)?;
+        relocated.insert(ptr, path_ptr + buf.len() as u64);
+        buf.extend_from_slice(&s);
+        buf.push(0);
+        Ok(())
+    };
+
+    // Strings whose tail reaches path_ptr from below. Anything further than
+    // MAX_ARG_STRLEN below cannot reach it within a string the kernel would
+    // accept.
+    let mut below: Vec<u64> = slots
+        .iter()
+        .map(|&(_, p)| p)
+        .filter(|&p| p < path_ptr && path_ptr - p < EXEC_MAX_ARG_STRLEN as u64)
+        .collect();
+    below.sort_unstable();
+    below.dedup();
+    let mut nul_free_from = path_ptr;
+    for &p in below.iter().rev() {
+        let seg = read_exec_range(read, p, (nul_free_from - p) as usize)?;
+        if seg.contains(&0) {
+            break;
+        }
+        relocate(&mut buf, &mut relocated, read, p)?;
+        nul_free_from = p;
+    }
+
+    // Strings starting inside the (growing) window.
+    loop {
+        let end = path_ptr + buf.len() as u64;
+        let mut grew = false;
+        for &(_, p) in &slots {
+            if !relocated.contains_key(&p) && p >= path_ptr && p < end {
+                relocate(&mut buf, &mut relocated, read, p)?;
+                grew = true;
+            }
+        }
+        if !grew {
+            break;
+        }
+    }
+
+    let end = path_ptr + buf.len() as u64;
+    for (base, n) in [(argv_ptr, argv.len()), (envp_ptr, envp.len())] {
+        if base != 0 && base < end && base + 8 * (n as u64 + 1) > path_ptr {
+            return Err(NotifError::Supervisor(
+                "execve argv/envp pointer array overlaps the path rewrite window".into(),
+            ));
+        }
+    }
+
+    let patches = slots
+        .iter()
+        .filter_map(|&(slot, p)| relocated.get(&p).map(|&np| (slot, np)))
+        .collect();
+    Ok(ExecRewritePlan { buf, patches })
+}
+
 /// Rewrite an execve/execveat path argument to `/proc/self/fd/<child_fd>`,
-/// preserving argv[0].
+/// preserving every argv/envp string the rewrite would clobber.
 ///
-/// Shells and `execvp`-style callers commonly pass the same buffer as both
-/// the exec path and argv[0] (dash execs `./m` with path == argv[0]).
-/// Rewriting the path in place would then also rewrite argv[0], breaking
-/// multicall binaries (busybox, uutils coreutils) that dispatch on
-/// basename(argv[0]) — they would see basename "N" of the fd path. When
-/// argv[0] points into the bytes the rewrite clobbers, the original argv[0]
-/// string is relocated to directly after the fd path and the argv[0] pointer
-/// slot is patched to the relocated copy.
+/// A user-notif supervisor cannot change syscall registers, so redirecting
+/// an exec to an injected fd means overwriting the child's path buffer in
+/// place. Shells and `execvp`-style callers commonly pass the same buffer as
+/// both the exec path and argv[0] (dash execs `./m` with path == argv[0]),
+/// and libcs may pack other argv/envp strings right after it; a blind
+/// overwrite corrupts whatever the fd path lands on. Multicall binaries
+/// (busybox, uutils coreutils) then dispatch on basename(argv[0]) = "N" and
+/// fail. [`plan_exec_rewrite`] relocates every affected string past the fd
+/// path and patches the pointer slots, so the exec'd program sees its
+/// original arguments for any string layout.
 ///
-/// Writing past the original path buffer (both the fd path itself and the
-/// relocated argv[0]) is harmless for the same reason as the plain rewrite:
-/// execve replaces the whole address space on success, and the kernel copies
-/// the path and argv/envp strings out of the old address space only after
-/// this returns Continue, before anything else runs in the child.
+/// Writing past the original path buffer is safe because execve replaces the
+/// whole address space on success, and the kernel copies the path and
+/// argv/envp strings out of the old address space only after this returns
+/// Continue, before anything else runs in the child. If the exec fails
+/// instead (e.g. the injected fd is not executable), the child keeps running
+/// with the rewritten buffer and patched pointers; argv is preserved so the
+/// damage is confined to the path string, same as before this helper.
 ///
-/// `argv_ptr` is the syscall's argv argument (args[1] for execve, args[2]
-/// for execveat); 0 (NULL argv) skips the preservation and only rewrites
-/// the path.
+/// Pointer slots are 8 bytes: the BPF filter kills non-native-arch syscalls
+/// before they reach the notif fd, and every supported native arch is
+/// 64-bit.
+///
+/// `argv_ptr`/`envp_ptr` are the syscall's argv/envp arguments (args[1]/[2]
+/// for execve, args[2]/[3] for execveat); 0 (NULL) arrays are skipped.
 pub(crate) fn rewrite_exec_path_to_fd(
     notif_fd: RawFd,
     id: u64,
     pid: u32,
     path_ptr: u64,
     argv_ptr: u64,
+    envp_ptr: u64,
     child_fd: i32,
 ) -> Result<(), NotifError> {
     let fd_path = format!("/proc/self/fd/{}\0", child_fd);
-    let clobber_end = path_ptr + fd_path.len() as u64;
-
-    // Read the argv[0] pointer slot before deciding whether the rewrite
-    // clobbers the string it points at.
-    let argv0_ptr = if argv_ptr != 0 {
-        read_child_mem(notif_fd, id, pid, argv_ptr, 8)
-            .ok()
-            .and_then(|b| <[u8; 8]>::try_from(b).ok())
-            .map(u64::from_ne_bytes)
-    } else {
-        None
-    };
-
-    match argv0_ptr {
-        Some(p) if p >= path_ptr && p < clobber_end => {
-            // argv[0] aliases the path buffer: save it first, then write
-            // [fd_path NUL][argv0 NUL] and point the argv[0] slot at the copy.
-            let orig = read_child_cstr(notif_fd, id, pid, p, 4096).unwrap_or_default();
-            let mut buf = Vec::with_capacity(fd_path.len() + orig.len() + 1);
-            buf.extend_from_slice(fd_path.as_bytes());
-            buf.extend_from_slice(orig.as_bytes());
-            buf.push(0);
-            write_child_mem_force(notif_fd, id, pid, path_ptr, &buf)?;
-            let relocated = path_ptr + fd_path.len() as u64;
-            write_child_mem_force(notif_fd, id, pid, argv_ptr, &relocated.to_ne_bytes())
-        }
-        _ => write_child_mem_force(notif_fd, id, pid, path_ptr, fd_path.as_bytes()),
+    let mut read = |addr: u64, len: usize| read_child_mem(notif_fd, id, pid, addr, len);
+    let plan = plan_exec_rewrite(&mut read, path_ptr, fd_path.as_bytes(), argv_ptr, envp_ptr)?;
+    write_child_mem_force(notif_fd, id, pid, path_ptr, &plan.buf)?;
+    for (slot, new_ptr) in plan.patches {
+        write_child_mem_force(notif_fd, id, pid, slot, &new_ptr.to_ne_bytes())?;
     }
+    Ok(())
 }
 
 // ============================================================
@@ -2110,6 +2295,157 @@ mod tests {
 
     fn gettid() -> u32 {
         (unsafe { libc::syscall(libc::SYS_gettid) }) as u32
+    }
+
+    // ---- plan_exec_rewrite ----
+
+    /// Fake child memory: whole zero-filled pages at FAKE_BASE, so the
+    /// page-chunked readers never run off a mapped page mid-scan and a
+    /// zero word naturally terminates a pointer array.
+    const FAKE_BASE: u64 = 0x10000;
+    const FD: &[u8] = b"/proc/self/fd/3\0"; // 16 bytes
+
+    fn put(mem: &mut [u8], addr: u64, bytes: &[u8]) {
+        let off = (addr - FAKE_BASE) as usize;
+        mem[off..off + bytes.len()].copy_from_slice(bytes);
+    }
+
+    fn put_ptrs(mem: &mut [u8], addr: u64, ptrs: &[u64]) {
+        for (i, &p) in ptrs.iter().enumerate() {
+            put(mem, addr + 8 * i as u64, &p.to_ne_bytes());
+        }
+    }
+
+    fn plan(
+        mem: &[u8],
+        path_ptr: u64,
+        argv_ptr: u64,
+        envp_ptr: u64,
+    ) -> Result<ExecRewritePlan, NotifError> {
+        let mut read = |addr: u64, len: usize| {
+            let off = addr
+                .checked_sub(FAKE_BASE)
+                .ok_or_else(|| NotifError::Supervisor("read below fake memory".into()))?
+                as usize;
+            mem.get(off..off + len)
+                .map(|s| s.to_vec())
+                .ok_or_else(|| NotifError::Supervisor("read past fake memory".into()))
+        };
+        plan_exec_rewrite(&mut read, path_ptr, FD, argv_ptr, envp_ptr)
+    }
+
+    #[test]
+    fn exec_rewrite_plain_when_no_string_overlaps() {
+        let mut mem = vec![0u8; 4096];
+        put(&mut mem, FAKE_BASE, b"./m\0");
+        put(&mut mem, FAKE_BASE + 0x200, b"prog\0");
+        put_ptrs(&mut mem, FAKE_BASE + 0x800, &[FAKE_BASE + 0x200]);
+        let p = plan(&mem, FAKE_BASE, FAKE_BASE + 0x800, 0).unwrap();
+        assert_eq!(p.buf, FD);
+        assert!(p.patches.is_empty());
+    }
+
+    #[test]
+    fn exec_rewrite_relocates_aliased_argv0() {
+        // The common shell case: execve path and argv[0] are the same buffer.
+        let mut mem = vec![0u8; 4096];
+        put(&mut mem, FAKE_BASE, b"./m\0");
+        put_ptrs(&mut mem, FAKE_BASE + 0x800, &[FAKE_BASE]);
+        let p = plan(&mem, FAKE_BASE, FAKE_BASE + 0x800, 0).unwrap();
+        assert_eq!(p.buf, [FD, b"./m\0".as_slice()].concat());
+        assert_eq!(p.patches, vec![(FAKE_BASE + 0x800, FAKE_BASE + 16)]);
+    }
+
+    #[test]
+    fn exec_rewrite_relocates_packed_argv1() {
+        // argv[1] sits right after the path string, inside the fd-path
+        // window; both strings must survive.
+        let mut mem = vec![0u8; 4096];
+        put(&mut mem, FAKE_BASE, b"./echo\0EXEC_OK\0");
+        put_ptrs(&mut mem, FAKE_BASE + 0x800, &[FAKE_BASE, FAKE_BASE + 7]);
+        let p = plan(&mem, FAKE_BASE, FAKE_BASE + 0x800, 0).unwrap();
+        assert_eq!(p.buf, [FD, b"./echo\0EXEC_OK\0".as_slice()].concat());
+        assert_eq!(
+            p.patches,
+            vec![
+                (FAKE_BASE + 0x800, FAKE_BASE + 16),
+                (FAKE_BASE + 0x808, FAKE_BASE + 23),
+            ]
+        );
+    }
+
+    #[test]
+    fn exec_rewrite_relocates_string_reaching_window_from_below() {
+        // The path pointer aims into the tail of argv[0] ("echo" inside
+        // "/bin/echo"): the whole string must be relocated.
+        let mut mem = vec![0u8; 4096];
+        put(&mut mem, FAKE_BASE, b"/bin/echo\0");
+        put_ptrs(&mut mem, FAKE_BASE + 0x800, &[FAKE_BASE]);
+        let p = plan(&mem, FAKE_BASE + 5, FAKE_BASE + 0x800, 0).unwrap();
+        assert_eq!(p.buf, [FD, b"/bin/echo\0".as_slice()].concat());
+        assert_eq!(p.patches, vec![(FAKE_BASE + 0x800, FAKE_BASE + 5 + 16)]);
+    }
+
+    #[test]
+    fn exec_rewrite_skips_terminated_string_below_window() {
+        let mut mem = vec![0u8; 4096];
+        put(&mut mem, FAKE_BASE, b"a\0");
+        put(&mut mem, FAKE_BASE + 8, b"./m\0");
+        put_ptrs(&mut mem, FAKE_BASE + 0x800, &[FAKE_BASE]);
+        let p = plan(&mem, FAKE_BASE + 8, FAKE_BASE + 0x800, 0).unwrap();
+        assert_eq!(p.buf, FD);
+        assert!(p.patches.is_empty());
+    }
+
+    #[test]
+    fn exec_rewrite_relocates_envp_string() {
+        let mut mem = vec![0u8; 4096];
+        put(&mut mem, FAKE_BASE, b"./m\0K=V\0");
+        put(&mut mem, FAKE_BASE + 0x200, b"prog\0");
+        put_ptrs(&mut mem, FAKE_BASE + 0x800, &[FAKE_BASE + 0x200]);
+        put_ptrs(&mut mem, FAKE_BASE + 0x900, &[FAKE_BASE + 4]);
+        let p = plan(&mem, FAKE_BASE, FAKE_BASE + 0x800, FAKE_BASE + 0x900).unwrap();
+        assert_eq!(p.buf, [FD, b"K=V\0".as_slice()].concat());
+        assert_eq!(p.patches, vec![(FAKE_BASE + 0x900, FAKE_BASE + 16)]);
+    }
+
+    #[test]
+    fn exec_rewrite_window_growth_pulls_in_later_string() {
+        // argv[1] starts past the fd path but inside the window once the
+        // relocated argv[0] extends it.
+        let mut mem = vec![0u8; 4096];
+        put(&mut mem, FAKE_BASE, b"./m\0");
+        put(&mut mem, FAKE_BASE + 18, b"Z\0");
+        put_ptrs(&mut mem, FAKE_BASE + 0x800, &[FAKE_BASE, FAKE_BASE + 18]);
+        let p = plan(&mem, FAKE_BASE, FAKE_BASE + 0x800, 0).unwrap();
+        assert_eq!(p.buf, [FD, b"./m\0".as_slice(), b"Z\0".as_slice()].concat());
+        assert_eq!(
+            p.patches,
+            vec![
+                (FAKE_BASE + 0x800, FAKE_BASE + 16),
+                (FAKE_BASE + 0x808, FAKE_BASE + 20),
+            ]
+        );
+    }
+
+    #[test]
+    fn exec_rewrite_rejects_pointer_array_inside_window() {
+        // The arrays cannot be moved (their addresses live in registers), so
+        // a layout where the rewrite would smash them must fail closed.
+        let mut mem = vec![0u8; 4096];
+        put(&mut mem, FAKE_BASE, b"./m\0");
+        put_ptrs(&mut mem, FAKE_BASE + 8, &[FAKE_BASE + 0x200]);
+        put(&mut mem, FAKE_BASE + 0x200, b"prog\0");
+        assert!(plan(&mem, FAKE_BASE, FAKE_BASE + 8, 0).is_err());
+    }
+
+    #[test]
+    fn exec_rewrite_null_arrays() {
+        let mut mem = vec![0u8; 4096];
+        put(&mut mem, FAKE_BASE, b"./m\0");
+        let p = plan(&mem, FAKE_BASE, 0, 0).unwrap();
+        assert_eq!(p.buf, FD);
+        assert!(p.patches.is_empty());
     }
 
     #[test]

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -1311,7 +1311,7 @@ fn plan_exec_rewrite(
 
     let mut buf = fd_path.to_vec();
     let mut relocated: std::collections::BTreeMap<u64, u64> = std::collections::BTreeMap::new();
-    let mut relocate = |buf: &mut Vec<u8>,
+    let relocate = |buf: &mut Vec<u8>,
                         relocated: &mut std::collections::BTreeMap<u64, u64>,
                         read: &mut dyn FnMut(u64, usize) -> Result<Vec<u8>, NotifError>,
                         ptr: u64|

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -1176,6 +1176,66 @@ fn write_child_mem_proc(pid: u32, addr: u64, data: &[u8]) -> Result<(), NotifErr
     Ok(())
 }
 
+/// Rewrite an execve/execveat path argument to `/proc/self/fd/<child_fd>`,
+/// preserving argv[0].
+///
+/// Shells and `execvp`-style callers commonly pass the same buffer as both
+/// the exec path and argv[0] (dash execs `./m` with path == argv[0]).
+/// Rewriting the path in place would then also rewrite argv[0], breaking
+/// multicall binaries (busybox, uutils coreutils) that dispatch on
+/// basename(argv[0]) — they would see basename "N" of the fd path. When
+/// argv[0] points into the bytes the rewrite clobbers, the original argv[0]
+/// string is relocated to directly after the fd path and the argv[0] pointer
+/// slot is patched to the relocated copy.
+///
+/// Writing past the original path buffer (both the fd path itself and the
+/// relocated argv[0]) is harmless for the same reason as the plain rewrite:
+/// execve replaces the whole address space on success, and the kernel copies
+/// the path and argv/envp strings out of the old address space only after
+/// this returns Continue, before anything else runs in the child.
+///
+/// `argv_ptr` is the syscall's argv argument (args[1] for execve, args[2]
+/// for execveat); 0 (NULL argv) skips the preservation and only rewrites
+/// the path.
+pub(crate) fn rewrite_exec_path_to_fd(
+    notif_fd: RawFd,
+    id: u64,
+    pid: u32,
+    path_ptr: u64,
+    argv_ptr: u64,
+    child_fd: i32,
+) -> Result<(), NotifError> {
+    let fd_path = format!("/proc/self/fd/{}\0", child_fd);
+    let clobber_end = path_ptr + fd_path.len() as u64;
+
+    // Read the argv[0] pointer slot before deciding whether the rewrite
+    // clobbers the string it points at.
+    let argv0_ptr = if argv_ptr != 0 {
+        read_child_mem(notif_fd, id, pid, argv_ptr, 8)
+            .ok()
+            .and_then(|b| <[u8; 8]>::try_from(b).ok())
+            .map(u64::from_ne_bytes)
+    } else {
+        None
+    };
+
+    match argv0_ptr {
+        Some(p) if p >= path_ptr && p < clobber_end => {
+            // argv[0] aliases the path buffer: save it first, then write
+            // [fd_path NUL][argv0 NUL] and point the argv[0] slot at the copy.
+            let orig = read_child_cstr(notif_fd, id, pid, p, 4096).unwrap_or_default();
+            let mut buf = Vec::with_capacity(fd_path.len() + orig.len() + 1);
+            buf.extend_from_slice(fd_path.as_bytes());
+            buf.extend_from_slice(orig.as_bytes());
+            buf.push(0);
+            write_child_mem_force(notif_fd, id, pid, path_ptr, &buf)?;
+            let relocated = path_ptr + fd_path.len() as u64;
+            write_child_mem_force(notif_fd, id, pid, argv_ptr, &relocated.to_ne_bytes())
+        }
+        _ => write_child_mem_force(notif_fd, id, pid, path_ptr, fd_path.as_bytes()),
+    }
+}
+
 // ============================================================
 // Response dispatch
 // ============================================================

--- a/crates/sandlock-core/tests/integration/test_chroot.rs
+++ b/crates/sandlock-core/tests/integration/test_chroot.rs
@@ -24,8 +24,17 @@ fn minimal_exec_policy(rootfs: &PathBuf) -> sandlock_core::SandboxBuilder {
 }
 
 fn temp_dir(name: &str) -> PathBuf {
-    let dir =
-        std::env::temp_dir().join(format!("sandlock-test-chroot-{}-{}", name, std::process::id()));
+    // Prefer cargo's per-test-binary tmp dir (under `target/`, the same
+    // filesystem as the compiled rootfs-helper) so build_test_rootfs can
+    // hard-link the helper into the rootfs instead of copying it. A
+    // cross-filesystem temp such as /tmp (often tmpfs) forces the fs::copy
+    // fallback, whose writable fd can be inherited by a concurrent fork+exec in
+    // another parallel test and leave the helper briefly open for write, making
+    // the eventual execve fail with ETXTBSY (Text file busy).
+    let base = option_env!("CARGO_TARGET_TMPDIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir);
+    let dir = base.join(format!("sandlock-test-chroot-{}-{}", name, std::process::id()));
     let _ = fs::create_dir_all(&dir);
     dir
 }

--- a/crates/sandlock-core/tests/integration/test_cow.rs
+++ b/crates/sandlock-core/tests/integration/test_cow.rs
@@ -431,7 +431,7 @@ async fn test_seccomp_cow_statx_created_file() {
         "buf = ctypes.create_string_buffer(256)\n",
         "AT_FDCWD = -100\n",
         "STATX_BASIC_STATS = 0x7ff\n",
-        "nr = 291 if platform.machine() == 'aarch64' else 332\n",
+        "nr = 291 if platform.machine() in ('aarch64', 'riscv64') else 332\n",
         "ret = libc.syscall(nr, AT_FDCWD, b'created.txt', 0, STATX_BASIC_STATS, buf)\n",
         "err = ctypes.get_errno()\n",
         "open('{out}', 'w').write('OK' if ret == 0 else f'FAIL:errno={{err}}')\n",

--- a/crates/sandlock-core/tests/integration/test_cow.rs
+++ b/crates/sandlock-core/tests/integration/test_cow.rs
@@ -501,3 +501,54 @@ async fn test_seccomp_cow_exec_created_file() {
 
     let _ = fs::remove_dir_all(&workdir);
 }
+
+/// Exec a COW-created binary with the path and argv strings tightly packed
+/// in one buffer: the /proc/self/fd/N rewrite window covers argv[1] too, so
+/// the supervisor must relocate every clobbered string, not only argv[0].
+/// Shell-driven layouts happen to keep argv[1] out of the window; this
+/// crafts the packed layout directly with execve(2) via ctypes.
+#[tokio::test]
+async fn test_seccomp_cow_exec_packed_argv_relocation() {
+    let workdir = temp_dir("seccomp-exec-packed");
+    let helper = helper_binary();
+    let helper_dir = helper.parent().unwrap().to_path_buf();
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr").fs_read("/lib").fs_read_if_exists("/lib64").fs_read("/bin").fs_read("/etc")
+        .fs_read("/proc").fs_read("/dev")
+        .fs_read(&helper_dir)
+        .fs_write(&workdir)
+        .workdir(&workdir)
+        .cwd(&workdir)
+        .on_exit(BranchAction::Abort)
+        .build()
+        .unwrap();
+
+    let script = format!(concat!(
+        "import ctypes, shutil, os\n",
+        "shutil.copy('{helper}', 'echo')\n",
+        "os.chmod('echo', 0o755)\n",
+        "libc = ctypes.CDLL(None, use_errno=True)\n",
+        "buf = ctypes.create_string_buffer(b'./echo\\0EXEC_OK_PACKED\\0')\n",
+        "base = ctypes.addressof(buf)\n",
+        "argv = (ctypes.c_void_p * 3)(base, base + 7, None)\n",
+        "envp = (ctypes.c_void_p * 1)(None)\n",
+        "libc.execve(ctypes.c_void_p(base), argv, envp)\n",
+        "raise SystemExit('execve failed errno=%d' % ctypes.get_errno())\n",
+    ), helper = helper.display());
+
+    let result = policy.clone().with_name("test").run(&["python3", "-c", &script]).await.unwrap();
+
+    assert!(
+        result.success(),
+        "packed-argv exec should succeed, exit={:?}, stderr={}",
+        result.code(), result.stderr_str().unwrap_or("")
+    );
+    assert!(
+        result.stdout_str().unwrap_or("").contains("EXEC_OK_PACKED"),
+        "argv[1] must survive the path rewrite, stdout={:?}",
+        result.stdout_str()
+    );
+
+    let _ = fs::remove_dir_all(&workdir);
+}

--- a/crates/sandlock-core/tests/integration/test_cow.rs
+++ b/crates/sandlock-core/tests/integration/test_cow.rs
@@ -9,6 +9,14 @@ fn temp_dir(name: &str) -> PathBuf {
     dir
 }
 
+/// Path to the static rootfs-helper binary (compiled by build.rs).
+fn helper_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/rootfs-helper")
+        .canonicalize()
+        .expect("rootfs-helper not found — build.rs should have compiled it")
+}
+
 // ============================================================
 // Seccomp-based COW tests (workdir set)
 // ============================================================
@@ -453,10 +461,13 @@ async fn test_seccomp_cow_statx_created_file() {
 #[tokio::test]
 async fn test_seccomp_cow_exec_created_file() {
     let workdir = temp_dir("seccomp-exec");
+    let helper = helper_binary();
+    let helper_dir = helper.parent().unwrap().to_path_buf();
 
     let policy = Sandbox::builder()
         .fs_read("/usr").fs_read("/lib").fs_read_if_exists("/lib64").fs_read("/bin").fs_read("/etc")
         .fs_read("/proc").fs_read("/dev")
+        .fs_read(&helper_dir)
         .fs_write(&workdir)
         .workdir(&workdir)
         .cwd(&workdir)
@@ -464,14 +475,22 @@ async fn test_seccomp_cow_exec_created_file() {
         .build()
         .unwrap();
 
-    // Copy a real binary into the COW workdir (lands in upper), then exec it.
+    // Copy our own static rootfs-helper into the COW workdir (lands in
+    // upper), then exec it. The helper (not a system binary like /bin/echo,
+    // whose behavior varies across hosts: Ubuntu rust-coreutils ships a
+    // multicall binary) is itself busybox-style: invoked as `./echo` it
+    // dispatches on basename(argv[0]). That also catches the exec redirect
+    // clobbering argv[0]: shells pass the same buffer as execve path and
+    // argv[0], so rewriting the path to /proc/self/fd/N must relocate
+    // argv[0], or the helper sees basename "N" and exits 127.
+    let cmd = format!("cp {} echo && ./echo EXEC_OK", helper.display());
     let result = policy.clone().with_name("test").run(&[
-        "sh", "-c", "cp /bin/echo m && ./m EXEC_OK",
+        "sh", "-c", &cmd,
     ]).await.unwrap();
 
     assert!(
         result.success(),
-        "exec of COW-created binary should succeed, exit={:?}, stderr={}",
+        "exec of COW-created binary should succeed (argv[0] preserved), exit={:?}, stderr={}",
         result.code(), result.stderr_str().unwrap_or("")
     );
     assert!(

--- a/crates/sandlock-core/tests/integration/test_handlers.rs
+++ b/crates/sandlock-core/tests/integration/test_handlers.rs
@@ -677,11 +677,15 @@ async fn run_with_handlers_rejects_handler_on_default_blocklist_syscall() {
 async fn inject_bytes_delivers_synthetic_content_to_guest() {
     let policy = base_policy().build().unwrap();
     let out = temp_out("inject-bytes-content");
-    // Sentinel path: never created on the host. `cat` opens it (intercepted),
-    // the handler injects content, and `cat` writes that to `out`.
+    // Sentinel path: never created on the host. The shell opens it as a
+    // stdin redirect (intercepted), the handler injects content, and `cat`
+    // copies that to `out`. Redirection (not a `cat` path operand) keeps the
+    // open a bare openat: multicall coreutils `cat` (Ubuntu rust-coreutils)
+    // statx-es a path operand first and would fail on the host-nonexistent
+    // path before ever reaching the intercepted openat.
     let virt = "/tmp/sandlock-virtual-inject-XYZ";
     let content = "INJECTED_SECRET_42\n";
-    let cmd = format!("cat {virt} > {}", out.display());
+    let cmd = format!("cat < {virt} > {}", out.display());
 
     let handler = |cx: &HandlerCtx| {
         // openat(2): args[1] is the path. Read it synchronously, then move only

--- a/crates/sandlock-ffi/tests/c/handler_smoke.c
+++ b/crates/sandlock-ffi/tests/c/handler_smoke.c
@@ -123,7 +123,11 @@ static int check_policy_fn_user_data_drop(void) {
     b = sandlock_sandbox_builder_fs_read(b, "/usr");
     b = sandlock_sandbox_builder_fs_read(b, "/bin");
     b = sandlock_sandbox_builder_fs_read(b, "/lib");
-    b = sandlock_sandbox_builder_fs_read(b, "/lib64");
+    /* /lib64 does not exist on all arches (e.g. riscv64); granting a
+     * nonexistent path makes the run fail. */
+    if (access("/lib64", F_OK) == 0) {
+        b = sandlock_sandbox_builder_fs_read(b, "/lib64");
+    }
     b = sandlock_sandbox_builder_fs_read(b, "/etc");
     b = sandlock_sandbox_builder_fs_read(b, "/proc");
     b = sandlock_sandbox_builder_fs_read(b, "/dev");
@@ -164,7 +168,11 @@ int main(void) {
     b = sandlock_sandbox_builder_fs_read(b, "/usr");
     b = sandlock_sandbox_builder_fs_read(b, "/bin");
     b = sandlock_sandbox_builder_fs_read(b, "/lib");
-    b = sandlock_sandbox_builder_fs_read(b, "/lib64");
+    /* /lib64 does not exist on all arches (e.g. riscv64); granting a
+     * nonexistent path makes the run fail. */
+    if (access("/lib64", F_OK) == 0) {
+        b = sandlock_sandbox_builder_fs_read(b, "/lib64");
+    }
     b = sandlock_sandbox_builder_fs_read(b, "/etc");
     b = sandlock_sandbox_builder_fs_read(b, "/proc");
     b = sandlock_sandbox_builder_fs_read(b, "/dev");

--- a/crates/sandlock-ffi/tests/handler_smoke.rs
+++ b/crates/sandlock-ffi/tests/handler_smoke.rs
@@ -487,9 +487,15 @@ fn run_with_handlers_intercepts_getpid() {
         let p = CString::new("/lib").unwrap();
         sandlock_sandbox_builder_fs_read(builder, p.as_ptr())
     };
-    let builder = unsafe {
-        let p = CString::new("/lib64").unwrap();
-        sandlock_sandbox_builder_fs_read(builder, p.as_ptr())
+    // `/lib64` only when the host has it (RISC-V glibc / musl put the loader
+    // under `/lib` and have no `/lib64`); fs_read is a mandatory grant.
+    let builder = if std::path::Path::new("/lib64").exists() {
+        unsafe {
+            let p = CString::new("/lib64").unwrap();
+            sandlock_sandbox_builder_fs_read(builder, p.as_ptr())
+        }
+    } else {
+        builder
     };
     let builder = unsafe {
         let p = CString::new("/etc").unwrap();
@@ -1437,9 +1443,15 @@ fn run_with_handlers_empty_registrations_runs_normally() {
         let p = CString::new("/lib").unwrap();
         sandlock_sandbox_builder_fs_read(builder, p.as_ptr())
     };
-    let builder = unsafe {
-        let p = CString::new("/lib64").unwrap();
-        sandlock_sandbox_builder_fs_read(builder, p.as_ptr())
+    // `/lib64` only when the host has it (RISC-V glibc / musl put the loader
+    // under `/lib` and have no `/lib64`); fs_read is a mandatory grant.
+    let builder = if std::path::Path::new("/lib64").exists() {
+        unsafe {
+            let p = CString::new("/lib64").unwrap();
+            sandlock_sandbox_builder_fs_read(builder, p.as_ptr())
+        }
+    } else {
+        builder
     };
     let builder = unsafe {
         let p = CString::new("/etc").unwrap();
@@ -1610,9 +1622,15 @@ fn run_with_handlers_two_handlers_each_fires_for_own_syscall() {
         let p = CString::new("/lib").unwrap();
         sandlock_sandbox_builder_fs_read(builder, p.as_ptr())
     };
-    let builder = unsafe {
-        let p = CString::new("/lib64").unwrap();
-        sandlock_sandbox_builder_fs_read(builder, p.as_ptr())
+    // `/lib64` only when the host has it (RISC-V glibc / musl put the loader
+    // under `/lib` and have no `/lib64`); fs_read is a mandatory grant.
+    let builder = if std::path::Path::new("/lib64").exists() {
+        unsafe {
+            let p = CString::new("/lib64").unwrap();
+            sandlock_sandbox_builder_fs_read(builder, p.as_ptr())
+        }
+    } else {
+        builder
     };
     let builder = unsafe {
         let p = CString::new("/etc").unwrap();
@@ -1774,9 +1792,15 @@ fn mem_read_cstr_reads_path_from_intercepted_openat() {
         let p = CString::new("/lib").unwrap();
         sandlock_sandbox_builder_fs_read(builder, p.as_ptr())
     };
-    let builder = unsafe {
-        let p = CString::new("/lib64").unwrap();
-        sandlock_sandbox_builder_fs_read(builder, p.as_ptr())
+    // `/lib64` only when the host has it (RISC-V glibc / musl put the loader
+    // under `/lib` and have no `/lib64`); fs_read is a mandatory grant.
+    let builder = if std::path::Path::new("/lib64").exists() {
+        unsafe {
+            let p = CString::new("/lib64").unwrap();
+            sandlock_sandbox_builder_fs_read(builder, p.as_ptr())
+        }
+    } else {
+        builder
     };
     let builder = unsafe {
         let p = CString::new("/etc").unwrap();

--- a/crates/sandlock-ffi/tests/popen.rs
+++ b/crates/sandlock-ffi/tests/popen.rs
@@ -25,6 +25,8 @@ const NULL: u32 = 2;
 fn build_policy() -> *mut sandlock_sandbox_t {
     let mut b = sandlock_sandbox_builder_new();
     for p in ["/usr", "/lib", "/lib64", "/bin", "/etc", "/proc", "/dev"] {
+        // `/lib64` is absent on RISC-V glibc / musl; fs_read is mandatory.
+        if p == "/lib64" && !std::path::Path::new("/lib64").exists() { continue; }
         let c = CString::new(p).unwrap();
         b = unsafe { sandlock_sandbox_builder_fs_read(b, c.as_ptr()) };
     }

--- a/crates/sandlock-ffi/tests/restore.rs
+++ b/crates/sandlock-ffi/tests/restore.rs
@@ -61,6 +61,8 @@ void _start(void){{
 fn build_policy(tmp: &str) -> *mut sandlock_sandbox_t {
     let mut b = sandlock_sandbox_builder_new();
     for p in ["/usr", "/lib", "/lib64", "/bin", "/etc", "/proc", "/dev", tmp] {
+        // `/lib64` is absent on RISC-V glibc / musl; fs_read is mandatory.
+        if p == "/lib64" && !std::path::Path::new("/lib64").exists() { continue; }
         let c = CString::new(p).unwrap();
         b = unsafe { sandlock_sandbox_builder_fs_read(b, c.as_ptr()) };
     }


### PR DESCRIPTION
Fixes all of the RISC-V test failures, including one product bug that the RISC-V environment exposed but that exists on every architecture. Full suites verified on x86-64 (lib, integration, spec, ffi handler and C smoke tests); the argv[0] clobber reproduces on x86-64 and is regression-tested there.

## 1. `/lib64` as an optional read grant (586b5cd, 3b98496)

RISC-V glibc and musl put the dynamic loader under `/lib` and have no `/lib64` at all, so a mandatory `/lib64` read grant aborts confinement. The builder-based tests already used `fs_read_if_exists`; the CLI, profile, and ffi layers had no equivalent:

- `cli_test.rs`: `args_for_host()` drops `-r /lib64` when absent.
- `profile_integration.rs`: `read_list()` omits `/lib64` from the TOML when absent.
- ffi `popen.rs`/`restore.rs`/`handler_smoke.rs`: skip the `fs_read` when absent.
- `examples/openat_audit.rs`: `fs_read` -> `fs_read_if_exists`.
- `tests/c/handler_smoke.c` (the pure-C smoke test) granted `fs_read("/lib64")` unconditionally, so `sandlock_run_with_handlers` returned NULL on riscv64. It now grants `/lib64` only when `access(2)` finds it.

On x86-64 (where `/lib64` exists) the resulting arguments and policies are unchanged.

## 2. statx syscall number + rootfs-helper ETXTBSY (8275206)

- `test_seccomp_cow_statx_created_file` hardcoded the x86-64 `statx` number (332) with only an aarch64 (291) special case; RISC-V uses the asm-generic table where `statx` is also 291, so the raw syscall returned ENOSYS. Use the file's existing `machine() in ('aarch64', 'riscv64')` convention.
- `test_chroot_*` failed with ETXTBSY when `build_test_rootfs` fell back from `hard_link` to `fs::copy` (temp rootfs on a different filesystem than the compiled helper): the copy's writable fd can be inherited by a concurrent fork+exec in a parallel test, leaving the helper open for write when it is `execve`'d. Place the temp rootfs under `CARGO_TARGET_TMPDIR` (same filesystem as the helper) so the atomic `hard_link` path is taken.

## 3. Exec fd-redirect clobbered argv[0]: product bug on all arches (73c4cf2, be654d7, 7d18c24)

The `coreutils: unknown program '3'` failure was diagnosed on RISC-V hardware: Ubuntu rust-coreutils ships `/bin/echo` and `/bin/cat` as uutils **multicall** binaries that dispatch on `basename(argv[0])`.

The COW and chroot exec handlers redirect an exec by rewriting the child's path buffer to `/proc/self/fd/N` (a user-notif supervisor cannot change syscall registers). Shells pass the **same buffer** as the execve path and `argv[0]` (dash execs `./m` with `path == argv[0]`), so the rewrite silently clobbered `argv[0]` on every architecture. GNU echo ignores `argv[0]` and hid the bug; a multicall binary dispatches on it and fails with basename `"3"`. Reproduced on x86-64 with an argv0-printing binary before fixing.

The fix, `rewrite_exec_path_to_fd()` in `seccomp/notif.rs`, plans the rewrite against the full argv **and** envp pointer arrays and relocates every string the write window touches, patching the affected pointer slots:

- strings starting inside the window (shell aliasing, packed argv[1]/envp strings), with a fixpoint loop because each relocation grows the window;
- strings whose tail reaches the window from below (a path pointer aimed into the middle of a longer string), scanned downward with each gap segment read once;
- layouts where the argv/envp pointer arrays themselves fall inside the window are refused with EFAULT, since the array addresses live in registers and cannot be moved.

All reads happen before any write, so relocated strings always carry their original bytes. String length is capped at the kernel's own `MAX_ARG_STRLEN`; the 8-byte pointer-slot width is safe because the BPF filter kills non-native-arch syscalls before they reach the notif fd.

Tests: 9 planner unit tests against fake child memory (aliased argv[0], packed argv[1], envp strings, tail overlap, window growth, array-in-window rejection, NULL arrays); a packed-argv integration test crafts the path and argv[1] in one buffer via raw `execve(2)` and fails on the pre-fix code.

## 4. Test portability against uutils coreutils (73c4cf2, 8d7b915)

- `test_seccomp_cow_exec_created_file` copies `tests/rootfs-helper` instead of `/bin/echo`: a copied uutils `echo` dispatches on `basename(argv[0]) = "m"` and fails even outside a sandbox. The helper is itself busybox-style argv[0]-dispatched, so the test both avoids depending on the host coreutils flavor and regression-tests the argv[0] preservation above.
- `inject_bytes_delivers_synthetic_content_to_guest` intercepts only `openat`, but uutils `cat` statx-es a path operand before opening it and failed on the host-nonexistent sentinel before the handler could fire. Feed `cat` via stdin redirection so the intercepted open is the shell's bare `openat`.
