### PR TITLE
fix(net): canonicalize v4-mapped IPv6 destinations before policy checks

### DIFF
--- a/crates/sandlock-core/src/network/connect.rs
+++ b/crates/sandlock-core/src/network/connect.rs
@@ -13,7 +13,7 @@ use crate::sys::structs::{SeccompNotif, ECONNREFUSED};
 
 use super::materialize::{
     named_unix_socket_path, parse_ip_from_sockaddr, parse_port_from_sockaddr,
-    set_port_in_sockaddr,
+    set_port_in_sockaddr, sockaddr_is_ipv6,
 };
 use super::unix::connect_named_unix_on_behalf;
 use super::verdict::{destination_verdict, path_under_any};
@@ -110,7 +110,10 @@ pub(super) async fn connect_on_behalf(
         // reused rather than pidfd_getfd-ing a second time.
         if plan.record_orig_dest {
             if let Some(ref map) = orig_dest_map {
-                record_orig_dest(map, dup_fd.as_raw_fd(), ip.is_ipv6(), ip);
+                // The local-address probe must bind in the socket's own
+                // family, which for a v4-mapped destination is AF_INET6
+                // even though the canonical `ip` is V4.
+                record_orig_dest(map, dup_fd.as_raw_fd(), sockaddr_is_ipv6(&addr_bytes), ip);
             }
         }
         connect_dup(dup_fd.as_raw_fd(), &plan.addr)
@@ -181,7 +184,10 @@ fn plan_connect_target(
     proxy: Option<std::net::SocketAddr>,
     remap_port: Option<u16>,
 ) -> Result<ConnectPlan, i32> {
-    let is_ipv6 = parse_ip_from_sockaddr(addr_bytes).map_or(false, |ip| ip.is_ipv6());
+    // Family of the sockaddr (== the socket's family on a valid connect):
+    // a v4-mapped destination on a dual-stack socket still needs an
+    // AF_INET6 sockaddr, so this must not come from the canonical IP.
+    let is_ipv6 = sockaddr_is_ipv6(addr_bytes);
     if let Some(proxy_addr) = proxy {
         let addr = if is_ipv6 {
             // IPv6 socket: redirect via the IPv4-mapped IPv6 address
@@ -405,9 +411,17 @@ mod tests {
         let a = v6_sockaddr(80);
         let proxy: std::net::SocketAddr = "127.0.0.1:3128".parse().unwrap();
         let plan = plan_connect_target(&a, Some(proxy), None).unwrap();
+        // The rewritten sockaddr stays AF_INET6 (the socket's family) and
+        // carries ::ffff:127.0.0.1; the parser reports the canonical V4.
+        let family = u16::from_ne_bytes([plan.addr[0], plan.addr[1]]);
+        assert_eq!(family, libc::AF_INET6 as u16);
+        assert_eq!(
+            plan.addr[8..24],
+            "::ffff:127.0.0.1".parse::<std::net::Ipv6Addr>().unwrap().octets()
+        );
         assert_eq!(
             parse_ip_from_sockaddr(&plan.addr),
-            Some("::ffff:127.0.0.1".parse().unwrap())
+            Some("127.0.0.1".parse().unwrap())
         );
         assert_eq!(parse_port_from_sockaddr(&plan.addr), Some(3128));
         assert!(plan.record_orig_dest);
@@ -421,6 +435,22 @@ mod tests {
             plan_connect_target(&a, Some(proxy), None).map(|p| p.addr),
             Err(libc::EAFNOSUPPORT)
         );
+    }
+
+    #[test]
+    fn plan_proxy_on_v6_socket_with_mapped_v4_destination_keeps_v6_family() {
+        // A dual-stack v6 socket connecting to ::ffff:a.b.c.d must be
+        // redirected with an AF_INET6 sockaddr (family follows the socket,
+        // not the canonicalized destination IP).
+        let mut a = v6_sockaddr(80);
+        let mapped: std::net::Ipv6Addr = "::ffff:93.184.216.34".parse().unwrap();
+        a[8..24].copy_from_slice(&mapped.octets());
+        let proxy: std::net::SocketAddr = "127.0.0.1:3128".parse().unwrap();
+        let plan = plan_connect_target(&a, Some(proxy), None).unwrap();
+        let family = u16::from_ne_bytes([plan.addr[0], plan.addr[1]]);
+        assert_eq!(family, libc::AF_INET6 as u16);
+        assert_eq!(parse_port_from_sockaddr(&plan.addr), Some(3128));
+        assert!(plan.record_orig_dest);
     }
 
     #[test]

--- a/crates/sandlock-core/src/network/materialize.rs
+++ b/crates/sandlock-core/src/network/materialize.rs
@@ -28,6 +28,13 @@ const MAX_CONTROL_BUF: usize = 16 << 10;
 
 /// Parse IP address from a sockaddr byte buffer.
 /// Returns None for non-IP families (AF_UNIX etc.) — always allowed.
+///
+/// A v4-mapped IPv6 destination (`::ffff:a.b.c.d`) is returned as the
+/// canonical `V4` address: on a dual-stack socket it reaches `a.b.c.d`
+/// over IPv4, so leaving it in `V6` form would let the mapped spelling
+/// bypass every v4 policy rule (family-exact CIDR matching) and dodge
+/// `is_loopback()` gates. Family-sensitive sockaddr rewrites must use
+/// [`sockaddr_is_ipv6`], not the returned IP's family.
 pub(crate) fn parse_ip_from_sockaddr(bytes: &[u8]) -> Option<IpAddr> {
     if bytes.len() < 2 {
         return None;
@@ -48,10 +55,17 @@ pub(crate) fn parse_ip_from_sockaddr(bytes: &[u8]) -> Option<IpAddr> {
             }
             let mut addr_bytes = [0u8; 16];
             addr_bytes.copy_from_slice(&bytes[8..24]);
-            Some(IpAddr::V6(Ipv6Addr::from(addr_bytes)))
+            Some(IpAddr::V6(Ipv6Addr::from(addr_bytes)).to_canonical())
         }
         _ => None,
     }
+}
+
+/// True iff the sockaddr's family field is `AF_INET6`. Sockaddr rewrites
+/// (proxy redirect) must follow the socket's family, which
+/// [`parse_ip_from_sockaddr`] no longer preserves for v4-mapped addresses.
+pub(crate) fn sockaddr_is_ipv6(bytes: &[u8]) -> bool {
+    bytes.len() >= 2 && u16::from_ne_bytes([bytes[0], bytes[1]]) as u32 == AF_INET6
 }
 
 // ============================================================
@@ -447,5 +461,49 @@ mod tests {
         assert_eq!(mmsg_entry_ptr(0x1000, 0), 0x1000);
         assert_eq!(mmsg_entry_ptr(0x1000, 2), 0x1000 + 2 * MMSGHDR_SIZE as u64);
         assert_eq!(mmsg_msglen_addr(0x1000), 0x1000 + MSG_LEN_OFFSET as u64);
+    }
+
+    // --- parse_ip_from_sockaddr tests (sockaddr bytes, child-controlled) ---
+
+    fn v6_sockaddr_bytes(ip: Ipv6Addr, port: u16) -> Vec<u8> {
+        let mut sa6: libc::sockaddr_in6 = unsafe { std::mem::zeroed() };
+        sa6.sin6_family = libc::AF_INET6 as u16;
+        sa6.sin6_port = port.to_be();
+        sa6.sin6_addr.s6_addr = ip.octets();
+        unsafe {
+            std::slice::from_raw_parts(
+                &sa6 as *const _ as *const u8,
+                std::mem::size_of::<libc::sockaddr_in6>(),
+            )
+        }
+        .to_vec()
+    }
+
+    #[test]
+    fn parse_ip_canonicalizes_v4_mapped_ipv6() {
+        // ::ffff:a.b.c.d names an IPv4 destination; the parse phase must
+        // hand the policy layer the canonical V4 form so v4 rules match.
+        let bytes = v6_sockaddr_bytes("::ffff:169.254.169.254".parse().unwrap(), 80);
+        assert_eq!(
+            parse_ip_from_sockaddr(&bytes),
+            Some("169.254.169.254".parse::<IpAddr>().unwrap())
+        );
+    }
+
+    #[test]
+    fn parse_ip_keeps_plain_ipv6_untouched() {
+        let bytes = v6_sockaddr_bytes(Ipv6Addr::LOCALHOST, 80);
+        assert_eq!(parse_ip_from_sockaddr(&bytes), Some(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+        assert!(sockaddr_is_ipv6(&bytes));
+    }
+
+    #[test]
+    fn sockaddr_family_is_independent_of_canonical_ip() {
+        // The socket family drives sockaddr rewrites (proxy redirect); it
+        // must come from the family field, not from the canonicalized IP.
+        let mapped = v6_sockaddr_bytes("::ffff:1.2.3.4".parse().unwrap(), 80);
+        assert!(sockaddr_is_ipv6(&mapped));
+        let v4_family = (AF_INET as u16).to_ne_bytes();
+        assert!(!sockaddr_is_ipv6(&[v4_family[0], v4_family[1], 0, 0]));
     }
 }

--- a/crates/sandlock-core/src/network/mod.rs
+++ b/crates/sandlock-core/src/network/mod.rs
@@ -29,7 +29,7 @@ use crate::seccomp::notif::{read_child_mem, NotifAction};
 use crate::sys::structs::SeccompNotif;
 
 mod connect;
-mod materialize;
+pub(crate) mod materialize;
 mod rules;
 mod send;
 mod send_engine;

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -273,6 +273,11 @@ pub enum NetworkPolicy {
 impl NetworkPolicy {
     /// True iff a connection to (ip, port) should be permitted.
     pub fn allows(&self, ip: IpAddr, port: u16) -> bool {
+        // `::ffff:a.b.c.d` is the same destination as `a.b.c.d` (a
+        // dual-stack socket reaches it over IPv4), and CIDR matching is
+        // family-exact: match rules against the canonical form so the
+        // mapped spelling can't bypass a v4 rule.
+        let ip = ip.to_canonical();
         match self {
             NetworkPolicy::Unrestricted => true,
             NetworkPolicy::AllowList { per_ip, cidrs, any_ip_ports } => {
@@ -1689,7 +1694,9 @@ fn resolve_second_path_for_notif(notif: &SeccompNotif, notif_fd: RawFd) -> Optio
     }
 }
 
-/// Extract IP and port from a sockaddr in child memory.
+/// Extract IP and port from a sockaddr in child memory. Parsing (including
+/// v4-mapped canonicalization) is shared with the enforcement path so the
+/// policy_fn callback judges the same address the policy layer does.
 fn read_sockaddr_for_event(notif: &SeccompNotif, addr: u64, len: usize, notif_fd: RawFd)
     -> (Option<std::net::IpAddr>, Option<u16>)
 {
@@ -1698,23 +1705,9 @@ fn read_sockaddr_for_event(notif: &SeccompNotif, addr: u64, len: usize, notif_fd
         Ok(b) => b,
         Err(_) => return (None, None),
     };
-    if bytes.len() < 4 { return (None, None); }
-    let family = u16::from_ne_bytes([bytes[0], bytes[1]]);
-    let port = u16::from_be_bytes([bytes[2], bytes[3]]);
-    let ip = match family as u32 {
-        f if f == crate::sys::structs::AF_INET && bytes.len() >= 8 => {
-            Some(std::net::IpAddr::V4(std::net::Ipv4Addr::new(
-                bytes[4], bytes[5], bytes[6], bytes[7],
-            )))
-        }
-        f if f == crate::sys::structs::AF_INET6 && bytes.len() >= 24 => {
-            let mut addr = [0u8; 16];
-            addr.copy_from_slice(&bytes[8..24]);
-            Some(std::net::IpAddr::V6(std::net::Ipv6Addr::from(addr)))
-        }
-        _ => None,
-    };
-    (ip, if port > 0 { Some(port) } else { None })
+    let ip = crate::network::materialize::parse_ip_from_sockaddr(&bytes);
+    let port = crate::network::materialize::parse_port_from_sockaddr(&bytes);
+    (ip, port.filter(|&p| p > 0))
 }
 
 /// Read argv (NULL-terminated array of char* in child memory) for execve.
@@ -2834,5 +2827,36 @@ mod tests {
         };
         assert!(policy.allows("192.168.5.5".parse().unwrap(), 9999)); // any port in range
         assert!(!policy.allows("10.0.0.1".parse().unwrap(), 9999));   // out of range
+    }
+
+    #[test]
+    fn denylist_blocks_v4_mapped_ipv6_form_of_denied_ip() {
+        // A dual-stack AF_INET6 socket connecting to ::ffff:169.254.169.254
+        // reaches 169.254.169.254 over IPv4, so a v4 deny rule must match
+        // the mapped form or the denylist is bypassable.
+        use crate::network::IpCidr;
+        let policy = NetworkPolicy::DenyList {
+            cidrs: vec![(IpCidr::parse("169.254.169.254").unwrap(), PortAllow::Any)],
+            any_ip_ports: HashSet::new(),
+            deny_all: false,
+        };
+        assert!(!policy.allows("::ffff:169.254.169.254".parse().unwrap(), 80));
+    }
+
+    #[test]
+    fn allowlist_accepts_v4_mapped_ipv6_form_of_allowed_ip() {
+        // Mirror of the deny case: the mapped form is the same destination,
+        // so a v4 allow entry must match it (per_ip and cidr paths both).
+        use crate::network::IpCidr;
+        let mut per_ip = HashMap::new();
+        per_ip.insert("1.2.3.4".parse().unwrap(), PortAllow::Any);
+        let policy = NetworkPolicy::AllowList {
+            per_ip,
+            cidrs: vec![(IpCidr::parse("10.0.0.0/8").unwrap(), PortAllow::Any)],
+            any_ip_ports: HashSet::new(),
+        };
+        assert!(policy.allows("::ffff:1.2.3.4".parse().unwrap(), 443));
+        assert!(policy.allows("::ffff:10.1.2.3".parse().unwrap(), 443));
+        assert!(!policy.allows("::ffff:8.8.8.8".parse().unwrap(), 443));
     }
 }


### PR DESCRIPTION
## Problem

Network policy matching is family-exact, but a dual-stack `AF_INET6` socket that connects to the v4-mapped form `::ffff:a.b.c.d` reaches `a.b.c.d` over IPv4. The mapped spelling therefore matched neither v4 CIDR rules nor the `is_loopback()` gates:

- `--net-deny 169.254.169.254` was bypassable via `connect(::ffff:169.254.169.254)` (fails open).
- A v4 `--net-allow` target rejected the same destination written in mapped form (fails closed).
- `::ffff:127.0.0.1` was treated as non-loopback by the connect supervision and port-remap gates.

## Fix

Canonicalize v4-mapped destinations to their V4 form before any policy decision:

- `parse_ip_from_sockaddr` (the parse-phase choke point for connect/sendto/sendmsg/sendmmsg) now returns `Ipv6Addr::to_canonical()`, so every downstream consumer sees the real destination.
- `NetworkPolicy::allows` canonicalizes at entry as defense in depth, keeping the pure matcher safe regardless of caller.
- `read_sockaddr_for_event` now reuses the shared materialize parsers (dropping its duplicated hand-rolled parsing), so policy_fn callbacks judge the same canonical address the enforcement path does.

Sockaddr rewrites must keep following the socket's family, not the canonical IP's family, so the proxy-redirect plan and the `record_orig_dest` local-bind probe now use a new `sockaddr_is_ipv6` helper that reads the family field directly. A v6 socket connecting to a mapped destination is still redirected with an `AF_INET6` sockaddr.

## Testing

- New unit tests at three layers: `NetworkPolicy::allows` (deny and allow sides), `parse_ip_from_sockaddr` canonicalization, and a `plan_connect_target` regression guard for the redirect family. All were written first and failed on the pre-fix code.
- Full suite passes: 515 lib + 292 integration Rust tests, 386 Python tests.
- Verified end to end with the CLI: `sandlock run --net-deny 169.254.169.254` now refuses `connect(::ffff:169.254.169.254)` instantly with `ECONNREFUSED`, while a control run denying an unrelated IP proceeds to the wire and times out.

Known remaining wart (out of scope here): a rule literal written in mapped form, e.g. `--net-deny '::ffff:1.2.3.4'`, still parses as a V6 host and will never match a canonical destination. Canonicalizing single-host mapped literals in `IpCidr::parse` would be a small follow-up.
