### PR TITLE
Follow-up fixes from the PR #113 review

### DIFF
--- a/crates/sandlock-cli/Cargo.toml
+++ b/crates/sandlock-cli/Cargo.toml
@@ -21,6 +21,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 jiff = "0.2"
 libc = "0.2"
-tempfile = "3"
 
 [dev-dependencies]
+tempfile = "3"

--- a/crates/sandlock-cli/src/learn.rs
+++ b/crates/sandlock-cli/src/learn.rs
@@ -118,30 +118,14 @@ fn dedup_subsumed(paths: Vec<PathBuf>) -> Vec<PathBuf> {
 /// Collapse paths using the N-threshold heuristic and explicit prefixes.
 ///
 /// Protected/guarded directories are never collapsed by the N-threshold.
-/// --collapse-prefix targeting a protected dir is always refused.
-/// --collapse-prefix targeting a guarded dir requires force_sensitive=true.
+/// Sensitive --collapse-prefix targets are refused up front in `run`, before
+/// the workload executes; prefixes reaching here are already vetted.
 fn collapse_by_threshold(
     paths: Vec<PathBuf>,
     n: usize,
     force_prefixes: &[PathBuf],
-    force_sensitive: bool,
     observed: &BTreeSet<PathBuf>,
 ) -> Vec<PathBuf> {
-    // Validate force_prefixes upfront.
-    for prefix in force_prefixes {
-        match classify_path(prefix) {
-            PathTier::Normal => {}
-            _ if !force_sensitive => {
-                eprintln!(
-                    "sandlock learn: ERROR: --collapse-prefix '{}' targets a sensitive path; use --force-sensitive-collapse to proceed",
-                    prefix.display()
-                );
-                std::process::exit(1);
-            }
-            _ => {}
-        }
-    }
-
     // Count how many paths share the same parent directory.
     let mut dir_counts: std::collections::HashMap<PathBuf, usize> = Default::default();
     for p in &paths {
@@ -200,12 +184,32 @@ fn is_junk_path(p: &std::path::Path) -> bool {
     // /proc/self/... and /proc/<pid>/... are pid-specific;
     let proc_pid = b.starts_with(b"/proc/self")
         || (b.starts_with(b"/proc/") && b.get(6).map_or(false, u8::is_ascii_digit));
+    // Only the controlling terminal is session-specific; hardware serial
+    // devices (/dev/ttyS*, /dev/ttyUSB*, ...) are stable paths a workload
+    // may legitimately need.
     proc_pid
         || b.starts_with(b"/dev/pts/") || b == b"/dev/pts"
-        || b.starts_with(b"/dev/tty")
+        || b == b"/dev/tty"
 }
 
 use crate::LearnArgs;
+
+/// Fail learn (writing no profile) unless the workload exited cleanly.
+fn require_clean_exit(status: &sandlock_core::ExitStatus) -> Result<()> {
+    match status {
+        sandlock_core::ExitStatus::Code(0) => {
+            eprintln!("sandlock learn: done");
+            Ok(())
+        }
+        sandlock_core::ExitStatus::Code(n) => {
+            Err(anyhow!("process exited with code {n}, not writing profile"))
+        }
+        sandlock_core::ExitStatus::Signal(sig) => {
+            Err(anyhow!("process killed by signal {sig}, not writing profile"))
+        }
+        _ => Err(anyhow!("process terminated abnormally, not writing profile")),
+    }
+}
 
 // openat flags (from fcntl.h)
 const O_WRONLY: u64 = 0o1;
@@ -249,9 +253,14 @@ struct LearnObserver {
     reads: Arc<Mutex<BTreeSet<PathBuf>>>,
     writes: Arc<Mutex<BTreeSet<PathBuf>>>,
     connects: Arc<Mutex<BTreeSet<String>>>,
-    /// PIDs that just completed an execve — on the NEXT event from that PID,
-    /// /proc/<pid>/maps will reflect the new binary's dynamic linker.
+    /// PIDs with an exec attempt observed but the post-exec maps scan still
+    /// pending; the scan runs on the pid's first non-exec event, which is
+    /// guaranteed to run under the new image.
     pending_maps: Arc<Mutex<HashSet<u32>>>,
+    /// Resolved path of the first binary the workload exec'd, from
+    /// /proc/<pid>/exe. Pins [program].exec to an absolute path; argv[0] may
+    /// be relative (resolved through $PATH by execvp) and useless to `run`.
+    first_exe: Arc<Mutex<Option<PathBuf>>>,
 }
 
 impl LearnObserver {
@@ -261,6 +270,7 @@ impl LearnObserver {
             writes: Arc::new(Mutex::new(BTreeSet::new())),
             connects: Arc::new(Mutex::new(BTreeSet::new())),
             pending_maps: Arc::new(Mutex::new(HashSet::new())),
+            first_exe: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -280,6 +290,10 @@ impl LearnObserver {
             // /proc/<pid>/exe is the canonical real binary path (symlinks resolved by the kernel),
             // race-free at this point since the new image is already loaded.
             if let Ok(exe) = std::fs::read_link(format!("/proc/{}/exe", event.pid)) {
+                let mut first = self.first_exe.lock().unwrap();
+                if first.is_none() {
+                    *first = Some(exe.clone());
+                }
                 reads.insert(exe);
             }
             for path in read_rx_mapped_files(event.pid) {
@@ -356,7 +370,18 @@ impl LearnObserver {
 
 pub async fn run(args: LearnArgs) -> Result<()> {
     if args.cmd.is_empty() {
-        anyhow::bail!("no command given — use: sandlock learn [flags] -- <cmd> [args...]");
+        anyhow::bail!("no command given; use: sandlock learn [flags] -- <cmd> [args...]");
+    }
+
+    // Refuse bad flag combinations before the workload runs, not after a
+    // full observation pass.
+    for prefix in &args.collapse_prefix {
+        if classify_path(prefix) != PathTier::Normal && !args.force_sensitive_collapse {
+            anyhow::bail!(
+                "--collapse-prefix '{}' targets a sensitive path; use --force-sensitive-collapse to proceed",
+                prefix.display()
+            );
+        }
     }
 
     let cmd_str = args.cmd.join(" ");
@@ -432,21 +457,7 @@ pub async fn run(args: LearnArgs) -> Result<()> {
             Ok(r) => {
                 let result = r.map_err(|e| anyhow!("sandbox error: {e}"))?;
                 sampler.abort();
-                match result.exit_status {
-                    sandlock_core::ExitStatus::Code(0) => eprintln!("sandlock learn: done"),
-                    sandlock_core::ExitStatus::Code(n) => {
-                        eprintln!("sandlock learn: process exited with code {n}, not writing profile");
-                        std::process::exit(1);
-                    }
-                    sandlock_core::ExitStatus::Signal(sig) => {
-                        eprintln!("sandlock learn: process killed by signal {sig}, not writing profile");
-                        std::process::exit(1);
-                    }
-                    sandlock_core::ExitStatus::Killed | sandlock_core::ExitStatus::Timeout => {
-                        eprintln!("sandlock learn: process terminated abnormally, not writing profile");
-                        std::process::exit(1);
-                    }
-                }
+                require_clean_exit(&result.exit_status)?;
                 false
             }
             Err(_elapsed) => {
@@ -463,21 +474,7 @@ pub async fn run(args: LearnArgs) -> Result<()> {
         let result = sandbox.wait().await
             .map_err(|e| anyhow!("sandbox error: {e}"))?;
         sampler.abort();
-        match result.exit_status {
-            sandlock_core::ExitStatus::Code(0) => eprintln!("sandlock learn: done"),
-            sandlock_core::ExitStatus::Code(n) => {
-                eprintln!("sandlock learn: process exited with code {n}, not writing profile");
-                std::process::exit(1);
-            }
-            sandlock_core::ExitStatus::Signal(sig) => {
-                eprintln!("sandlock learn: process killed by signal {sig}, not writing profile");
-                std::process::exit(1);
-            }
-            sandlock_core::ExitStatus::Killed | sandlock_core::ExitStatus::Timeout => {
-                eprintln!("sandlock learn: process terminated abnormally, not writing profile");
-                std::process::exit(1);
-            }
-        }
+        require_clean_exit(&result.exit_status)?;
         false
     };
 
@@ -493,8 +490,10 @@ pub async fn run(args: LearnArgs) -> Result<()> {
     let mut profile_out = ProfileInput::default();
 
     // Record the observed command so `sandlock run -p profile.toml` works
-    // without repeating the command on the CLI.
-    profile_out.program.exec = Some(PathBuf::from(&args.cmd[0]));
+    // without repeating the command on the CLI. Prefer the observed absolute
+    // binary path over argv[0], which may be a bare name resolved via $PATH.
+    let first_exe = observer.first_exe.lock().unwrap().clone();
+    profile_out.program.exec = first_exe.or_else(|| Some(PathBuf::from(&args.cmd[0])));
     profile_out.program.args = args.cmd[1..].to_vec();
 
     let reads_raw: Vec<PathBuf> = observer.reads.lock().unwrap().iter()
@@ -507,20 +506,19 @@ pub async fn run(args: LearnArgs) -> Result<()> {
         .cloned()
         .collect();
 
-    let fsc = args.force_sensitive_collapse;
     let reads = if let Some(n) = args.collapse {
-        dedup_subsumed(collapse_by_threshold(reads_raw, n, &args.collapse_prefix, fsc, &observed_all))
+        dedup_subsumed(collapse_by_threshold(reads_raw, n, &args.collapse_prefix, &observed_all))
     } else if !args.collapse_prefix.is_empty() {
-        dedup_subsumed(collapse_by_threshold(reads_raw, usize::MAX, &args.collapse_prefix, fsc, &observed_all))
+        dedup_subsumed(collapse_by_threshold(reads_raw, usize::MAX, &args.collapse_prefix, &observed_all))
     } else {
         dedup_subsumed(reads_raw)
     };
 
     let writes_collapsed = collapse_write_paths(&writes_raw);
     let writes = if let Some(n) = args.collapse {
-        dedup_subsumed(collapse_by_threshold(writes_collapsed, n, &args.collapse_prefix, fsc, &observed_all))
+        dedup_subsumed(collapse_by_threshold(writes_collapsed, n, &args.collapse_prefix, &observed_all))
     } else if !args.collapse_prefix.is_empty() {
-        dedup_subsumed(collapse_by_threshold(writes_collapsed, usize::MAX, &args.collapse_prefix, fsc, &observed_all))
+        dedup_subsumed(collapse_by_threshold(writes_collapsed, usize::MAX, &args.collapse_prefix, &observed_all))
     } else {
         dedup_subsumed(writes_collapsed)
     };

--- a/crates/sandlock-cli/src/learn.rs
+++ b/crates/sandlock-cli/src/learn.rs
@@ -267,10 +267,15 @@ impl LearnObserver {
     /// The policy_fn callback: classifies each intercepted syscall into
     /// reads, writes, or connects for profile generation.
     fn on_event(&self, event: SyscallEvent) -> Verdict {
-        // After an execve, the NEXT event from that PID fires once the
-        // new binary is running — /proc/<pid>/maps now shows the dynamic
-        // linker loaded by the kernel (which bypassed seccomp).
-        if self.pending_maps.lock().unwrap().remove(&event.pid) {
+        // After a successful execve, the NEXT event from that PID runs under
+        // the new image, so /proc/<pid>/maps shows the binary and dynamic
+        // linker the kernel loaded (which bypassed seccomp). Another exec
+        // event from a pending PID instead means the previous attempt failed
+        // (execvp walking $PATH; a successful execve never returns), so keep
+        // waiting: scanning then would record the old image, which for the
+        // workload's first exec is the sandbox runtime itself.
+        let is_exec = matches!(event.syscall.as_str(), "execve" | "execveat");
+        if !is_exec && self.pending_maps.lock().unwrap().remove(&event.pid) {
             let mut reads = self.reads.lock().unwrap();
             // /proc/<pid>/exe is the canonical real binary path (symlinks resolved by the kernel),
             // race-free at this point since the new image is already loaded.

--- a/crates/sandlock-cli/tests/cli_test.rs
+++ b/crates/sandlock-cli/tests/cli_test.rs
@@ -582,7 +582,7 @@ fn test_learn_then_run_write() {
         .args(["learn", "-o", &profile_path, "--", "sh", "-c", &format!("echo hello > {write_path}")])
         .output()
         .expect("failed to run sandlock learn");
-    assert!(learn.status.success() || learn.status.code() == Some(2),
+    assert!(learn.status.success(),
         "learn failed unexpectedly: {}", String::from_utf8_lossy(&learn.stderr));
     assert!(!std::path::Path::new(write_path).exists(), "COW isolation failed during learn");
 

--- a/crates/sandlock-core/src/arch.rs
+++ b/crates/sandlock-core/src/arch.rs
@@ -74,6 +74,13 @@ legacy_syscall!(sys_lchown, "lchown");
 legacy_syscall!(sys_vfork, "vfork");
 legacy_syscall!(sys_fork, "fork");
 
+/// `renameat` syscall number on this architecture, or `None` where the ABI
+/// omits it. Unlike the legacy syscalls above it survived into the generic
+/// ABI on aarch64; only riscv64 dropped it in favor of `renameat2` alone.
+pub fn sys_renameat() -> Option<i64> {
+    sysno("renameat")
+}
+
 /// Fork-class syscalls present on this architecture: `clone`/`clone3` always,
 /// plus `fork`/`vfork` only where the legacy ABI provides them. Single source
 /// of truth for callers enumerating fork-class syscalls (BPF notif

--- a/crates/sandlock-core/src/policy_fn.rs
+++ b/crates/sandlock-core/src/policy_fn.rs
@@ -318,11 +318,14 @@ impl Default for Verdict {
 
 /// A callback function invoked for each intercepted syscall.
 ///
-/// Called synchronously on a dedicated thread. For `execve` syscalls,
-/// the child process is held until the callback returns.
+/// Called synchronously on a dedicated thread. For held syscalls the child
+/// process is blocked until the callback returns.
 ///
-/// Return `Verdict::Deny` to block the current syscall. Only effective
-/// for held syscalls (execve/execveat) and network syscalls (connect/sendto).
+/// Return `Verdict::Deny` to block the current syscall. Only effective for
+/// held syscalls: exec (execve/execveat), open (open/openat/openat2), and
+/// network (connect/bind/sendto/sendmsg/sendmmsg). Filesystem-mutation
+/// events (mkdir/unlink/symlink/link/rename/truncate) are observation-only;
+/// their verdicts are ignored. Use `fs_deny` to block paths.
 ///
 /// Wrapped in `Arc` so that `Policy` remains `Clone`.
 pub type PolicyCallback = Arc<dyn Fn(SyscallEvent, &mut PolicyContext) -> Verdict + Send + Sync + 'static>;

--- a/crates/sandlock-core/src/policy_fn.rs
+++ b/crates/sandlock-core/src/policy_fn.rs
@@ -118,7 +118,8 @@ pub struct SyscallEvent {
     /// `O_WRONLY`, `O_CREAT`). `None` for non-openat syscalls.
     pub flags: Option<u64>,
     /// Socket protocol for network syscalls (connect, sendto, sendmsg, sendmmsg).
-    /// One of "tcp", "udp", "icmp". `None` for non-network syscalls or if
+    /// One of "tcp", "udp", "icmp". `None` for non-network syscalls or when
+    /// protocol resolution fails.
     pub protocol: Option<String>,
 }
 

--- a/crates/sandlock-core/src/profile.rs
+++ b/crates/sandlock-core/src/profile.rs
@@ -190,8 +190,6 @@ pub struct LimitsSection {
     pub num_cpus: Option<u32>,
 }
 
-/// Convert a parsed `ProfileInput` into a `(Sandbox, ProgramSpec)` pair.
-///
 impl ProfileInput {
     /// Serialize the profile to a TOML string.
     pub fn to_toml(&self) -> Result<String, toml::ser::Error> {
@@ -199,6 +197,8 @@ impl ProfileInput {
     }
 }
 
+/// Convert a parsed `ProfileInput` into a `(Sandbox, ProgramSpec)` pair.
+///
 /// Forwards each schema section's fields to the corresponding `SandboxBuilder`
 /// method calls. The two private helpers (`parse_branch_action`,
 /// `parse_mount_spec`) handle string-to-typed-value conversions for fields

--- a/crates/sandlock-core/src/sandbox/builder.rs
+++ b/crates/sandlock-core/src/sandbox/builder.rs
@@ -217,7 +217,6 @@ pub struct SandboxBuilder {
     // COW fork work function: runs in each COW clone.
     #[cfg_attr(feature = "cli", clap(skip))]
     pub(crate) work_fn: Option<Arc<dyn Fn(u32) + Send + Sync + 'static>>,
-
 }
 
 impl std::fmt::Debug for SandboxBuilder {

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -332,7 +332,8 @@ impl NetworkPolicy {
 ///
 /// For two-path syscalls (renameat2, linkat), checks both source and
 /// destination paths — a denied file must not be linked, renamed, or
-/// overwritten.
+/// overwritten. Single-path destructive syscalls (truncate, unlinkat) are
+/// gated too: a denied file must not be wiped or deleted.
 ///
 /// Each resolved path is checked both as-is (lexical normalization) and
 /// after following symlinks via `canonicalize`.  This prevents bypass via
@@ -1626,6 +1627,13 @@ fn resolve_at_path_for_event(notif: &SeccompNotif, dirfd: i64, path: &str) -> Op
     Some(normalize_path(&base.join(path)))
 }
 
+/// Resolve the primary path argument of a path-bearing syscall.
+///
+/// Serves two callers with different scopes: `emit_policy_event` uses it for
+/// every syscall matched here (observation, e.g. `sandlock learn`), while
+/// deny enforcement via `is_path_denied_for_notif` only ever sees syscalls in
+/// `fs_denied_path_syscalls` — adding a match arm here does NOT widen deny
+/// gating.
 fn resolve_path_for_notif(notif: &SeccompNotif, notif_fd: RawFd) -> Option<String> {
     let nr = notif.data.nr as i64;
     match nr {
@@ -1688,10 +1696,6 @@ fn resolve_path_for_notif(notif: &SeccompNotif, notif_fd: RawFd) -> Option<Strin
             let path = read_path_for_event(notif, notif.data.args[1], notif_fd)?;
             resolve_at_path_for_event(notif, libc::AT_FDCWD as i64, &path)
         }
-        // symlinkat/symlink intentionally omitted from deny-path gating: creating
-        // a symlink does not access its target, so there is nothing to gate here.
-        // Any later open through the symlink resolves to the real target and is
-        // denied race-free on the open path (issue #111). See `on_behalf_open_for_deny`.
         // link(oldpath, newpath) — legacy, AT_FDCWD implied for both
         n if Some(n) == arch::sys_link() => {
             let path = read_path_for_event(notif, notif.data.args[0], notif_fd)?;
@@ -2042,21 +2046,14 @@ async fn handle_notification(
         maybe_patch_vdso(notif.pid as i32, &mut pfs, policy);
     }
 
-    // Check dynamic path denials before dispatch
+    // Check dynamic path denials before dispatch. The gated syscall set is
+    // shared with the BPF notif list so enforcement scope cannot drift from
+    // interception scope; see `fs_denied_path_syscalls` for what is gated
+    // and why symlink/mkdir are not.
     let mut action = {
         let nr = notif.data.nr as i64;
-        // symlinkat/symlink are not gated: creating a symlink does not access
-        // its target (any open through it is denied race-free on the open
-        // path). See `resolve_path_for_notif`.
-        let mut path_check_nrs = vec![
-            libc::SYS_openat, arch::SYS_OPENAT2, libc::SYS_execve, libc::SYS_execveat,
-            libc::SYS_linkat, libc::SYS_renameat2,
-        ];
-        path_check_nrs.extend([
-            arch::sys_open(), arch::sys_link(), arch::sys_rename(),
-        ].into_iter().flatten());
         let should_precheck_denied = policy.chroot_root.is_none()
-            && path_check_nrs.contains(&nr);
+            && crate::seccomp_plan::fs_denied_path_syscalls().contains(&nr);
         if should_precheck_denied {
             let pfs = ctx.policy_fn.lock().await;
             if is_path_denied_for_notif(&pfs, &notif, fd) {

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -1945,11 +1945,19 @@ async fn emit_policy_event(
         protocol,
     };
 
-    // Hold syscalls where the callback's verdict matters.
-    // The child is blocked until the callback returns.
+    // Hold syscalls where the callback's verdict matters: exec, every open
+    // variant (openat2 and legacy open emit the same "openat" event, so a
+    // deny that skipped them would be silently bypassable), and every
+    // network-send variant (same reasoning for sendmsg/sendmmsg vs sendto).
+    // The child is blocked until the callback returns. Filesystem-mutation
+    // events (mkdir/unlink/symlink/link/rename/truncate) are observation-only
+    // per the `PolicyCallback` contract; use `fs_deny` to block paths.
     let is_held = nr == libc::SYS_execve || nr == libc::SYS_execveat
-        || nr == libc::SYS_connect || nr == libc::SYS_sendto
-        || nr == libc::SYS_bind || nr == libc::SYS_openat;
+        || nr == libc::SYS_openat || nr == arch::SYS_OPENAT2
+        || Some(nr) == arch::sys_open()
+        || nr == libc::SYS_connect || nr == libc::SYS_bind
+        || nr == libc::SYS_sendto || nr == libc::SYS_sendmsg
+        || nr == libc::SYS_sendmmsg;
 
     if is_held {
         let (gate_tx, gate_rx) = tokio::sync::oneshot::channel();

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -1533,6 +1533,7 @@ fn syscall_name(nr: i64) -> &'static str {
         n if Some(n) == arch::sys_symlink() => "symlinkat",
         n if Some(n) == arch::sys_link() => "linkat",
         n if Some(n) == arch::sys_rename() => "renameat2",
+        n if Some(n) == arch::sys_renameat() => "renameat2",
         _ => "unknown",
     }
 }
@@ -1548,7 +1549,12 @@ fn syscall_category(nr: i64) -> crate::policy_fn::SyscallCategory {
             || n == libc::SYS_truncate || n == libc::SYS_readlinkat
             || n == libc::SYS_newfstatat || n == libc::SYS_statx
             || n == libc::SYS_faccessat || n == libc::SYS_getdents64
-            || Some(n) == arch::sys_getdents() => SyscallCategory::File,
+            || Some(n) == arch::sys_getdents()
+            || Some(n) == arch::sys_open() || Some(n) == arch::sys_mkdir()
+            || Some(n) == arch::sys_rmdir() || Some(n) == arch::sys_unlink()
+            || Some(n) == arch::sys_symlink() || Some(n) == arch::sys_link()
+            || Some(n) == arch::sys_rename() || Some(n) == arch::sys_renameat()
+            => SyscallCategory::File,
         n if n == libc::SYS_connect || n == libc::SYS_sendto
             || n == libc::SYS_sendmsg || n == libc::SYS_sendmmsg
             || n == libc::SYS_bind
@@ -1657,9 +1663,9 @@ fn resolve_path_for_notif(notif: &SeccompNotif, notif_fd: RawFd) -> Option<Strin
             let path = read_path_for_event(notif, notif.data.args[1], notif_fd)?;
             resolve_at_path_for_event(notif, notif.data.args[0] as i64, &path)
         }
-        // renameat2(olddirfd, oldpath, newdirfd, newpath, flags)
+        // renameat2/renameat(olddirfd, oldpath, newdirfd, newpath[, flags])
         // Check the source (old) path — deny if a denied file is being renamed away.
-        n if n == libc::SYS_renameat2 => {
+        n if n == libc::SYS_renameat2 || Some(n) == arch::sys_renameat() => {
             let path = read_path_for_event(notif, notif.data.args[1], notif_fd)?;
             resolve_at_path_for_event(notif, notif.data.args[0] as i64, &path)
         }
@@ -1716,8 +1722,8 @@ fn resolve_path_for_notif(notif: &SeccompNotif, notif_fd: RawFd) -> Option<Strin
 fn resolve_second_path_for_notif(notif: &SeccompNotif, notif_fd: RawFd) -> Option<String> {
     let nr = notif.data.nr as i64;
     match nr {
-        // renameat2(olddirfd, oldpath, newdirfd, newpath, flags)
-        n if n == libc::SYS_renameat2 => {
+        // renameat2/renameat(olddirfd, oldpath, newdirfd, newpath[, flags])
+        n if n == libc::SYS_renameat2 || Some(n) == arch::sys_renameat() => {
             let path = read_path_for_event(notif, notif.data.args[3], notif_fd)?;
             resolve_at_path_for_event(notif, notif.data.args[2] as i64, &path)
         }
@@ -1923,7 +1929,8 @@ async fn emit_policy_event(
         || nr == libc::SYS_renameat2 || nr == libc::SYS_linkat
         || Some(nr) == arch::sys_mkdir() || Some(nr) == arch::sys_rmdir()
         || Some(nr) == arch::sys_unlink() || Some(nr) == arch::sys_symlink()
-        || Some(nr) == arch::sys_link() || Some(nr) == arch::sys_rename();
+        || Some(nr) == arch::sys_link() || Some(nr) == arch::sys_rename()
+        || Some(nr) == arch::sys_renameat();
     if is_fs_mutating {
         path = resolve_path_for_notif(notif, notif_fd).map(std::path::PathBuf::from);
         path2 = resolve_second_path_for_notif(notif, notif_fd).map(std::path::PathBuf::from);

--- a/crates/sandlock-core/src/seccomp_plan.rs
+++ b/crates/sandlock-core/src/seccomp_plan.rs
@@ -261,6 +261,7 @@ pub(crate) fn fs_denied_path_syscalls() -> Vec<i64> {
             arch::sys_open(),
             arch::sys_link(),
             arch::sys_rename(),
+            arch::sys_renameat(),
             arch::sys_unlink(),
             arch::sys_rmdir(),
         ]
@@ -303,6 +304,7 @@ fn policy_event_syscalls() -> Vec<i64> {
             arch::sys_symlink(),
             arch::sys_link(),
             arch::sys_rename(),
+            arch::sys_renameat(),
         ]
         .into_iter()
         .flatten(),

--- a/crates/sandlock-core/src/seccomp_plan.rs
+++ b/crates/sandlock-core/src/seccomp_plan.rs
@@ -270,15 +270,45 @@ pub(crate) fn fs_denied_path_syscalls() -> Vec<i64> {
     v
 }
 
-const POLICY_EVENT_SYSCALLS: &[i64] = &[
-    libc::SYS_openat,
-    arch::SYS_OPENAT2,
-    libc::SYS_connect,
-    libc::SYS_sendto,
-    libc::SYS_bind,
-    libc::SYS_execve,
-    libc::SYS_execveat,
-];
+/// Syscalls intercepted for policy_fn event emission.
+///
+/// Must match what `emit_policy_event` can decode into a `SyscallEvent`, so
+/// every field documented there fires for a policy_fn-only sandbox instead of
+/// depending on COW, chroot, or network supervision happening to intercept
+/// the syscall.
+fn policy_event_syscalls() -> Vec<i64> {
+    let mut v = vec![
+        libc::SYS_openat,
+        arch::SYS_OPENAT2,
+        libc::SYS_connect,
+        libc::SYS_sendto,
+        libc::SYS_sendmsg,
+        libc::SYS_sendmmsg,
+        libc::SYS_bind,
+        libc::SYS_execve,
+        libc::SYS_execveat,
+        libc::SYS_mkdirat,
+        libc::SYS_unlinkat,
+        libc::SYS_symlinkat,
+        libc::SYS_linkat,
+        libc::SYS_renameat2,
+        libc::SYS_truncate,
+    ];
+    v.extend(
+        [
+            arch::sys_open(),
+            arch::sys_mkdir(),
+            arch::sys_rmdir(),
+            arch::sys_unlink(),
+            arch::sys_symlink(),
+            arch::sys_link(),
+            arch::sys_rename(),
+        ]
+        .into_iter()
+        .flatten(),
+    );
+    v
+}
 
 const PORT_REMAP_SYSCALLS: &[i64] = &[
     libc::SYS_bind,
@@ -367,12 +397,10 @@ pub(crate) fn notif_syscalls_resolved(resolved: &ResolvedSandbox) -> Vec<u32> {
         nrs.extend(&fs_denied_path_syscalls());
     }
 
-    // Dynamic policy callback: intercept key syscalls for event emission.
-    // Also includes the legacy open(2) syscall (absent on some arches) so
-    // path events fire on kernels that still dispatch it.
+    // Dynamic policy callback: intercept every syscall the event emitter
+    // can decode.
     if features.policy_fn {
-        nrs.extend(POLICY_EVENT_SYSCALLS);
-        nrs.push_optional(arch::sys_open());
+        nrs.extend(&policy_event_syscalls());
     }
 
     // Port remapping

--- a/crates/sandlock-core/src/seccomp_plan.rs
+++ b/crates/sandlock-core/src/seccomp_plan.rs
@@ -231,11 +231,18 @@ fn chroot_path_syscalls() -> Vec<i64> {
     v
 }
 
-fn fs_denied_path_syscalls() -> Vec<i64> {
-    // symlinkat/symlink are intentionally absent: creating a symlink does not
-    // access its target, so there is nothing to deny at creation time. A later
-    // open through the symlink resolves to the real target and is denied
-    // race-free on the open path (issue #111).
+/// Syscalls gated by the deny-path precheck in `handle_notification`.
+///
+/// This is the single source of truth for deny-path enforcement scope: it
+/// decides both which syscalls enter the notif BPF list when deny paths are
+/// configured and which notifications run `is_path_denied_for_notif`.
+///
+/// symlinkat/symlink and mkdirat/mkdir are intentionally absent: creating a
+/// symlink does not access its target, and mkdir cannot touch existing
+/// content, so there is nothing to deny at creation time. A later open
+/// through the created name resolves to the real target and is denied
+/// race-free on the open path (issue #111).
+pub(crate) fn fs_denied_path_syscalls() -> Vec<i64> {
     let mut v = vec![
         libc::SYS_openat,
         arch::SYS_OPENAT2,
@@ -243,12 +250,19 @@ fn fs_denied_path_syscalls() -> Vec<i64> {
         libc::SYS_execveat,
         libc::SYS_linkat,
         libc::SYS_renameat2,
+        // A denied file must not be destroyed either: truncate(2) wipes its
+        // content and unlinkat(2) (incl. AT_REMOVEDIR) deletes it, and both
+        // take a path so the fd-based open deny never sees them.
+        libc::SYS_truncate,
+        libc::SYS_unlinkat,
     ];
     v.extend(
         [
             arch::sys_open(),
             arch::sys_link(),
             arch::sys_rename(),
+            arch::sys_unlink(),
+            arch::sys_rmdir(),
         ]
         .into_iter()
         .flatten(),

--- a/crates/sandlock-core/tests/integration/test_policy_fn.rs
+++ b/crates/sandlock-core/tests/integration/test_policy_fn.rs
@@ -586,3 +586,120 @@ async fn test_policy_fn_fork_does_not_deadlock() {
     let out = String::from_utf8_lossy(result.stdout.as_deref().unwrap_or(b""));
     assert!(out.contains("FORKS_OK 30"), "all 30 forks should complete, got: {}", out);
 }
+
+/// A policy_fn-only sandbox (no COW, no network supervision) must receive
+/// filesystem-mutation events with a resolved path: the policy_fn feature
+/// itself puts these syscalls in the notif list, not other features.
+#[tokio::test]
+async fn test_policy_fn_fs_mutation_events() {
+    let events: Arc<Mutex<Vec<(String, Option<PathBuf>)>>> = Arc::new(Mutex::new(Vec::new()));
+    let events_clone = events.clone();
+
+    let policy = base_policy()
+        .policy_fn(move |event, _ctx| {
+            events_clone.lock().unwrap().push((event.syscall.clone(), event.path.clone()));
+            Verdict::Allow
+        })
+        .build()
+        .unwrap();
+
+    let dir = temp_file("mutations-dir");
+    let renamed = temp_file("mutations-renamed");
+    let cmd = format!(
+        "mkdir {dir} && mv {dir} {renamed} && rmdir {renamed}",
+        dir = dir.display(),
+        renamed = renamed.display(),
+    );
+    let result = policy.clone().with_name("test").run(&["sh", "-c", &cmd]).await.unwrap();
+    assert!(result.success());
+
+    let captured = events.lock().unwrap();
+    for name in ["mkdirat", "renameat2", "unlinkat"] {
+        assert!(
+            captured.iter().any(|(n, p)| n == name && p.is_some()),
+            "expected a {name} event with a resolved path, got: {:?}",
+            captured.iter().map(|(n, _)| n).collect::<Vec<_>>(),
+        );
+    }
+}
+
+/// Verdict::Deny for an "openat" event must block openat2(2) too: openat2
+/// emits the same event name, so a callback cannot tell them apart and a
+/// held-gate that skipped openat2 would let opens bypass the deny.
+#[tokio::test]
+async fn test_policy_fn_deny_openat2() {
+    let secret = temp_file("deny-openat2-secret");
+    std::fs::write(&secret, "TOP_SECRET").unwrap();
+    let out = temp_file("deny-openat2-out");
+    let deny_path = secret.clone();
+
+    let policy = base_policy()
+        .fs_read("/tmp")
+        .policy_fn(move |event, _ctx| {
+            if event.syscall == "openat" && event.path.as_deref() == Some(deny_path.as_path()) {
+                return Verdict::Deny; // EPERM
+            }
+            Verdict::Allow
+        })
+        .build()
+        .unwrap();
+
+    // SYS_openat2 = 437 on all supported arches; struct open_how { flags, mode, resolve }.
+    let script = format!(concat!(
+        "import ctypes, os\n",
+        "libc = ctypes.CDLL(None, use_errno=True)\n",
+        "class How(ctypes.Structure):\n",
+        "  _fields_ = [('f', ctypes.c_uint64), ('m', ctypes.c_uint64), ('r', ctypes.c_uint64)]\n",
+        "how = How(f=os.O_RDONLY)\n",
+        "fd = libc.syscall(437, -100, b'{secret}', ctypes.byref(how), ctypes.sizeof(how))\n",
+        "if fd < 0:\n",
+        "  open('{out}', 'w').write('BLOCKED:%d' % ctypes.get_errno())\n",
+        "else:\n",
+        "  open('{out}', 'w').write(os.read(fd, 32).decode())\n",
+    ), secret = secret.display(), out = out.display());
+
+    let result = policy.clone().with_name("test").run_interactive(&["python3", "-c", &script]).await.unwrap();
+    assert!(result.success());
+
+    let content = std::fs::read_to_string(&out).unwrap_or_default();
+    let _ = std::fs::remove_file(&out);
+    let _ = std::fs::remove_file(&secret);
+    assert_eq!(content, "BLOCKED:1", "openat2 must be denied by the policy_fn openat deny (EPERM)");
+}
+
+/// Verdict::Deny for a "sendmsg" event must block the send: sendto is held,
+/// so a datagram sent via sendmsg(2) must not bypass the verdict.
+#[tokio::test]
+async fn test_policy_fn_deny_sendmsg() {
+    let out = temp_file("deny-sendmsg-out");
+    let receiver = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+    let port = receiver.local_addr().unwrap().port();
+
+    let policy = base_policy()
+        .net_allow(format!("udp://127.0.0.1:{port}"))
+        .policy_fn(move |event, _ctx| {
+            if event.syscall == "sendmsg" {
+                return Verdict::Deny; // EPERM
+            }
+            Verdict::Allow
+        })
+        .build()
+        .unwrap();
+
+    let script = format!(concat!(
+        "import socket\n",
+        "s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n",
+        "try:\n",
+        "  s.sendmsg([b'hi'], [], 0, ('127.0.0.1', {port}))\n",
+        "  open('{out}', 'w').write('SENT')\n",
+        "except OSError as e:\n",
+        "  open('{out}', 'w').write('BLOCKED:%d' % e.errno)\n",
+    ), port = port, out = out.display());
+
+    let result = policy.clone().with_name("test").run_interactive(&["python3", "-c", &script]).await.unwrap();
+    assert!(result.success());
+
+    let content = std::fs::read_to_string(&out).unwrap_or_default();
+    let _ = std::fs::remove_file(&out);
+    assert_eq!(content, "BLOCKED:1", "sendmsg should be denied by policy_fn (EPERM)");
+}

--- a/crates/sandlock-core/tests/integration/test_sandbox.rs
+++ b/crates/sandlock-core/tests/integration/test_sandbox.rs
@@ -358,6 +358,61 @@ async fn test_denied_path_rename_blocked() {
     );
 }
 
+/// truncate(2) takes a path, so the fd-based open deny never sees it; the
+/// deny precheck must gate it or a denied file inside a granted write tree
+/// can be wiped.
+#[tokio::test]
+async fn test_denied_path_truncate_blocked() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let secret = tmp.path().join("secret.txt");
+    std::fs::write(&secret, "TOP_SECRET").unwrap();
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr").fs_read("/lib").fs_read_if_exists("/lib64")
+        .fs_read("/bin").fs_read("/proc").fs_read("/etc")
+        .fs_read(tmp.path())
+        .fs_write(tmp.path())
+        .fs_deny(&secret)
+        .build()
+        .unwrap();
+
+    // os.truncate on a path issues truncate(2), not open+ftruncate.
+    let script = format!("import os; os.truncate('{}', 0)", secret.display());
+    let _ = policy.clone().with_name("test").run(&["python3", "-c", &script]).await.unwrap();
+    assert_eq!(
+        std::fs::read_to_string(&secret).unwrap(),
+        "TOP_SECRET",
+        "truncate bypass: sandbox allowed wiping a denied file via truncate(2)"
+    );
+}
+
+/// unlinkat(2) takes a path, so the fd-based open deny never sees it; the
+/// deny precheck must gate it or a denied file inside a granted write tree
+/// can be deleted.
+#[tokio::test]
+async fn test_denied_path_unlink_blocked() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let secret = tmp.path().join("secret.txt");
+    std::fs::write(&secret, "TOP_SECRET").unwrap();
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr").fs_read("/lib").fs_read_if_exists("/lib64")
+        .fs_read("/bin").fs_read("/proc").fs_read("/etc")
+        .fs_read(tmp.path())
+        .fs_write(tmp.path())
+        .fs_deny(&secret)
+        .build()
+        .unwrap();
+
+    let cmd = format!("rm -f {}", secret.display());
+    let _ = policy.clone().with_name("test").run(&["sh", "-c", &cmd]).await.unwrap();
+    assert_eq!(
+        std::fs::read_to_string(&secret).unwrap_or_default(),
+        "TOP_SECRET",
+        "unlink bypass: sandbox allowed deleting a denied file via unlinkat(2)"
+    );
+}
+
 #[tokio::test]
 async fn test_denied_path_symlink_blocked() {
     let tmp = tempfile::TempDir::new().unwrap();

--- a/crates/sandlock-core/tests/integration/test_sandbox.rs
+++ b/crates/sandlock-core/tests/integration/test_sandbox.rs
@@ -358,6 +358,47 @@ async fn test_denied_path_rename_blocked() {
     );
 }
 
+/// renameat(2), the middle-generation variant between rename(2) and
+/// renameat2(2), must be deny-gated like the other two: a raw
+/// syscall(SYS_renameat, ...) must not rename a denied file away.
+/// riscv64 has no renameat, so the test only exists where the ABI does.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[tokio::test]
+async fn test_denied_path_renameat_blocked() {
+    #[cfg(target_arch = "x86_64")]
+    const SYS_RENAMEAT: i64 = 264;
+    #[cfg(target_arch = "aarch64")]
+    const SYS_RENAMEAT: i64 = 38;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let secret = tmp.path().join("secret.txt");
+    std::fs::write(&secret, "TOP_SECRET").unwrap();
+    let renamed = tmp.path().join("renamed.txt");
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr").fs_read("/lib").fs_read_if_exists("/lib64")
+        .fs_read("/bin").fs_read("/proc").fs_read("/etc")
+        .fs_read(tmp.path())
+        .fs_write(tmp.path())
+        .fs_deny(&secret)
+        .build()
+        .unwrap();
+
+    let script = format!(
+        "import ctypes; libc = ctypes.CDLL(None, use_errno=True); \
+         libc.syscall({SYS_RENAMEAT}, -100, b'{}', -100, b'{}')",
+        secret.display(),
+        renamed.display(),
+    );
+    let _ = policy.clone().with_name("test").run(&["python3", "-c", &script]).await.unwrap();
+    assert_eq!(
+        std::fs::read_to_string(&secret).unwrap_or_default(),
+        "TOP_SECRET",
+        "renameat bypass: sandbox allowed renaming a denied file via renameat(2)"
+    );
+    assert!(!renamed.exists(), "renameat bypass: denied file was renamed away");
+}
+
 /// truncate(2) takes a path, so the fd-based open deny never sees it; the
 /// deny precheck must gate it or a denied file inside a granted write tree
 /// can be wiped.

--- a/crates/sandlock-core/tests/integration/test_sandbox.rs
+++ b/crates/sandlock-core/tests/integration/test_sandbox.rs
@@ -399,6 +399,81 @@ async fn test_denied_path_renameat_blocked() {
     assert!(!renamed.exists(), "renameat bypass: denied file was renamed away");
 }
 
+/// The deny gate must also check the rename *destination*: a file the
+/// sandboxed process created inside its granted write tree must not be
+/// renameable onto a denied path. Unlike wiping or deleting (which fail
+/// closed at the next reader), substitution is silent and hands whoever
+/// reads the denied path attacker-chosen content.
+#[tokio::test]
+async fn test_denied_path_rename_onto_blocked() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let secret = tmp.path().join("secret.txt");
+    std::fs::write(&secret, "TOP_SECRET").unwrap();
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr").fs_read("/lib").fs_read_if_exists("/lib64")
+        .fs_read("/bin").fs_read("/proc").fs_read("/etc")
+        .fs_read(tmp.path())
+        .fs_write(tmp.path())
+        .fs_deny(&secret)
+        .build()
+        .unwrap();
+
+    let cmd = format!(
+        "echo ATTACKER > {dir}/planted.txt && mv {dir}/planted.txt {}",
+        secret.display(),
+        dir = tmp.path().display(),
+    );
+    let _ = policy.clone().with_name("test").run(&["sh", "-c", &cmd]).await.unwrap();
+    assert_eq!(
+        std::fs::read_to_string(&secret).unwrap_or_default(),
+        "TOP_SECRET",
+        "rename-onto bypass: sandbox allowed substituting a denied file's content via rename"
+    );
+}
+
+/// Destination-direction gating for renameat(2) specifically: the second-path
+/// resolver must cover the middle-generation variant too, or a raw
+/// syscall(SYS_renameat, ...) substitutes attacker content at the denied path
+/// while rename(2)/renameat2(2) are refused. riscv64 has no renameat, so the
+/// test only exists where the ABI does.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[tokio::test]
+async fn test_denied_path_renameat_onto_blocked() {
+    #[cfg(target_arch = "x86_64")]
+    const SYS_RENAMEAT: i64 = 264;
+    #[cfg(target_arch = "aarch64")]
+    const SYS_RENAMEAT: i64 = 38;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let secret = tmp.path().join("secret.txt");
+    std::fs::write(&secret, "TOP_SECRET").unwrap();
+    let planted = tmp.path().join("planted.txt");
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr").fs_read("/lib").fs_read_if_exists("/lib64")
+        .fs_read("/bin").fs_read("/proc").fs_read("/etc")
+        .fs_read(tmp.path())
+        .fs_write(tmp.path())
+        .fs_deny(&secret)
+        .build()
+        .unwrap();
+
+    let script = format!(
+        "import ctypes; libc = ctypes.CDLL(None, use_errno=True); \
+         open('{planted}', 'w').write('ATTACKER'); \
+         libc.syscall({SYS_RENAMEAT}, -100, b'{planted}', -100, b'{}')",
+        secret.display(),
+        planted = planted.display(),
+    );
+    let _ = policy.clone().with_name("test").run(&["python3", "-c", &script]).await.unwrap();
+    assert_eq!(
+        std::fs::read_to_string(&secret).unwrap_or_default(),
+        "TOP_SECRET",
+        "renameat-onto bypass: sandbox allowed substituting a denied file's content via renameat(2)"
+    );
+}
+
 /// truncate(2) takes a path, so the fd-based open deny never sees it; the
 /// deny precheck must gate it or a denied file inside a granted write tree
 /// can be wiped.

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -67,6 +67,7 @@ and guarded paths. A warning and diff are still printed.
 ```bash
 # All learn tests
 cargo test -p sandlock-cli -- test_learn
+```
 
 Tests require Linux 5.6+ (seccomp notif) and Linux 5.13+ (Landlock). They run the real `sandlock` binary, so build first:
 


### PR DESCRIPTION
Follow-up to #113 (sandlock learn), addressing the remaining review findings plus deeper issues uncovered while fixing them.

## sandlock-core

**Deny-path gating: truncate/unlink (`c1fa373`).** Tracing the review's resolution/enforcement coupling concern showed the deny precheck was already scope-filtered (so #113 never widened enforcement), but revealed a pre-existing hole dating to the Rust rewrite: a `fs_deny`'d file inside a granted write tree could be wiped via `truncate(2)` or deleted via `unlinkat(2)`, since neither was intercepted (the fd-based open deny never sees path-based destruction). `fs_denied_path_syscalls()` is now the single source of truth for both the BPF notif list and the runtime precheck, and gates truncate, unlinkat (covers `AT_REMOVEDIR`), and legacy unlink/rmdir. This hole exists in every release through 0.8.5.

**policy_fn contract (`7759974`).** `POLICY_EVENT_SYSCALLS` now matches everything `emit_policy_event` can decode, so documented `SyscallEvent` fields fire for a policy_fn-only sandbox instead of depending on COW or network supervision side effects. Extending interception exposed two verdict bypasses: openat2/legacy open emit the same "openat" event as openat, and sendmsg/sendmmsg the same send class as sendto, but none were held, so `Verdict::Deny` was silently ignored for those variants. All are now held, and `PolicyCallback` documents the exact held/observation-only split.

**renameat(2) coverage (`ef5e6fa`).** The middle-generation variant between rename and renameat2 was absent everywhere: a raw `syscall(SYS_renameat, ...)` could rename a denied file away and emitted no policy event. Added `arch::sys_renameat()` (Option-returning; riscv64 provides only renameat2) and wired it alongside renameat2. Also moved the legacy fs syscalls into `syscall_category`'s File arm.

## sandlock learn

**Self-capture (`7765c82`).** Learned profiles included the sandlock binary and its libraries: execvp issues one execve attempt per $PATH candidate, and the `/proc/<pid>/maps` scan armed by an execve event fired on the pid's next event, which after a failed attempt is another execve still running the pre-exec (sandbox runtime) image. Since a successful execve never returns, the scan now skips exec events and fires on the first non-exec event, guaranteed to run under the new image. This also removes the `/usr/lib` symlink-alias duplicates the old-image scan produced.

**Cleanup batch (`9e16376`).** Upfront `--collapse-prefix` validation (before the workload runs), exit-status handling deduplicated into `require_clean_exit()` returning anyhow errors, `[program].exec` pinned to the observed absolute binary path, `is_junk_path` no longer swallows stable serial devices (`/dev/ttyS*`, `/dev/ttyUSB*`), tempfile back to dev-dependencies, doc-comment and docs/learn.md fixes.

## Tests

New regression tests: truncate/unlink/renameat deny bypasses (content-preservation asserts), fs-mutation events with resolved paths in a policy_fn-only sandbox, and `Verdict::Deny` blocking openat2 and sendmsg with EPERM. Full sandlock-core suite green locally (517 unit + 296 integration).

## Not in this PR

Known remaining learn issues, queued separately: unbracketed IPv6 endpoints in `network.allow`, phantom `udp://<ip>:80` entries from glibc getaddrinfo address-sorting probes, and `bind` never being written to `allow_bind` (server workloads do not round-trip).