### PR TITLE
cow: subtree-aware whiteouts with a durable deletion log and type-aware copy-up

### DIFF
--- a/crates/sandlock-core/src/chroot/dispatch.rs
+++ b/crates/sandlock-core/src/chroot/dispatch.rs
@@ -986,8 +986,8 @@ pub(crate) async fn handle_chroot_write(
                 if cow.matches(&old_str) {
                     match cow.handle_rename(&old_str, &new_host.to_string_lossy()) {
                         Ok(true) => return NotifAction::ReturnValue(0),
-                        Err(crate::error::BranchError::QuotaExceeded) => return NotifAction::Errno(libc::ENOSPC),
-                        _ => {}
+                        Err(errno) => return NotifAction::Errno(errno),
+                        Ok(false) => {}
                     }
                 }
             }

--- a/crates/sandlock-core/src/cow/deletions.rs
+++ b/crates/sandlock-core/src/cow/deletions.rs
@@ -1,0 +1,192 @@
+//! Subtree-aware whiteout tracking for the seccomp COW branch.
+//!
+//! A whiteout entered here hides the entered path AND everything beneath it
+//! in the merged view, the way removing a directory hides its contents.
+//! Entries are never removed: a path re-created after deletion is exposed by
+//! existing in the upper layer (upper presence shadows the whiteout), which
+//! is what makes an entry whose directory reappears behave as an opaque
+//! directory. The set therefore only grows, and the on-disk log is
+//! append-only.
+//!
+//! The log exists so the deletion half of a change set survives the process:
+//! the upper directory is self-describing on disk, the RAM-only deletion set
+//! was not (issues #159/#160/#161 all grew from that asymmetry). RAM stays
+//! the in-process source of truth; a log write failure degrades durability,
+//! not correctness, so it is deliberately not fatal.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::io::{BufRead, Write};
+use std::path::Path;
+
+pub(crate) struct DeletionSet {
+    entries: BTreeSet<String>,
+    log: Option<fs::File>,
+}
+
+fn escape(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    for c in raw.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+fn unescape(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut it = raw.chars();
+    while let Some(c) = it.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match it.next() {
+            Some('n') => out.push('\n'),
+            Some(other) => out.push(other),
+            None => out.push('\\'),
+        }
+    }
+    out
+}
+
+impl DeletionSet {
+    /// Open a fresh set. `log_path` is opened for appending; `None`, or a
+    /// path that cannot be created, gives a RAM-only set.
+    pub fn create(log_path: Option<&Path>) -> Self {
+        let log = log_path.and_then(|p| {
+            fs::OpenOptions::new().create(true).append(true).open(p).ok()
+        });
+        Self { entries: BTreeSet::new(), log }
+    }
+
+    /// Rebuild a set from an existing log and reopen the log for append.
+    /// Unreadable log lines are skipped, not fatal: a torn final line from a
+    /// crash must not hide the deletions before it.
+    // No production caller yet: this is the recovery half of the durability
+    // story, consumed by the preserved-branch sweep (PR #148 / RFC #65).
+    #[allow(dead_code)]
+    pub fn load(log_path: &Path) -> Self {
+        let mut entries = BTreeSet::new();
+        if let Ok(f) = fs::File::open(log_path) {
+            for line in std::io::BufReader::new(f).lines().map_while(Result::ok) {
+                if !line.is_empty() {
+                    entries.insert(unescape(&line));
+                }
+            }
+        }
+        let log = fs::OpenOptions::new().create(true).append(true).open(log_path).ok();
+        Self { entries, log }
+    }
+
+    /// Record `rel` as deleted. Idempotent; the log line and its fdatasync
+    /// happen only on first insertion.
+    pub fn insert(&mut self, rel: &str) {
+        if !self.entries.insert(rel.to_string()) {
+            return;
+        }
+        if let Some(f) = self.log.as_mut() {
+            let _ = writeln!(f, "{}", escape(rel));
+            let _ = f.sync_data();
+        }
+    }
+
+    /// True when `rel` or any ancestor directory of it has been deleted.
+    /// Matching is per path component: "d" covers "d/x" but never "d2".
+    pub fn covers(&self, rel: &str) -> bool {
+        if self.entries.contains(rel) {
+            return true;
+        }
+        let mut end = rel.len();
+        while let Some(i) = rel[..end].rfind('/') {
+            if self.entries.contains(&rel[..i]) {
+                return true;
+            }
+            end = i;
+        }
+        false
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &str> {
+        self.entries.iter().map(String::as_str)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn covers_exact_and_descendants_not_siblings() {
+        let mut s = DeletionSet::create(None);
+        s.insert("d");
+        assert!(s.covers("d"));
+        assert!(s.covers("d/x"));
+        assert!(s.covers("d/x/y"));
+        assert!(!s.covers("d2"));
+        assert!(!s.covers("d2/x"));
+        assert!(!s.covers("e"));
+    }
+
+    #[test]
+    fn covers_nested_entry() {
+        let mut s = DeletionSet::create(None);
+        s.insert("a/b");
+        assert!(!s.covers("a"));
+        assert!(s.covers("a/b/c"));
+        assert!(!s.covers("a/bc"));
+    }
+
+    #[test]
+    fn insert_is_idempotent() {
+        let mut s = DeletionSet::create(None);
+        s.insert("f");
+        s.insert("f");
+        assert_eq!(s.iter().collect::<Vec<_>>(), vec!["f"]);
+    }
+
+    #[test]
+    fn log_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("deleted.log");
+        {
+            let mut s = DeletionSet::create(Some(&log));
+            s.insert("plain.txt");
+            s.insert("dir/with\nnewline");
+            s.insert("back\\slash");
+        }
+        let replayed = DeletionSet::load(&log);
+        assert_eq!(
+            replayed.iter().collect::<Vec<_>>(),
+            vec!["back\\slash", "dir/with\nnewline", "plain.txt"]
+        );
+        assert!(replayed.covers("dir/with\nnewline/child"));
+    }
+
+    #[test]
+    fn load_appends_not_truncates() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("deleted.log");
+        {
+            let mut s = DeletionSet::create(Some(&log));
+            s.insert("one");
+        }
+        {
+            let mut s = DeletionSet::load(&log);
+            s.insert("two");
+        }
+        let s = DeletionSet::load(&log);
+        assert_eq!(s.iter().collect::<Vec<_>>(), vec!["one", "two"]);
+    }
+
+    #[test]
+    fn ram_only_when_no_log() {
+        let mut s = DeletionSet::create(None);
+        s.insert("x");
+        assert!(s.covers("x"));
+        assert_eq!(s.iter().count(), 1);
+    }
+}

--- a/crates/sandlock-core/src/cow/deletions.rs
+++ b/crates/sandlock-core/src/cow/deletions.rs
@@ -30,6 +30,10 @@ fn escape(raw: &str) -> String {
         match c {
             '\\' => out.push_str("\\\\"),
             '\n' => out.push_str("\\n"),
+            // BufRead::lines strips a trailing \r on replay; unescaped, a
+            // path ending in \r would round-trip to the \r-less sibling,
+            // hiding that one and resurrecting the deleted path.
+            '\r' => out.push_str("\\r"),
             _ => out.push(c),
         }
     }
@@ -46,6 +50,7 @@ fn unescape(raw: &str) -> String {
         }
         match it.next() {
             Some('n') => out.push('\n'),
+            Some('r') => out.push('\r'),
             Some(other) => out.push(other),
             None => out.push('\\'),
         }
@@ -53,12 +58,26 @@ fn unescape(raw: &str) -> String {
     out
 }
 
+/// Persist the log's directory entry. `insert` only fdatasyncs the file
+/// itself, which does not cover the name in the parent directory: without
+/// this, a power loss after the first deletion can drop the whole log, the
+/// exact crash class it exists for. Best-effort like every other log write.
+fn sync_parent_dir(p: &Path) {
+    if let Some(dir) = p.parent() {
+        if let Ok(d) = fs::File::open(dir) {
+            let _ = d.sync_all();
+        }
+    }
+}
+
 impl DeletionSet {
     /// Open a fresh set. `log_path` is opened for appending; `None`, or a
     /// path that cannot be created, gives a RAM-only set.
     pub fn create(log_path: Option<&Path>) -> Self {
         let log = log_path.and_then(|p| {
-            fs::OpenOptions::new().create(true).append(true).open(p).ok()
+            let f = fs::OpenOptions::new().create(true).append(true).open(p).ok()?;
+            sync_parent_dir(p);
+            Some(f)
         });
         Self { entries: BTreeSet::new(), log }
     }
@@ -78,7 +97,12 @@ impl DeletionSet {
                 }
             }
         }
-        let log = fs::OpenOptions::new().create(true).append(true).open(log_path).ok();
+        let log = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(log_path)
+            .ok()
+            .inspect(|_| sync_parent_dir(log_path));
         Self { entries, log }
     }
 
@@ -164,6 +188,25 @@ mod tests {
             vec!["back\\slash", "dir/with\nnewline", "plain.txt"]
         );
         assert!(replayed.covers("dir/with\nnewline/child"));
+    }
+
+    #[test]
+    fn log_roundtrip_carriage_return() {
+        // A trailing \r is stripped by the line reader; without escaping,
+        // "d/file\r" would replay as "d/file", after which covers() hides
+        // the wrong sibling and the actually-deleted path resurrects.
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("deleted.log");
+        {
+            let mut s = DeletionSet::create(Some(&log));
+            s.insert("d/file\r");
+            s.insert("mid\rdle");
+        }
+        let replayed = DeletionSet::load(&log);
+        assert!(replayed.covers("d/file\r"));
+        assert!(!replayed.covers("d/file"));
+        assert!(replayed.covers("mid\rdle"));
+        assert!(replayed.covers("mid\rdle/child"));
     }
 
     #[test]

--- a/crates/sandlock-core/src/cow/dispatch.rs
+++ b/crates/sandlock-core/src/cow/dispatch.rs
@@ -491,6 +491,9 @@ fn cow_result(r: Result<bool, crate::error::BranchError>) -> NotifAction {
         Ok(true) => NotifAction::ReturnValue(0),
         Err(crate::error::BranchError::QuotaExceeded) => NotifAction::Errno(libc::ENOSPC),
         Err(crate::error::BranchError::Denied) => NotifAction::Errno(libc::EPERM),
+        // Whiteouted source: Continue would let the kernel act on the lower
+        // entry, which still exists with its pre-delete content.
+        Err(crate::error::BranchError::Deleted) => NotifAction::Errno(libc::ENOENT),
         _ => NotifAction::Continue,
     }
 }

--- a/crates/sandlock-core/src/cow/dispatch.rs
+++ b/crates/sandlock-core/src/cow/dispatch.rs
@@ -498,7 +498,7 @@ fn cow_result(r: Result<bool, crate::error::BranchError>) -> NotifAction {
     }
 }
 
-/// Map an unlink result (returns errno directly) to a NotifAction.
+/// Map an errno-style handler result (unlink, rename) to a NotifAction.
 fn unlink_result(r: Result<bool, i32>) -> NotifAction {
     match r {
         Ok(true) => NotifAction::ReturnValue(0),
@@ -631,7 +631,7 @@ pub(crate) async fn handle_cow_write(
         }
         CowWriteOp::Rename { ref old_path, ref new_path } => {
             if !cow.matches(old_path) { return NotifAction::Continue; }
-            cow_result(cow.handle_rename(old_path, new_path))
+            unlink_result(cow.handle_rename(old_path, new_path))
         }
         CowWriteOp::Symlink { ref target, ref linkpath } => {
             if !cow.matches(linkpath) { return NotifAction::Continue; }

--- a/crates/sandlock-core/src/cow/dispatch.rs
+++ b/crates/sandlock-core/src/cow/dispatch.rs
@@ -813,9 +813,25 @@ pub(crate) async fn handle_cow_stat(
 
     // newfstatat(dirfd, pathname, statbuf, flags)
     // faccessat(dirfd, pathname, mode, flags)
-    let dirfd = notif.data.args[0] as i64;
+    // stat/lstat(pathname, statbuf), access(pathname, mode)
+    //
+    // The legacy x86_64 variants carry the path in args[0] and have no
+    // dirfd or flags. Parsing them with the at-variant layout reads the
+    // statbuf pointer as the path, never matches the workdir, and falls
+    // through to the kernel, which leaks whiteouted lower entries to any
+    // static-libc child that emits legacy stat (same register-layout bug
+    // handle_cow_open fixed for legacy open).
+    let legacy = [arch::sys_stat(), arch::sys_lstat(), arch::sys_access()]
+        .into_iter()
+        .flatten()
+        .any(|l| l == nr);
+    let (dirfd, path_ptr) = if legacy {
+        (libc::AT_FDCWD as i64, notif.data.args[0])
+    } else {
+        (notif.data.args[0] as i64, notif.data.args[1])
+    };
     let virtual_cwd = current_virtual_cwd(processes, notif.pid).await;
-    let path = match read_path(notif, notif.data.args[1], notif_fd) {
+    let path = match read_path(notif, path_ptr, notif_fd) {
         Some(p) => resolve_at_path_with_virtual(notif, dirfd, &p, virtual_cwd.as_deref()),
         None => return NotifAction::Continue,
     };
@@ -839,7 +855,10 @@ pub(crate) async fn handle_cow_stat(
         (real, upper_root, workdir_root)
     };
 
-    if nr == libc::SYS_faccessat || nr == crate::arch::SYS_FACCESSAT2 {
+    if nr == libc::SYS_faccessat
+        || nr == crate::arch::SYS_FACCESSAT2
+        || arch::sys_access() == Some(nr)
+    {
         // Existence check, confined: lstat succeeds for any present entry
         // (including a dangling symlink), matching the prior semantics.
         let (root, rel) = match pick_root_rel(&upper_root, &workdir_root, &real_path) {
@@ -852,12 +871,16 @@ pub(crate) async fn handle_cow_stat(
         return NotifAction::Errno(libc::ENOENT);
     }
 
-    // newfstatat — stat the resolved path (confined to its layer root) and
-    // write the native libc layout back to the child. Do not hand-pack struct
-    // stat; its layout is architecture-specific.
-    let statbuf_addr = notif.data.args[2];
-    let flags = (notif.data.args[3] & 0xFFFF_FFFF) as i32;
-    let follow = (flags & libc::AT_SYMLINK_NOFOLLOW) == 0;
+    // newfstatat/stat/lstat — stat the resolved path (confined to its layer
+    // root) and write the native libc layout back to the child. Do not
+    // hand-pack struct stat; its layout is architecture-specific.
+    let statbuf_addr = if legacy { notif.data.args[1] } else { notif.data.args[2] };
+    let follow = if legacy {
+        arch::sys_lstat() != Some(nr)
+    } else {
+        let flags = (notif.data.args[3] & 0xFFFF_FFFF) as i32;
+        (flags & libc::AT_SYMLINK_NOFOLLOW) == 0
+    };
     let (root, rel) = match pick_root_rel(&upper_root, &workdir_root, &real_path) {
         Ok(v) => v,
         Err(e) => return NotifAction::Errno(e),

--- a/crates/sandlock-core/src/cow/mod.rs
+++ b/crates/sandlock-core/src/cow/mod.rs
@@ -1,2 +1,3 @@
+pub(crate) mod deletions;
 pub(crate) mod seccomp;
 pub(crate) mod dispatch;

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -544,6 +544,9 @@ impl SeccompCowBranch {
             Some(r) => r,
             None => return Ok(false),
         };
+        if self.is_deleted(&rel) {
+            return Err(libc::ENOENT);
+        }
         let upper_file = self.upper.join(&rel);
         let lower_file = self.workdir.join(&rel);
 
@@ -567,6 +570,14 @@ impl SeccompCowBranch {
                 // unlink() on a directory → EISDIR
                 return Err(libc::EISDIR);
             }
+        }
+
+        // rmdir semantics come from the merged view: entries in either layer
+        // that the child can still see make the directory non-empty (issue
+        // #161). The path-based whiteout would otherwise delete a subtree the
+        // child never emptied, and would do it while reporting success.
+        if is_dir && !self.list_merged_dir(&rel).is_empty() {
+            return Err(libc::ENOTEMPTY);
         }
 
         if upper_file.exists() || upper_file.is_symlink() {
@@ -1904,6 +1915,70 @@ mod tests {
             .collect();
         assert_eq!(for_path.len(), 1);
         assert_eq!(for_path[0].kind, crate::dry_run::ChangeKind::Added);
+    }
+
+    #[test]
+    fn rmdir_nonempty_gives_enotempty() {
+        // Issue #161: rmdir must consult the merged view, as the kernel would.
+        let (workdir, storage) = setup_workdir();
+        fs::create_dir(workdir.path().join("d")).unwrap();
+        fs::write(workdir.path().join("d/inner.txt"), "DATA").unwrap();
+        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        let wd = branch.workdir_str().to_string();
+
+        assert_eq!(
+            branch.handle_unlink(&format!("{}/d", wd), true),
+            Err(libc::ENOTEMPTY)
+        );
+        assert!(workdir.path().join("d/inner.txt").exists());
+        branch.commit().unwrap();
+        assert!(workdir.path().join("d/inner.txt").exists());
+    }
+
+    #[test]
+    fn rmdir_succeeds_after_draining_merged_view() {
+        let (workdir, storage) = setup_workdir();
+        fs::create_dir(workdir.path().join("d")).unwrap();
+        fs::write(workdir.path().join("d/inner.txt"), "DATA").unwrap();
+        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        let wd = branch.workdir_str().to_string();
+
+        assert_eq!(
+            branch.handle_unlink(&format!("{}/d/inner.txt", wd), false),
+            Ok(true)
+        );
+        assert_eq!(branch.handle_unlink(&format!("{}/d", wd), true), Ok(true));
+        branch.commit().unwrap();
+        assert!(!workdir.path().join("d").exists());
+    }
+
+    #[test]
+    fn rmdir_nonempty_in_upper_only_gives_enotempty() {
+        // Emptiness is about the merged view: content that exists only in
+        // the upper still blocks the rmdir.
+        let (workdir, storage) = setup_workdir();
+        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        let wd = branch.workdir_str().to_string();
+        assert!(branch.handle_mkdir(&format!("{}/newdir", wd)).unwrap());
+        fs::write(branch.upper_dir().join("newdir/f.txt"), "x").unwrap();
+        assert_eq!(
+            branch.handle_unlink(&format!("{}/newdir", wd), true),
+            Err(libc::ENOTEMPTY)
+        );
+    }
+
+    #[test]
+    fn unlink_hidden_path_gives_enoent() {
+        let (workdir, storage) = setup_workdir();
+        fs::create_dir(workdir.path().join("d")).unwrap();
+        fs::write(workdir.path().join("d/inner.txt"), "DATA").unwrap();
+        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        branch.mark_deleted("d");
+        let wd = branch.workdir_str().to_string();
+        assert_eq!(
+            branch.handle_unlink(&format!("{}/d/inner.txt", wd), false),
+            Err(libc::ENOENT)
+        );
     }
 
     #[test]

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -82,13 +82,14 @@ fn dir_size(dir: &Path) -> u64 {
 }
 
 /// Seccomp-based COW branch. Redirects writes to an upper directory
-/// and tracks deletions in memory.
+/// and tracks deletions in a subtree-aware whiteout set, mirrored to an
+/// append-only log beside the upper.
 pub struct SeccompCowBranch {
     workdir: PathBuf,
     workdir_str: String,
     upper: PathBuf,
     storage_dir: PathBuf,
-    deleted: HashSet<String>,
+    deleted: crate::cow::deletions::DeletionSet,
     has_changes: bool,
     finished: bool,
     max_disk_bytes: u64,
@@ -113,12 +114,15 @@ impl SeccompCowBranch {
         let workdir = workdir.canonicalize()
             .map_err(|e| BranchError::Operation(format!("canonicalize workdir: {}", e)))?;
 
+        let deleted =
+            crate::cow::deletions::DeletionSet::create(Some(&branch_dir.join("deleted.log")));
+
         Ok(Self {
             workdir_str: workdir.to_string_lossy().into_owned(),
             workdir,
             upper,
             storage_dir: branch_dir,
-            deleted: HashSet::new(),
+            deleted,
             has_changes: false,
             finished: false,
             max_disk_bytes,
@@ -153,10 +157,12 @@ impl SeccompCowBranch {
     }
 
     /// Check if a path has been modified or deleted in the COW layer.
-    /// Used to skip read-only opens for unmodified files.
+    /// Used to skip read-only opens for unmodified files. A path covered by
+    /// a whiteout needs interception even when re-created in the upper: the
+    /// read must be redirected there, never fall through to the lower file.
     pub fn needs_read_intercept(&self, path: &str) -> bool {
         if let Some(rel) = self.safe_rel(path) {
-            self.is_deleted(&rel) || self.upper.join(&rel).exists()
+            self.deleted.covers(&rel) || self.upper.join(&rel).exists()
         } else {
             false
         }
@@ -172,14 +178,21 @@ impl SeccompCowBranch {
         Some(rel_str)
     }
 
-    /// Check if a relative path has been deleted.
-    pub fn is_deleted(&self, rel_path: &str) -> bool {
-        self.deleted.contains(rel_path)
+    /// Confined lstat: does the upper hold an entry (any type) at `rel`?
+    fn upper_has(&self, rel: &str) -> bool {
+        crate::sys::fs::statat_in_root(&self.upper, rel, false).is_ok()
     }
 
-    /// Mark a relative path as deleted.
+    /// Check if a relative path is hidden by a whiteout in the merged view.
+    /// A whiteout covers its whole subtree; an entry re-created in the upper
+    /// shadows the whiteout and is visible again.
+    pub fn is_deleted(&self, rel_path: &str) -> bool {
+        self.deleted.covers(rel_path) && !self.upper_has(rel_path)
+    }
+
+    /// Mark a relative path as deleted (whiteout over it and its subtree).
     pub fn mark_deleted(&mut self, rel_path: &str) {
-        self.deleted.insert(rel_path.to_string());
+        self.deleted.insert(rel_path);
         self.has_changes = true;
     }
 
@@ -212,7 +225,6 @@ impl SeccompCowBranch {
     /// file copies to the caller. This is the shared core used by both
     /// `ensure_cow_copy` (synchronous) and the async two-phase dispatch.
     pub fn prepare_copy(&mut self, rel_path: &str) -> Result<CowCopyPlan, BranchError> {
-        self.deleted.remove(rel_path);
         self.has_changes = true;
 
         let upper_file = self.upper.join(rel_path);
@@ -226,6 +238,15 @@ impl SeccompCowBranch {
 
         if let Some(p) = parent_rel(rel_path) {
             let _ = crate::sys::fs::mkdirp_in_root(&self.upper, p, 0o755);
+        }
+
+        // A whiteout covers this path: the lower entry is logically gone, so
+        // there is nothing to copy up. Creating over the whiteout starts
+        // fresh, and the entry appearing in the upper is what re-exposes it
+        // in the merged view (and what makes a re-created directory opaque).
+        if self.deleted.covers(rel_path) {
+            self.check_quota(0)?;
+            return Ok(CowCopyPlan::Ready(upper_file));
         }
 
         // Classify the lower entry confined to the workdir root, so a symlinked
@@ -574,7 +595,6 @@ impl SeccompCowBranch {
             None => return Ok(false),
         };
         self.check_quota(4096)?; // directory metadata
-        self.deleted.remove(&rel);
         self.has_changes = true;
         let ok = crate::sys::fs::mkdirp_in_root(&self.upper, &rel, 0o755).is_ok();
         if ok {
@@ -604,7 +624,6 @@ impl SeccompCowBranch {
             None => return Ok(false),
         };
         self.check_quota(256)?;
-        self.deleted.remove(&rel);
         self.has_changes = true;
         // Ensure the parent directory exists in the upper layer before creating
         // the node (mirrors handle_symlink; parent may only exist in lower).
@@ -670,7 +689,6 @@ impl SeccompCowBranch {
             return Ok(false);
         }
         self.check_quota(256)?;
-        self.deleted.remove(&rel);
         self.has_changes = true;
         if let Some(p) = parent_rel(&rel) {
             let _ = crate::sys::fs::mkdirp_in_root(&self.upper, p, 0o755);
@@ -782,8 +800,15 @@ impl SeccompCowBranch {
             return None;
         }
         // Read the link confined to each layer root so a symlinked parent
-        // component cannot escape the tree (issue #112).
-        for root in [&self.upper, &self.workdir] {
+        // component cannot escape the tree (issue #112). A covered path only
+        // consults the upper: falling through to the lower link would leak
+        // the pre-delete target of a whiteouted-then-recreated entry.
+        let roots: &[&PathBuf] = if self.deleted.covers(&rel) {
+            &[&self.upper]
+        } else {
+            &[&self.upper, &self.workdir]
+        };
+        for root in roots {
             if let Ok(target) = crate::sys::fs::readlink_in_root(root, &rel) {
                 return Some(String::from_utf8_lossy(&target).into_owned());
             }
@@ -805,7 +830,11 @@ impl SeccompCowBranch {
             }
             let rel = entry.path().strip_prefix(&self.upper).unwrap();
             let lower = self.workdir.join(rel);
-            let kind = if lower.exists() {
+            // A covered path's lower entry is logically gone, so a re-created
+            // upper entry is an addition even though lower bytes still exist.
+            let kind = if self.deleted.covers(&rel.to_string_lossy()) {
+                ChangeKind::Added
+            } else if lower.exists() {
                 ChangeKind::Modified
             } else {
                 ChangeKind::Added
@@ -813,8 +842,12 @@ impl SeccompCowBranch {
             result.push(Change { kind, path: rel.to_path_buf() });
         }
 
-        // Deletions from tracked set
-        for rel_path in &self.deleted {
+        // Deletions from the whiteout set; an entry re-created in the upper
+        // is reported by the upper walk instead.
+        for rel_path in self.deleted.iter() {
+            if self.upper_has(rel_path) {
+                continue;
+            }
             result.push(Change {
                 kind: ChangeKind::Deleted,
                 path: std::path::PathBuf::from(rel_path),
@@ -843,7 +876,9 @@ impl SeccompCowBranch {
                 } else {
                     format!("{}/{}", rel_path, name)
                 };
-                if !self.is_deleted(&child_rel) {
+                // covers, not is_deleted: a covered child re-created in the
+                // upper was already inserted by the upper loop above.
+                if !self.deleted.covers(&child_rel) {
                     entries.insert(name);
                 }
             }
@@ -855,8 +890,9 @@ impl SeccompCowBranch {
     pub fn commit(&mut self) -> Result<(), BranchError> {
         if self.finished { return Ok(()); }
 
-        // Apply deletions
-        for rel_path in &self.deleted {
+        // Apply deletions first; the upper overlay below re-creates anything
+        // shadowed, which is exactly the opaque-directory merge order.
+        for rel_path in self.deleted.iter() {
             let dest = self.workdir.join(rel_path);
             if dest.is_dir() {
                 let _ = crate::sys::fs::remove_dir_all_in_root(&self.workdir, rel_path);
@@ -1170,11 +1206,10 @@ mod tests {
     #[test]
     fn test_quota_handle_open_create_denied() {
         let (workdir, storage) = setup_workdir();
-        // O_CREAT on a deleted file triggers ensure_cow_copy.
+        // O_CREAT on an existing (not deleted) file triggers the copy-up,
+        // which must fail when the 5-byte file exceeds the 4-byte quota.
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 4).unwrap();
         let path = abs(&branch, "existing.txt");
-        branch.mark_deleted("existing.txt");
-        // O_CREAT on a deleted path — tries to COW-copy the 5-byte file, should fail.
         let err = branch.handle_open(&path, O_CREAT).unwrap_err();
         assert!(matches!(err, BranchError::QuotaExceeded));
     }
@@ -1769,5 +1804,115 @@ mod tests {
         // Nothing was readable to copy, so the plan is a fresh (absent or
         // empty) upper entry, never the lower bytes and never an error.
         assert!(!upper.exists() || fs::read(&upper).unwrap().is_empty());
+    }
+
+    // ---- Subtree whiteout semantics (issues #159/#160/#161 family) ----
+
+    #[test]
+    fn deleted_dir_hides_children() {
+        // Issue #159: a whiteout must cover the subtree, not just the path.
+        let (workdir, storage) = setup_workdir();
+        fs::create_dir(workdir.path().join("d")).unwrap();
+        fs::write(workdir.path().join("d/secret.txt"), "SECRET").unwrap();
+        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        branch.mark_deleted("d");
+
+        assert!(branch.is_deleted("d"));
+        assert!(branch.is_deleted("d/secret.txt"));
+        assert!(branch.list_merged_dir("d").is_empty());
+        assert!(matches!(
+            branch.handle_open(&format!("{}/d/secret.txt", branch.workdir_str()), 0),
+            Err(BranchError::Deleted)
+        ));
+        assert!(branch
+            .handle_stat(&format!("{}/d/secret.txt", branch.workdir_str()))
+            .is_none());
+        // Sibling boundary: d2 is not covered by the d whiteout.
+        fs::write(workdir.path().join("d2"), "kept").unwrap();
+        assert!(!branch.is_deleted("d2"));
+    }
+
+    #[test]
+    fn write_under_deleted_dir_does_not_republish_on_commit() {
+        // Issue #159 integrity half: a write-open under the deleted directory
+        // must not resurrect the deleted file's bytes into the commit.
+        let (workdir, storage) = setup_workdir();
+        fs::create_dir(workdir.path().join("d")).unwrap();
+        fs::write(workdir.path().join("d/secret.txt"), "SECRET").unwrap();
+        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        branch.mark_deleted("d");
+
+        let flags = (libc::O_WRONLY | libc::O_CREAT) as u64;
+        let upper = branch
+            .handle_open(&format!("{}/d/secret.txt", branch.workdir_str()), flags)
+            .unwrap()
+            .expect("create over whiteout resolves into upper");
+        // The plan points at the upper path; the child's O_CREAT would create
+        // it empty. Simulate that create with fresh bytes.
+        fs::write(&upper, "NEW").unwrap();
+
+        branch.commit().unwrap();
+        assert_eq!(
+            fs::read_to_string(workdir.path().join("d/secret.txt")).unwrap(),
+            "NEW"
+        );
+    }
+
+    #[test]
+    fn create_over_deleted_file_starts_empty() {
+        // Same failure class as #159: O_CREAT on a whiteouted file used to
+        // copy the pre-delete lower bytes up. It must start fresh.
+        let (workdir, storage) = setup_workdir();
+        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        branch.mark_deleted("existing.txt");
+        let upper = branch.ensure_cow_copy("existing.txt").unwrap();
+        assert!(!upper.exists() || fs::read(&upper).unwrap().is_empty());
+    }
+
+    #[test]
+    fn mkdir_over_deleted_dir_is_opaque() {
+        // rmdir d; mkdir d must yield an EMPTY d: the old contents stay hidden.
+        let (workdir, storage) = setup_workdir();
+        fs::create_dir(workdir.path().join("d")).unwrap();
+        fs::write(workdir.path().join("d/old.txt"), "old").unwrap();
+        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        branch.mark_deleted("d");
+        let wd = branch.workdir_str().to_string();
+        assert!(branch.handle_mkdir(&format!("{}/d", wd)).unwrap());
+
+        assert!(!branch.is_deleted("d"));
+        assert!(branch.is_deleted("d/old.txt"));
+        assert!(branch.list_merged_dir("d").is_empty());
+
+        branch.commit().unwrap();
+        assert!(workdir.path().join("d").is_dir());
+        assert!(!workdir.path().join("d/old.txt").exists());
+    }
+
+    #[test]
+    fn changes_skips_shadowed_whiteouts() {
+        let (workdir, storage) = setup_workdir();
+        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        branch.mark_deleted("existing.txt");
+        let upper = branch.ensure_cow_copy("existing.txt").unwrap();
+        fs::write(&upper, "recreated").unwrap();
+        let changes = branch.changes().unwrap();
+        // The recreated file is a single Added entry, not Deleted + Modified.
+        let for_path: Vec<_> = changes
+            .iter()
+            .filter(|c| c.path == std::path::Path::new("existing.txt"))
+            .collect();
+        assert_eq!(for_path.len(), 1);
+        assert_eq!(for_path[0].kind, crate::dry_run::ChangeKind::Added);
+    }
+
+    #[test]
+    fn deletion_log_written_beside_upper() {
+        let (workdir, storage) = setup_workdir();
+        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        branch.mark_deleted("existing.txt");
+        let log = branch.upper_dir().parent().unwrap().join("deleted.log");
+        let replayed = crate::cow::deletions::DeletionSet::load(&log);
+        assert!(replayed.covers("existing.txt"));
     }
 }

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -369,6 +369,37 @@ impl SeccompCowBranch {
         }
     }
 
+    /// Copy a lower tree into the upper, entry by entry, so a directory
+    /// rename can be staged in the branch without losing the contents
+    /// (issue #160). Each entry goes through the same confined,
+    /// quota-accounted single-entry copy-up, so symlinks are copied verbatim
+    /// and never followed (issue #112).
+    fn copy_up_tree(&mut self, rel: &str) -> Result<(), BranchError> {
+        self.ensure_cow_copy(rel)?;
+        let st = match crate::sys::fs::statat_in_root(&self.workdir, rel, false) {
+            Ok(st) => st,
+            Err(_) => return Ok(()),
+        };
+        if st.st_mode & libc::S_IFMT != libc::S_IFDIR {
+            return Ok(());
+        }
+        let names: Vec<String> = match fs::read_dir(self.workdir.join(rel)) {
+            Ok(rd) => rd
+                .flatten()
+                .map(|e| e.file_name().to_string_lossy().into_owned())
+                .collect(),
+            Err(_) => return Ok(()),
+        };
+        for name in names {
+            let child = format!("{}/{}", rel, name);
+            if self.deleted.covers(&child) && !self.upper_has(&child) {
+                continue;
+            }
+            self.copy_up_tree(&child)?;
+        }
+        Ok(())
+    }
+
     /// Resolve a read path: upper if modified, else lower.
     pub fn resolve_read(&self, rel_path: &str) -> PathBuf {
         let upper_file = self.upper.join(rel_path);
@@ -660,7 +691,10 @@ impl SeccompCowBranch {
             Some(r) => r,
             None => return Ok(false),
         };
-        let _old_upper = self.ensure_cow_copy(&old_rel)?;
+        if self.is_deleted(&old_rel) {
+            return Err(BranchError::Deleted);
+        }
+        self.copy_up_tree(&old_rel)?;
         if let Some(p) = parent_rel(&new_rel) {
             let _ = crate::sys::fs::mkdirp_in_root(&self.upper, p, 0o755);
         }
@@ -723,6 +757,18 @@ impl SeccompCowBranch {
             Some(r) => r,
             None => return Ok(false),
         };
+        if self.is_deleted(&old_rel) {
+            return Err(BranchError::Deleted);
+        }
+        // linkat on a directory is the kernel's EPERM to give; staging a
+        // copy for it would leave a meaningless empty dir in the upper.
+        let src_is_dir = crate::sys::fs::statat_in_root(&self.upper, &old_rel, false)
+            .or_else(|_| crate::sys::fs::statat_in_root(&self.workdir, &old_rel, false))
+            .map(|st| st.st_mode & libc::S_IFMT == libc::S_IFDIR)
+            .unwrap_or(false);
+        if src_is_dir {
+            return Ok(false);
+        }
         let _ = self.ensure_cow_copy(&old_rel)?;
         if let Some(p) = parent_rel(&new_rel) {
             let _ = crate::sys::fs::mkdirp_in_root(&self.upper, p, 0o755);
@@ -1979,6 +2025,104 @@ mod tests {
             branch.handle_unlink(&format!("{}/d/inner.txt", wd), false),
             Err(libc::ENOENT)
         );
+    }
+
+    #[test]
+    fn rename_lower_dir_preserves_contents() {
+        // Issue #160: renaming a lower-only directory must not destroy it.
+        let (workdir, storage) = setup_workdir();
+        let wd = workdir.path().canonicalize().unwrap();
+        fs::create_dir(wd.join("d")).unwrap();
+        fs::write(wd.join("d/inner.txt"), "PRECIOUS").unwrap();
+        fs::create_dir(wd.join("d/sub")).unwrap();
+        fs::write(wd.join("d/sub/deep.txt"), "DEEP").unwrap();
+
+        let mut branch = SeccompCowBranch::create(&wd, Some(storage.path()), 0).unwrap();
+        assert!(branch
+            .handle_rename(&format!("{}/d", wd.display()), &format!("{}/d2", wd.display()))
+            .unwrap());
+
+        // Merged view before commit: d hidden, d2 holds the tree.
+        assert!(branch.is_deleted("d"));
+        assert_eq!(
+            branch.list_merged_dir("d2"),
+            vec!["inner.txt".to_string(), "sub".to_string()]
+        );
+
+        branch.commit().unwrap();
+        assert!(!wd.join("d").exists());
+        assert_eq!(fs::read_to_string(wd.join("d2/inner.txt")).unwrap(), "PRECIOUS");
+        assert_eq!(fs::read_to_string(wd.join("d2/sub/deep.txt")).unwrap(), "DEEP");
+    }
+
+    #[test]
+    fn rename_dir_skips_deleted_children() {
+        // A child already whiteouted must not reappear under the new name.
+        let (workdir, storage) = setup_workdir();
+        let wd = workdir.path().canonicalize().unwrap();
+        fs::create_dir(wd.join("d")).unwrap();
+        fs::write(wd.join("d/keep.txt"), "keep").unwrap();
+        fs::write(wd.join("d/gone.txt"), "gone").unwrap();
+
+        let mut branch = SeccompCowBranch::create(&wd, Some(storage.path()), 0).unwrap();
+        assert_eq!(
+            branch.handle_unlink(&format!("{}/d/gone.txt", wd.display()), false),
+            Ok(true)
+        );
+        assert!(branch
+            .handle_rename(&format!("{}/d", wd.display()), &format!("{}/d2", wd.display()))
+            .unwrap());
+        branch.commit().unwrap();
+        assert!(wd.join("d2/keep.txt").exists());
+        assert!(!wd.join("d2/gone.txt").exists());
+    }
+
+    #[test]
+    fn rename_hidden_source_gives_deleted() {
+        let (workdir, storage) = setup_workdir();
+        let wd = workdir.path().canonicalize().unwrap();
+        let mut branch = SeccompCowBranch::create(&wd, Some(storage.path()), 0).unwrap();
+        branch.mark_deleted("existing.txt");
+        assert!(matches!(
+            branch.handle_rename(
+                &format!("{}/existing.txt", wd.display()),
+                &format!("{}/moved.txt", wd.display())
+            ),
+            Err(BranchError::Deleted)
+        ));
+    }
+
+    #[test]
+    fn rename_file_still_works() {
+        let (workdir, storage) = setup_workdir();
+        let wd = workdir.path().canonicalize().unwrap();
+        let mut branch = SeccompCowBranch::create(&wd, Some(storage.path()), 0).unwrap();
+        assert!(branch
+            .handle_rename(
+                &format!("{}/existing.txt", wd.display()),
+                &format!("{}/renamed.txt", wd.display())
+            )
+            .unwrap());
+        branch.commit().unwrap();
+        assert!(!wd.join("existing.txt").exists());
+        assert_eq!(fs::read_to_string(wd.join("renamed.txt")).unwrap(), "hello");
+    }
+
+    #[test]
+    fn link_on_directory_falls_through() {
+        // linkat on a directory is the kernel's EPERM to give; the branch
+        // must not stage an empty-dir copy for it.
+        let (workdir, storage) = setup_workdir();
+        let wd = workdir.path().canonicalize().unwrap();
+        fs::create_dir(wd.join("d")).unwrap();
+        let mut branch = SeccompCowBranch::create(&wd, Some(storage.path()), 0).unwrap();
+        assert_eq!(
+            branch
+                .handle_link(&format!("{}/d", wd.display()), &format!("{}/d2", wd.display()))
+                .unwrap(),
+            false
+        );
+        assert!(!branch.upper_dir().join("d").exists());
     }
 
     #[test]

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -2217,6 +2217,84 @@ mod tests {
         assert_eq!(fs::read(upper_root.join("race")).unwrap(), b"");
     }
 
+    /// Recursively snapshot the merged view as (rel path -> Option<bytes>),
+    /// None for directories. This is what the child observes during the run.
+    fn merged_snapshot(
+        branch: &SeccompCowBranch,
+        rel: &str,
+        out: &mut std::collections::BTreeMap<String, Option<Vec<u8>>>,
+    ) {
+        for name in branch.list_merged_dir(rel) {
+            let child = if rel == "." { name.clone() } else { format!("{}/{}", rel, name) };
+            let resolved = branch.resolve_read(&child);
+            if resolved.is_dir() {
+                out.insert(child.clone(), None);
+                merged_snapshot(branch, &child, out);
+            } else if resolved.is_file() {
+                out.insert(child.clone(), Some(fs::read(&resolved).unwrap()));
+            }
+        }
+    }
+
+    /// Snapshot a real directory tree in the same shape.
+    fn dir_snapshot(
+        root: &std::path::Path,
+        rel: &str,
+        out: &mut std::collections::BTreeMap<String, Option<Vec<u8>>>,
+    ) {
+        let dir = if rel == "." { root.to_path_buf() } else { root.join(rel) };
+        for e in fs::read_dir(dir).unwrap().flatten() {
+            let name = e.file_name().to_string_lossy().into_owned();
+            let child = if rel == "." { name } else { format!("{}/{}", rel, name) };
+            let p = e.path();
+            if p.is_dir() {
+                out.insert(child.clone(), None);
+                dir_snapshot(root, &child, out);
+            } else if p.is_file() {
+                out.insert(child.clone(), Some(fs::read(&p).unwrap()));
+            }
+        }
+    }
+
+    #[test]
+    fn commit_reproduces_merged_view() {
+        // The invariant behind #159/#160/#161: what the child observed during
+        // the run is exactly what commit() publishes.
+        let (workdir, storage) = setup_workdir();
+        let wd = workdir.path().canonicalize().unwrap();
+        fs::create_dir(wd.join("d")).unwrap();
+        fs::write(wd.join("d/a.txt"), "A").unwrap();
+        fs::write(wd.join("d/b.txt"), "B").unwrap();
+        fs::create_dir(wd.join("e")).unwrap();
+        fs::write(wd.join("e/keep.txt"), "K").unwrap();
+
+        let mut branch = SeccompCowBranch::create(&wd, Some(storage.path()), 0).unwrap();
+        let w = |r: &str| format!("{}/{}", wd.display(), r);
+
+        // A mix of the operations the four issues cover.
+        let up = branch
+            .handle_open(&w("new.txt"), (libc::O_WRONLY | libc::O_CREAT) as u64)
+            .unwrap()
+            .unwrap();
+        fs::write(&up, "NEW").unwrap();
+        let up = branch
+            .handle_open(&w("existing.txt"), libc::O_WRONLY as u64)
+            .unwrap()
+            .unwrap();
+        fs::write(&up, "MODIFIED").unwrap();
+        assert_eq!(branch.handle_unlink(&w("d/a.txt"), false), Ok(true));
+        assert!(branch.handle_rename(&w("d"), &w("moved")).unwrap());
+        assert_eq!(branch.handle_unlink(&w("subdir/nested.txt"), false), Ok(true));
+        assert_eq!(branch.handle_unlink(&w("subdir"), true), Ok(true));
+
+        let mut merged = std::collections::BTreeMap::new();
+        merged_snapshot(&branch, ".", &mut merged);
+        branch.commit().unwrap();
+        let mut committed = std::collections::BTreeMap::new();
+        dir_snapshot(&wd, ".", &mut committed);
+        assert_eq!(merged, committed);
+    }
+
     #[test]
     fn deletion_log_written_beside_upper() {
         let (workdir, storage) = setup_workdir();

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -416,28 +416,63 @@ impl SeccompCowBranch {
     /// (issue #160). Each entry goes through the same confined,
     /// quota-accounted single-entry copy-up, so symlinks are copied verbatim
     /// and never followed (issue #112).
-    fn copy_up_tree(&mut self, rel: &str) -> Result<(), BranchError> {
-        self.ensure_cow_copy(rel)?;
-        let st = match crate::sys::fs::statat_in_root(&self.workdir, rel, false) {
-            Ok(st) => st,
-            Err(_) => return Ok(()),
-        };
-        if st.st_mode & libc::S_IFMT != libc::S_IFDIR {
-            return Ok(());
+    ///
+    /// Staging is all-or-nothing: a mid-tree failure (EACCES, EIO, quota)
+    /// must propagate rather than truncate the copy, because the caller
+    /// whiteouts the source afterwards and untraversed children would be
+    /// silently lost at commit. On failure every upper entry this staging
+    /// created is removed again and the quota re-derived.
+    fn copy_up_tree(&mut self, rel: &str) -> Result<(), i32> {
+        let mut created: Vec<String> = Vec::new();
+        let result = self.stage_tree(rel, &mut created);
+        if result.is_err() {
+            for c in created.iter().rev() {
+                let is_dir = crate::sys::fs::statat_in_root(&self.upper, c, false)
+                    .map(|st| st.st_mode & libc::S_IFMT == libc::S_IFDIR)
+                    .unwrap_or(false);
+                if is_dir {
+                    let _ = crate::sys::fs::remove_dir_all_in_root(&self.upper, c);
+                } else {
+                    let _ = crate::sys::fs::unlinkat_in_root(&self.upper, c, false);
+                }
+            }
+            self.recalc_disk_used();
         }
-        let names: Vec<String> = match fs::read_dir(self.workdir.join(rel)) {
-            Ok(rd) => rd
-                .flatten()
-                .map(|e| e.file_name().to_string_lossy().into_owned())
-                .collect(),
-            Err(_) => return Ok(()),
-        };
-        for name in names {
-            let child = format!("{}/{}", rel, name);
-            if self.deleted.covers(&child) && !self.upper_has(&child) {
+        result
+    }
+
+    /// The traversal half of `copy_up_tree`: an explicit worklist (child
+    /// directory depth must not become supervisor stack depth) that records
+    /// every upper entry it creates into `created` for rollback.
+    fn stage_tree(&mut self, root: &str, created: &mut Vec<String>) -> Result<(), i32> {
+        let mut queue = std::collections::VecDeque::new();
+        queue.push_back(root.to_string());
+        while let Some(rel) = queue.pop_front() {
+            let was_in_upper = self.upper_has(&rel);
+            self.ensure_cow_copy(&rel).map_err(branch_errno)?;
+            if !was_in_upper && self.upper_has(&rel) {
+                created.push(rel.clone());
+            }
+            let st = match crate::sys::fs::statat_in_root(&self.workdir, &rel, false) {
+                Ok(st) => st,
+                // Upper-only entry: nothing below it in the lower to stage.
+                Err(libc::ENOENT) => continue,
+                Err(e) => return Err(e),
+            };
+            if st.st_mode & libc::S_IFMT != libc::S_IFDIR {
                 continue;
             }
-            self.copy_up_tree(&child)?;
+            let rd = fs::read_dir(self.workdir.join(&rel))
+                .map_err(|e| e.raw_os_error().unwrap_or(libc::EIO))?;
+            for entry in rd {
+                let entry = entry.map_err(|e| e.raw_os_error().unwrap_or(libc::EIO))?;
+                let name = entry.file_name().to_string_lossy().into_owned();
+                let child = format!("{}/{}", rel, name);
+                if self.deleted.covers(&child) && !self.upper_has(&child) {
+                    continue;
+                }
+                queue.push_back(child);
+            }
         }
         Ok(())
     }
@@ -786,7 +821,7 @@ impl SeccompCowBranch {
                 _ => {}
             }
         }
-        self.copy_up_tree(&old_rel).map_err(branch_errno)?;
+        self.copy_up_tree(&old_rel)?;
         if let Some(p) = parent_rel(&new_rel) {
             let _ = crate::sys::fs::mkdirp_in_root(&self.upper, p, 0o755);
         }
@@ -2346,6 +2381,82 @@ mod tests {
             ),
             Err(libc::ENOENT)
         );
+    }
+
+    #[test]
+    fn rename_staging_failure_fails_rename_and_rolls_back() {
+        // A mid-tree staging error used to be swallowed, after which the
+        // source was whiteouted anyway and the untraversed children were
+        // lost at commit. The rename must fail, leave the merged view
+        // untouched, and leave no partially staged destination behind.
+        use std::os::unix::fs::PermissionsExt;
+        let (workdir, storage) = setup_workdir();
+        let wd = workdir.path().canonicalize().unwrap();
+        fs::create_dir(wd.join("d")).unwrap();
+        fs::write(wd.join("d/top.txt"), "top").unwrap();
+        fs::create_dir(wd.join("d/inner")).unwrap();
+        fs::write(wd.join("d/inner/deep.txt"), "deep").unwrap();
+        fs::set_permissions(wd.join("d/inner"), fs::Permissions::from_mode(0o000)).unwrap();
+
+        let mut branch = SeccompCowBranch::create(&wd, Some(storage.path()), 0).unwrap();
+        let result = branch.handle_rename(
+            &format!("{}/d", wd.display()),
+            &format!("{}/moved", wd.display()),
+        );
+        fs::set_permissions(wd.join("d/inner"), fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert_eq!(result, Err(libc::EACCES));
+        assert!(!branch.is_deleted("d"), "failed rename must not whiteout the source");
+        assert!(!branch.upper_dir().join("d").exists(), "partial staging left behind");
+        let merged = branch.list_merged_dir("d");
+        assert!(merged.contains(&"inner".to_string()));
+        assert!(merged.contains(&"top.txt".to_string()));
+        branch.commit().unwrap();
+        assert_eq!(fs::read_to_string(wd.join("d/inner/deep.txt")).unwrap(), "deep");
+    }
+
+    #[test]
+    fn rename_quota_failure_leaves_no_partial_staging() {
+        let (workdir, storage) = setup_workdir();
+        let wd = workdir.path().canonicalize().unwrap();
+        fs::create_dir(wd.join("d")).unwrap();
+        fs::write(wd.join("d/f1"), vec![b'x'; 50]).unwrap();
+        // Quota fits the staged directory (4096) but not the file after it.
+        let mut branch = SeccompCowBranch::create(&wd, Some(storage.path()), 4100).unwrap();
+        assert_eq!(
+            branch.handle_rename(&format!("{}/d", wd.display()), &format!("{}/m", wd.display())),
+            Err(libc::ENOSPC)
+        );
+        assert!(!branch.is_deleted("d"));
+        assert!(!branch.upper_dir().join("d").exists(), "partial staging left behind");
+        // The rollback must also return the reserved quota: a small write
+        // elsewhere still fits.
+        assert!(branch.ensure_cow_copy("existing.txt").is_ok());
+    }
+
+    #[test]
+    fn rename_deep_tree_stages_iteratively() {
+        // The staging walk is a worklist, not recursion: child-controlled
+        // directory depth must not become supervisor stack depth.
+        let (workdir, storage) = setup_workdir();
+        let wd = workdir.path().canonicalize().unwrap();
+        let mut rel = String::from("d");
+        fs::create_dir(wd.join(&rel)).unwrap();
+        for _ in 0..400 {
+            rel.push_str("/d");
+            fs::create_dir(wd.join(&rel)).unwrap();
+        }
+        fs::write(wd.join(format!("{}/leaf.txt", rel)), "LEAF").unwrap();
+
+        let mut branch = SeccompCowBranch::create(&wd, Some(storage.path()), 0).unwrap();
+        assert_eq!(
+            branch.handle_rename(&format!("{}/d", wd.display()), &format!("{}/m", wd.display())),
+            Ok(true)
+        );
+        branch.commit().unwrap();
+        let deep = format!("m{}", &rel[1..]);
+        assert_eq!(fs::read_to_string(wd.join(format!("{}/leaf.txt", deep))).unwrap(), "LEAF");
+        assert!(!wd.join("d").exists());
     }
 
     #[test]

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -39,10 +39,6 @@ pub enum CowCopyPlan {
         lower: PathBuf,
         file_size: u64,
     },
-    /// Not COW-managed (FIFO, socket, device node): I/O through it does not
-    /// change the tree, and copying it can block forever (issue #158). The
-    /// kernel handles the syscall against the real workdir entry.
-    Passthrough,
 }
 
 /// Plan returned by `prepare_open` — describes what I/O to do after releasing the lock.
@@ -295,7 +291,24 @@ impl SeccompCowBranch {
         }
 
         if kind != libc::S_IFREG {
-            return Ok(CowCopyPlan::Passthrough);
+            // Non-regular lower (FIFO, socket, device node): its content is
+            // not filesystem data, and reading it can block forever (issue
+            // #158: a FIFO open waits for a writer). Virtualize the write
+            // like any other COW write, onto an empty regular stub in the
+            // upper, WITHOUT reading the source. Under a COW workdir a
+            // write must never need real permission on the lower entry
+            // (learn mode COWs whole trees, so `> /dev/null` lands here)
+            // and must never touch the real device.
+            self.check_quota(0)?;
+            let fd = crate::sys::fs::openat2_in_root(
+                &self.upper,
+                rel_path,
+                libc::O_WRONLY | libc::O_CREAT | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                0o600,
+            )
+            .map_err(|e| BranchError::Operation(format!("create cow stub: {}", e)))?;
+            unsafe { libc::close(fd) };
+            return Ok(CowCopyPlan::Ready(upper_file));
         }
 
         // Regular file — defer the potentially expensive copy. Size comes from
@@ -369,16 +382,14 @@ impl SeccompCowBranch {
         Ok(())
     }
 
-    /// Ensure a COW copy exists in upper (synchronous). Returns the upper
-    /// path, or `None` when the entry is not COW-managed (passthrough).
+    /// Ensure a COW copy exists in upper (synchronous). Returns the upper path.
     /// For callers that don't need async two-phase behavior.
-    pub fn ensure_cow_copy(&mut self, rel_path: &str) -> Result<Option<PathBuf>, BranchError> {
+    pub fn ensure_cow_copy(&mut self, rel_path: &str) -> Result<PathBuf, BranchError> {
         match self.prepare_copy(rel_path)? {
-            CowCopyPlan::Ready(upper) => Ok(Some(upper)),
-            CowCopyPlan::Passthrough => Ok(None),
+            CowCopyPlan::Ready(upper) => Ok(upper),
             CowCopyPlan::NeedsCopy { upper, lower: _lower, file_size } => {
                 match Self::execute_copy(&self.workdir, &self.upper, rel_path) {
-                    Ok(()) => Ok(Some(upper)),
+                    Ok(()) => Ok(upper),
                     Err(e) => {
                         self.rollback_copy(file_size);
                         Err(BranchError::Operation(format!("copy: {}", e)))
@@ -460,7 +471,7 @@ impl SeccompCowBranch {
 
         if self.is_deleted(&rel) {
             if flags & O_CREAT != 0 {
-                return self.ensure_cow_copy(&rel);
+                return self.ensure_cow_copy(&rel).map(Some);
             }
             // Whiteout: the lower file still physically exists with its
             // pre-delete bytes. Surface the deletion so the caller returns
@@ -481,11 +492,11 @@ impl SeccompCowBranch {
                 return Err(BranchError::Exists);
             }
             // File truly doesn't exist — create in upper
-            return self.ensure_cow_copy(&rel);
+            return self.ensure_cow_copy(&rel).map(Some);
         }
 
         if is_write {
-            self.ensure_cow_copy(&rel)
+            self.ensure_cow_copy(&rel).map(Some)
         } else {
             let resolved = self.resolve_read(&rel);
             if resolved.exists() || resolved.is_symlink() {
@@ -568,7 +579,6 @@ impl SeccompCowBranch {
     fn prepare_cow_copy(&mut self, rel_path: &str) -> Result<CowOpenPlan, BranchError> {
         match self.prepare_copy(rel_path)? {
             CowCopyPlan::Ready(upper) => Ok(CowOpenPlan::UpperReady { upper }),
-            CowCopyPlan::Passthrough => Ok(CowOpenPlan::Skip),
             CowCopyPlan::NeedsCopy { upper, lower, file_size } => {
                 Ok(CowOpenPlan::NeedsCopy {
                     upper,
@@ -789,9 +799,7 @@ impl SeccompCowBranch {
         if src_is_dir {
             return Ok(false);
         }
-        if self.ensure_cow_copy(&old_rel)?.is_none() {
-            return Ok(false);
-        }
+        let _ = self.ensure_cow_copy(&old_rel)?;
         if let Some(p) = parent_rel(&new_rel) {
             let _ = crate::sys::fs::mkdirp_in_root(&self.upper, p, 0o755);
         }
@@ -806,9 +814,7 @@ impl SeccompCowBranch {
             Some(r) => r,
             None => return Ok(false),
         };
-        if self.ensure_cow_copy(&rel)?.is_none() {
-            return Ok(false);
-        }
+        let _ = self.ensure_cow_copy(&rel)?;
         Ok(crate::sys::fs::chmod_in_root(&self.upper, &rel, mode).is_ok())
     }
 
@@ -820,9 +826,7 @@ impl SeccompCowBranch {
             Some(r) => r,
             None => return Ok(false),
         };
-        if self.ensure_cow_copy(&rel)?.is_none() {
-            return Ok(false);
-        }
+        let _ = self.ensure_cow_copy(&rel)?;
         // Best-effort: try the real chown but succeed either way — the
         // supervisor typically lacks CAP_CHOWN so this will fail, but
         // in COW/dry-run mode the ownership doesn't matter.
@@ -839,9 +843,7 @@ impl SeccompCowBranch {
             None => return Ok(false),
         };
         let new_len = length as u64;
-        if self.ensure_cow_copy(&rel)?.is_none() {
-            return Ok(false);
-        }
+        let _ = self.ensure_cow_copy(&rel)?;
         let old_len = crate::sys::fs::statat_in_root(&self.upper, &rel, true)
             .map(|st| st.st_size as u64)
             .unwrap_or(0);
@@ -874,7 +876,8 @@ impl SeccompCowBranch {
             Some(r) => r,
             None => return Ok(None),
         };
-        Ok(self.ensure_cow_copy(&rel)?)
+        let upper = self.ensure_cow_copy(&rel)?;
+        Ok(Some(upper))
     }
 
     /// Handle readlink.
@@ -1099,7 +1102,7 @@ mod tests {
     fn test_ensure_cow_copy() {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
-        let upper = branch.ensure_cow_copy("existing.txt").unwrap().unwrap();
+        let upper = branch.ensure_cow_copy("existing.txt").unwrap();
         assert!(upper.exists());
         assert_eq!(fs::read_to_string(&upper).unwrap(), "hello");
         assert!(branch.has_changes());
@@ -1109,7 +1112,7 @@ mod tests {
     fn test_resolve_read_prefers_upper() {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
-        let upper = branch.ensure_cow_copy("existing.txt").unwrap().unwrap();
+        let upper = branch.ensure_cow_copy("existing.txt").unwrap();
         fs::write(&upper, "modified").unwrap();
         let resolved = branch.resolve_read("existing.txt");
         assert_eq!(fs::read_to_string(&resolved).unwrap(), "modified");
@@ -1129,7 +1132,7 @@ mod tests {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
         // Write a new file via COW
-        let upper = branch.ensure_cow_copy("new.txt").unwrap().unwrap();
+        let upper = branch.ensure_cow_copy("new.txt").unwrap();
         fs::write(&upper, "new content").unwrap();
         branch.commit().unwrap();
         assert_eq!(fs::read_to_string(workdir.path().join("new.txt")).unwrap(), "new content");
@@ -1148,7 +1151,7 @@ mod tests {
     fn test_abort_discards_changes() {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
-        let upper = branch.ensure_cow_copy("new.txt").unwrap().unwrap();
+        let upper = branch.ensure_cow_copy("new.txt").unwrap();
         fs::write(&upper, "should be discarded").unwrap();
         branch.abort().unwrap();
         assert!(!workdir.path().join("new.txt").exists());
@@ -1158,7 +1161,7 @@ mod tests {
     fn test_changes_added_file() {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
-        let upper = branch.ensure_cow_copy("brand_new.txt").unwrap().unwrap();
+        let upper = branch.ensure_cow_copy("brand_new.txt").unwrap();
         fs::write(&upper, "new content").unwrap();
         let changes = branch.changes().unwrap();
         assert_eq!(changes.len(), 1);
@@ -1170,7 +1173,7 @@ mod tests {
     fn test_changes_modified_file() {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
-        let upper = branch.ensure_cow_copy("existing.txt").unwrap().unwrap();
+        let upper = branch.ensure_cow_copy("existing.txt").unwrap();
         fs::write(&upper, "modified content").unwrap();
         let changes = branch.changes().unwrap();
         assert_eq!(changes.len(), 1);
@@ -1201,9 +1204,9 @@ mod tests {
     fn test_changes_mixed() {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
-        let upper = branch.ensure_cow_copy("new.txt").unwrap().unwrap();
+        let upper = branch.ensure_cow_copy("new.txt").unwrap();
         fs::write(&upper, "new").unwrap();
-        let upper2 = branch.ensure_cow_copy("existing.txt").unwrap().unwrap();
+        let upper2 = branch.ensure_cow_copy("existing.txt").unwrap();
         fs::write(&upper2, "changed").unwrap();
         branch.mark_deleted("subdir/nested.txt");
 
@@ -1537,7 +1540,7 @@ mod tests {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
         // Create a file only in upper (brand new file)
-        let upper = branch.ensure_cow_copy("brand_new.txt").unwrap().unwrap();
+        let upper = branch.ensure_cow_copy("brand_new.txt").unwrap();
         std::fs::write(&upper, "content").unwrap();
         let path = abs(&branch, "brand_new.txt");
         // O_WRONLY | O_CREAT | O_EXCL — file exists in upper
@@ -1752,7 +1755,7 @@ mod tests {
             SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
 
         // ensure_cow_copy on a path reached through the symlinked parent.
-        let upper = branch.ensure_cow_copy("evil/group").unwrap().unwrap();
+        let upper = branch.ensure_cow_copy("evil/group").unwrap();
 
         // The upper file must NOT contain the host /etc/group contents.
         let host = std::fs::read_to_string("/etc/group").unwrap_or_default();
@@ -1768,7 +1771,7 @@ mod tests {
         let (workdir, storage) = setup_workdir();
         let mut branch =
             SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
-        let upper = branch.ensure_cow_copy("existing.txt").unwrap().unwrap();
+        let upper = branch.ensure_cow_copy("existing.txt").unwrap();
         assert_eq!(std::fs::read_to_string(&upper).unwrap(), "hello");
     }
 
@@ -1782,7 +1785,7 @@ mod tests {
         let mut branch =
             SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
         // Trigger copy-up of the symlink into upper.
-        let upper = branch.ensure_cow_copy("secret").unwrap().unwrap();
+        let upper = branch.ensure_cow_copy("secret").unwrap();
         assert!(upper.is_symlink(), "precondition: upper holds a verbatim symlink");
 
         branch.commit().unwrap();
@@ -1806,7 +1809,7 @@ mod tests {
         std::os::unix::fs::symlink("existing.txt", workdir.path().join("link")).unwrap();
         let mut branch =
             SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
-        let upper = branch.ensure_cow_copy("link").unwrap().unwrap();
+        let upper = branch.ensure_cow_copy("link").unwrap();
         assert!(upper.is_symlink(), "in-tree symlink was not preserved");
         assert_eq!(
             std::fs::read_link(&upper).unwrap(),
@@ -1949,7 +1952,7 @@ mod tests {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
         branch.mark_deleted("existing.txt");
-        let upper = branch.ensure_cow_copy("existing.txt").unwrap().unwrap();
+        let upper = branch.ensure_cow_copy("existing.txt").unwrap();
         assert!(!upper.exists() || fs::read(&upper).unwrap().is_empty());
     }
 
@@ -1978,7 +1981,7 @@ mod tests {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
         branch.mark_deleted("existing.txt");
-        let upper = branch.ensure_cow_copy("existing.txt").unwrap().unwrap();
+        let upper = branch.ensure_cow_copy("existing.txt").unwrap();
         fs::write(&upper, "recreated").unwrap();
         let changes = branch.changes().unwrap();
         // The recreated file is a single Added entry, not Deleted + Modified.
@@ -2168,17 +2171,22 @@ mod tests {
         let (tx, rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
             let mut b = SeccompCowBranch::create(&wd, Some(&sd), 0).unwrap();
-            let _ = tx.send(b.ensure_cow_copy("pipe").map(|p| p.is_none()));
+            let _ = tx.send(b.ensure_cow_copy("pipe").map(|p| fs::read(p).map(|b| b.len())));
         });
         match rx.recv_timeout(std::time::Duration::from_secs(5)) {
-            Ok(Ok(true)) => {}
-            Ok(other) => panic!("expected passthrough for a FIFO, got {:?}", other),
+            // The FIFO is virtualized as an empty regular stub in the upper,
+            // created without ever opening the FIFO itself.
+            Ok(Ok(Ok(0))) => {}
+            Ok(other) => panic!("expected an empty upper stub for a FIFO, got {:?}", other),
             Err(_) => panic!("copy-up of a FIFO hung"),
         }
     }
 
     #[test]
-    fn write_open_of_fifo_is_not_intercepted() {
+    fn write_open_of_fifo_virtualizes_to_upper_stub() {
+        // A write-open of a FIFO under the COW tree keeps the virtualization
+        // contract (`> /dev/null` in a learn-mode tree must not need real
+        // write permission on /dev), and must not block the supervisor.
         let (workdir, storage) = setup_workdir();
         let fifo = workdir.path().join("pipe");
         let c = std::ffi::CString::new(fifo.to_str().unwrap()).unwrap();
@@ -2186,19 +2194,25 @@ mod tests {
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
         let wd = branch.workdir_str().to_string();
         let flags = libc::O_WRONLY as u64;
-        assert_eq!(branch.handle_open(&format!("{}/pipe", wd), flags).unwrap(), None);
-        assert!(!branch.upper_dir().join("pipe").exists());
+        let resolved = branch.handle_open(&format!("{}/pipe", wd), flags).unwrap();
+        assert_eq!(resolved, Some(branch.upper_dir().join("pipe")));
+        let meta = fs::metadata(branch.upper_dir().join("pipe")).unwrap();
+        assert!(meta.file_type().is_file(), "upper stub must be a regular file");
+        assert_eq!(meta.len(), 0);
     }
 
     #[test]
-    fn chmod_of_fifo_falls_through() {
+    fn chmod_of_fifo_stays_in_upper() {
         let (workdir, storage) = setup_workdir();
         let fifo = workdir.path().join("pipe");
         let c = std::ffi::CString::new(fifo.to_str().unwrap()).unwrap();
         assert_eq!(unsafe { libc::mkfifo(c.as_ptr(), 0o644) }, 0);
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
         let wd = branch.workdir_str().to_string();
-        assert_eq!(branch.handle_chmod(&format!("{}/pipe", wd), 0o600).unwrap(), false);
+        assert_eq!(branch.handle_chmod(&format!("{}/pipe", wd), 0o600).unwrap(), true);
+        // The chmod landed on the upper stub, not the real FIFO.
+        let lower_mode = fs::metadata(&fifo).unwrap().permissions();
+        assert_eq!(std::os::unix::fs::PermissionsExt::mode(&lower_mode) & 0o777, 0o644);
     }
 
     #[test]

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -39,6 +39,10 @@ pub enum CowCopyPlan {
         lower: PathBuf,
         file_size: u64,
     },
+    /// Not COW-managed (FIFO, socket, device node): I/O through it does not
+    /// change the tree, and copying it can block forever (issue #158). The
+    /// kernel handles the syscall against the real workdir entry.
+    Passthrough,
 }
 
 /// Plan returned by `prepare_open` — describes what I/O to do after releasing the lock.
@@ -290,6 +294,10 @@ impl SeccompCowBranch {
             return Ok(CowCopyPlan::Ready(upper_file));
         }
 
+        if kind != libc::S_IFREG {
+            return Ok(CowCopyPlan::Passthrough);
+        }
+
         // Regular file — defer the potentially expensive copy. Size comes from
         // the confined lstat, so the quota reservation matches the file
         // execute_copy will actually read.
@@ -326,7 +334,7 @@ impl SeccompCowBranch {
         let src_fd = match crate::sys::fs::openat2_in_root(
             workdir_root,
             rel,
-            libc::O_RDONLY | libc::O_CLOEXEC,
+            libc::O_RDONLY | libc::O_NONBLOCK | libc::O_CLOEXEC,
             0,
         ) {
             Ok(fd) => fd,
@@ -344,6 +352,15 @@ impl SeccompCowBranch {
         };
 
         let mut src = unsafe { fs::File::from_raw_fd(src_fd) };
+        // prepare_copy classified this entry as a regular file, but it can
+        // change type between that lstat and this open. Never stream a
+        // non-regular source: a FIFO read blocks or steals pipe data (issue
+        // #158). O_NONBLOCK above makes the FIFO open itself return instead
+        // of waiting for a writer; on a regular file it is a no-op for reads.
+        if !src.metadata()?.file_type().is_file() {
+            create_dest()?;
+            return Ok(());
+        }
         let mut dst = create_dest()?;
         std::io::copy(&mut src, &mut dst)?;
         if let Ok(meta) = src.metadata() {
@@ -352,14 +369,16 @@ impl SeccompCowBranch {
         Ok(())
     }
 
-    /// Ensure a COW copy exists in upper (synchronous). Returns the upper path.
+    /// Ensure a COW copy exists in upper (synchronous). Returns the upper
+    /// path, or `None` when the entry is not COW-managed (passthrough).
     /// For callers that don't need async two-phase behavior.
-    pub fn ensure_cow_copy(&mut self, rel_path: &str) -> Result<PathBuf, BranchError> {
+    pub fn ensure_cow_copy(&mut self, rel_path: &str) -> Result<Option<PathBuf>, BranchError> {
         match self.prepare_copy(rel_path)? {
-            CowCopyPlan::Ready(upper) => Ok(upper),
+            CowCopyPlan::Ready(upper) => Ok(Some(upper)),
+            CowCopyPlan::Passthrough => Ok(None),
             CowCopyPlan::NeedsCopy { upper, lower: _lower, file_size } => {
                 match Self::execute_copy(&self.workdir, &self.upper, rel_path) {
-                    Ok(()) => Ok(upper),
+                    Ok(()) => Ok(Some(upper)),
                     Err(e) => {
                         self.rollback_copy(file_size);
                         Err(BranchError::Operation(format!("copy: {}", e)))
@@ -441,7 +460,7 @@ impl SeccompCowBranch {
 
         if self.is_deleted(&rel) {
             if flags & O_CREAT != 0 {
-                return self.ensure_cow_copy(&rel).map(Some);
+                return self.ensure_cow_copy(&rel);
             }
             // Whiteout: the lower file still physically exists with its
             // pre-delete bytes. Surface the deletion so the caller returns
@@ -462,11 +481,11 @@ impl SeccompCowBranch {
                 return Err(BranchError::Exists);
             }
             // File truly doesn't exist — create in upper
-            return self.ensure_cow_copy(&rel).map(Some);
+            return self.ensure_cow_copy(&rel);
         }
 
         if is_write {
-            self.ensure_cow_copy(&rel).map(Some)
+            self.ensure_cow_copy(&rel)
         } else {
             let resolved = self.resolve_read(&rel);
             if resolved.exists() || resolved.is_symlink() {
@@ -549,6 +568,7 @@ impl SeccompCowBranch {
     fn prepare_cow_copy(&mut self, rel_path: &str) -> Result<CowOpenPlan, BranchError> {
         match self.prepare_copy(rel_path)? {
             CowCopyPlan::Ready(upper) => Ok(CowOpenPlan::UpperReady { upper }),
+            CowCopyPlan::Passthrough => Ok(CowOpenPlan::Skip),
             CowCopyPlan::NeedsCopy { upper, lower, file_size } => {
                 Ok(CowOpenPlan::NeedsCopy {
                     upper,
@@ -769,7 +789,9 @@ impl SeccompCowBranch {
         if src_is_dir {
             return Ok(false);
         }
-        let _ = self.ensure_cow_copy(&old_rel)?;
+        if self.ensure_cow_copy(&old_rel)?.is_none() {
+            return Ok(false);
+        }
         if let Some(p) = parent_rel(&new_rel) {
             let _ = crate::sys::fs::mkdirp_in_root(&self.upper, p, 0o755);
         }
@@ -784,7 +806,9 @@ impl SeccompCowBranch {
             Some(r) => r,
             None => return Ok(false),
         };
-        let _ = self.ensure_cow_copy(&rel)?;
+        if self.ensure_cow_copy(&rel)?.is_none() {
+            return Ok(false);
+        }
         Ok(crate::sys::fs::chmod_in_root(&self.upper, &rel, mode).is_ok())
     }
 
@@ -796,7 +820,9 @@ impl SeccompCowBranch {
             Some(r) => r,
             None => return Ok(false),
         };
-        let _ = self.ensure_cow_copy(&rel)?;
+        if self.ensure_cow_copy(&rel)?.is_none() {
+            return Ok(false);
+        }
         // Best-effort: try the real chown but succeed either way — the
         // supervisor typically lacks CAP_CHOWN so this will fail, but
         // in COW/dry-run mode the ownership doesn't matter.
@@ -813,7 +839,9 @@ impl SeccompCowBranch {
             None => return Ok(false),
         };
         let new_len = length as u64;
-        let _ = self.ensure_cow_copy(&rel)?;
+        if self.ensure_cow_copy(&rel)?.is_none() {
+            return Ok(false);
+        }
         let old_len = crate::sys::fs::statat_in_root(&self.upper, &rel, true)
             .map(|st| st.st_size as u64)
             .unwrap_or(0);
@@ -846,8 +874,7 @@ impl SeccompCowBranch {
             Some(r) => r,
             None => return Ok(None),
         };
-        let upper = self.ensure_cow_copy(&rel)?;
-        Ok(Some(upper))
+        Ok(self.ensure_cow_copy(&rel)?)
     }
 
     /// Handle readlink.
@@ -1072,7 +1099,7 @@ mod tests {
     fn test_ensure_cow_copy() {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
-        let upper = branch.ensure_cow_copy("existing.txt").unwrap();
+        let upper = branch.ensure_cow_copy("existing.txt").unwrap().unwrap();
         assert!(upper.exists());
         assert_eq!(fs::read_to_string(&upper).unwrap(), "hello");
         assert!(branch.has_changes());
@@ -1082,7 +1109,7 @@ mod tests {
     fn test_resolve_read_prefers_upper() {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
-        let upper = branch.ensure_cow_copy("existing.txt").unwrap();
+        let upper = branch.ensure_cow_copy("existing.txt").unwrap().unwrap();
         fs::write(&upper, "modified").unwrap();
         let resolved = branch.resolve_read("existing.txt");
         assert_eq!(fs::read_to_string(&resolved).unwrap(), "modified");
@@ -1102,7 +1129,7 @@ mod tests {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
         // Write a new file via COW
-        let upper = branch.ensure_cow_copy("new.txt").unwrap();
+        let upper = branch.ensure_cow_copy("new.txt").unwrap().unwrap();
         fs::write(&upper, "new content").unwrap();
         branch.commit().unwrap();
         assert_eq!(fs::read_to_string(workdir.path().join("new.txt")).unwrap(), "new content");
@@ -1121,7 +1148,7 @@ mod tests {
     fn test_abort_discards_changes() {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
-        let upper = branch.ensure_cow_copy("new.txt").unwrap();
+        let upper = branch.ensure_cow_copy("new.txt").unwrap().unwrap();
         fs::write(&upper, "should be discarded").unwrap();
         branch.abort().unwrap();
         assert!(!workdir.path().join("new.txt").exists());
@@ -1131,7 +1158,7 @@ mod tests {
     fn test_changes_added_file() {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
-        let upper = branch.ensure_cow_copy("brand_new.txt").unwrap();
+        let upper = branch.ensure_cow_copy("brand_new.txt").unwrap().unwrap();
         fs::write(&upper, "new content").unwrap();
         let changes = branch.changes().unwrap();
         assert_eq!(changes.len(), 1);
@@ -1143,7 +1170,7 @@ mod tests {
     fn test_changes_modified_file() {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
-        let upper = branch.ensure_cow_copy("existing.txt").unwrap();
+        let upper = branch.ensure_cow_copy("existing.txt").unwrap().unwrap();
         fs::write(&upper, "modified content").unwrap();
         let changes = branch.changes().unwrap();
         assert_eq!(changes.len(), 1);
@@ -1174,9 +1201,9 @@ mod tests {
     fn test_changes_mixed() {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
-        let upper = branch.ensure_cow_copy("new.txt").unwrap();
+        let upper = branch.ensure_cow_copy("new.txt").unwrap().unwrap();
         fs::write(&upper, "new").unwrap();
-        let upper2 = branch.ensure_cow_copy("existing.txt").unwrap();
+        let upper2 = branch.ensure_cow_copy("existing.txt").unwrap().unwrap();
         fs::write(&upper2, "changed").unwrap();
         branch.mark_deleted("subdir/nested.txt");
 
@@ -1510,7 +1537,7 @@ mod tests {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
         // Create a file only in upper (brand new file)
-        let upper = branch.ensure_cow_copy("brand_new.txt").unwrap();
+        let upper = branch.ensure_cow_copy("brand_new.txt").unwrap().unwrap();
         std::fs::write(&upper, "content").unwrap();
         let path = abs(&branch, "brand_new.txt");
         // O_WRONLY | O_CREAT | O_EXCL — file exists in upper
@@ -1725,7 +1752,7 @@ mod tests {
             SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
 
         // ensure_cow_copy on a path reached through the symlinked parent.
-        let upper = branch.ensure_cow_copy("evil/group").unwrap();
+        let upper = branch.ensure_cow_copy("evil/group").unwrap().unwrap();
 
         // The upper file must NOT contain the host /etc/group contents.
         let host = std::fs::read_to_string("/etc/group").unwrap_or_default();
@@ -1741,7 +1768,7 @@ mod tests {
         let (workdir, storage) = setup_workdir();
         let mut branch =
             SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
-        let upper = branch.ensure_cow_copy("existing.txt").unwrap();
+        let upper = branch.ensure_cow_copy("existing.txt").unwrap().unwrap();
         assert_eq!(std::fs::read_to_string(&upper).unwrap(), "hello");
     }
 
@@ -1755,7 +1782,7 @@ mod tests {
         let mut branch =
             SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
         // Trigger copy-up of the symlink into upper.
-        let upper = branch.ensure_cow_copy("secret").unwrap();
+        let upper = branch.ensure_cow_copy("secret").unwrap().unwrap();
         assert!(upper.is_symlink(), "precondition: upper holds a verbatim symlink");
 
         branch.commit().unwrap();
@@ -1779,7 +1806,7 @@ mod tests {
         std::os::unix::fs::symlink("existing.txt", workdir.path().join("link")).unwrap();
         let mut branch =
             SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
-        let upper = branch.ensure_cow_copy("link").unwrap();
+        let upper = branch.ensure_cow_copy("link").unwrap().unwrap();
         assert!(upper.is_symlink(), "in-tree symlink was not preserved");
         assert_eq!(
             std::fs::read_link(&upper).unwrap(),
@@ -1922,7 +1949,7 @@ mod tests {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
         branch.mark_deleted("existing.txt");
-        let upper = branch.ensure_cow_copy("existing.txt").unwrap();
+        let upper = branch.ensure_cow_copy("existing.txt").unwrap().unwrap();
         assert!(!upper.exists() || fs::read(&upper).unwrap().is_empty());
     }
 
@@ -1951,7 +1978,7 @@ mod tests {
         let (workdir, storage) = setup_workdir();
         let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
         branch.mark_deleted("existing.txt");
-        let upper = branch.ensure_cow_copy("existing.txt").unwrap();
+        let upper = branch.ensure_cow_copy("existing.txt").unwrap().unwrap();
         fs::write(&upper, "recreated").unwrap();
         let changes = branch.changes().unwrap();
         // The recreated file is a single Added entry, not Deleted + Modified.
@@ -2123,6 +2150,71 @@ mod tests {
             false
         );
         assert!(!branch.upper_dir().join("d").exists());
+    }
+
+    #[test]
+    fn copy_up_of_fifo_does_not_block() {
+        // Issue #158: opening a FIFO O_RDONLY blocks until a writer appears,
+        // so the copy-up path must never stream a non-regular file. The probe
+        // runs on a thread with a timeout so a regression hangs the test, not
+        // the suite.
+        let (workdir, storage) = setup_workdir();
+        let fifo = workdir.path().join("pipe");
+        let c = std::ffi::CString::new(fifo.to_str().unwrap()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(c.as_ptr(), 0o644) }, 0);
+
+        let wd = workdir.path().to_path_buf();
+        let sd = storage.path().to_path_buf();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let mut b = SeccompCowBranch::create(&wd, Some(&sd), 0).unwrap();
+            let _ = tx.send(b.ensure_cow_copy("pipe").map(|p| p.is_none()));
+        });
+        match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+            Ok(Ok(true)) => {}
+            Ok(other) => panic!("expected passthrough for a FIFO, got {:?}", other),
+            Err(_) => panic!("copy-up of a FIFO hung"),
+        }
+    }
+
+    #[test]
+    fn write_open_of_fifo_is_not_intercepted() {
+        let (workdir, storage) = setup_workdir();
+        let fifo = workdir.path().join("pipe");
+        let c = std::ffi::CString::new(fifo.to_str().unwrap()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(c.as_ptr(), 0o644) }, 0);
+        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        let wd = branch.workdir_str().to_string();
+        let flags = libc::O_WRONLY as u64;
+        assert_eq!(branch.handle_open(&format!("{}/pipe", wd), flags).unwrap(), None);
+        assert!(!branch.upper_dir().join("pipe").exists());
+    }
+
+    #[test]
+    fn chmod_of_fifo_falls_through() {
+        let (workdir, storage) = setup_workdir();
+        let fifo = workdir.path().join("pipe");
+        let c = std::ffi::CString::new(fifo.to_str().unwrap()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(c.as_ptr(), 0o644) }, 0);
+        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        let wd = branch.workdir_str().to_string();
+        assert_eq!(branch.handle_chmod(&format!("{}/pipe", wd), 0o600).unwrap(), false);
+    }
+
+    #[test]
+    fn execute_copy_guards_against_type_race() {
+        // Defense in depth: if the entry changes type between prepare_copy's
+        // lstat and execute_copy's open, the O_NONBLOCK+fstat guard must
+        // catch it and produce an empty destination instead of streaming.
+        let (workdir, storage) = setup_workdir();
+        let fifo = workdir.path().join("race");
+        let c = std::ffi::CString::new(fifo.to_str().unwrap()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(c.as_ptr(), 0o644) }, 0);
+        let branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        let workdir_root = branch.workdir().to_path_buf();
+        let upper_root = branch.upper_dir().to_path_buf();
+        SeccompCowBranch::execute_copy(&workdir_root, &upper_root, "race").unwrap();
+        assert_eq!(fs::read(upper_root.join("race")).unwrap(), b"");
     }
 
     #[test]

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -27,6 +27,18 @@ fn parent_rel(rel: &str) -> Option<&str> {
     rel.trim_end_matches('/').rfind('/').map(|i| &rel[..i])
 }
 
+/// Errno for a branch failure, for handlers that answer the child directly
+/// (the `handle_unlink` convention) rather than returning a `BranchError`.
+fn branch_errno(e: BranchError) -> i32 {
+    match e {
+        BranchError::QuotaExceeded => libc::ENOSPC,
+        BranchError::Denied => libc::EPERM,
+        BranchError::Deleted => libc::ENOENT,
+        BranchError::Exists => libc::EEXIST,
+        BranchError::Operation(_) | BranchError::Conflict(_) => libc::EIO,
+    }
+}
+
 /// Plan for a COW copy — returned by `prepare_copy()` to separate metadata
 /// updates (under lock) from potentially expensive file I/O (outside lock).
 #[derive(Debug)]
@@ -709,10 +721,31 @@ impl SeccompCowBranch {
         Ok(ok)
     }
 
+    /// Merged-view classification of `rel`: `Some(is_dir)` when the child can
+    /// see an entry there, `None` when the merged answer is ENOENT. The upper
+    /// is consulted first because upper presence shadows both the lower entry
+    /// and any whiteout; a trailing symlink classifies as a non-directory
+    /// (rename never follows it).
+    fn merged_entry_is_dir(&self, rel: &str) -> Option<bool> {
+        if let Ok(st) = crate::sys::fs::statat_in_root(&self.upper, rel, false) {
+            return Some(st.st_mode & libc::S_IFMT == libc::S_IFDIR);
+        }
+        if self.deleted.covers(rel) {
+            return None;
+        }
+        crate::sys::fs::statat_in_root(&self.workdir, rel, false)
+            .ok()
+            .map(|st| st.st_mode & libc::S_IFMT == libc::S_IFDIR)
+    }
+
     /// Handle rename.
     ///
-    /// Returns `Err(QuotaExceeded)` when the COW copy would exceed `max_disk`.
-    pub fn handle_rename(&mut self, old_path: &str, new_path: &str) -> Result<bool, BranchError> {
+    /// Returns `Ok(true)` on success, `Ok(false)` when the branch does not
+    /// handle the path, or `Err(errno)` when the merged view forbids the
+    /// rename (ENOENT for an absent or whiteouted source, ENOTEMPTY for a
+    /// non-empty directory destination, EISDIR/ENOTDIR for type mismatches,
+    /// ENOSPC for quota).
+    pub fn handle_rename(&mut self, old_path: &str, new_path: &str) -> Result<bool, i32> {
         let old_rel = match self.safe_rel(old_path) {
             Some(r) => r,
             None => return Ok(false),
@@ -721,19 +754,41 @@ impl SeccompCowBranch {
             Some(r) => r,
             None => return Ok(false),
         };
-        if self.is_deleted(&old_rel) {
-            return Err(BranchError::Deleted);
+        let src_is_dir = match self.merged_entry_is_dir(&old_rel) {
+            Some(d) => d,
+            None => return Err(libc::ENOENT),
+        };
+        // Destination semantics come from the merged view: renaming onto an
+        // existing directory must replace it or refuse, never publish the
+        // union of the renamed tree and the pre-existing one (issue #160
+        // review). The kernel cannot give these answers because it sees only
+        // one layer at a time.
+        if let Some(dest_is_dir) = self.merged_entry_is_dir(&new_rel) {
+            match (src_is_dir, dest_is_dir) {
+                (false, true) => return Err(libc::EISDIR),
+                (true, false) => return Err(libc::ENOTDIR),
+                (true, true) if !self.list_merged_dir(&new_rel).is_empty() => {
+                    return Err(libc::ENOTEMPTY)
+                }
+                _ => {}
+            }
         }
-        self.copy_up_tree(&old_rel)?;
+        self.copy_up_tree(&old_rel).map_err(branch_errno)?;
         if let Some(p) = parent_rel(&new_rel) {
             let _ = crate::sys::fs::mkdirp_in_root(&self.upper, p, 0o755);
         }
         if crate::sys::fs::renameat_in_root(&self.upper, &old_rel, &new_rel).is_err() {
             return Ok(false);
         }
-        let lower_old = self.workdir.join(&old_rel);
-        if lower_old.exists() || lower_old.is_symlink() {
+        // A surviving lower entry under either name gets a whiteout: the
+        // source so it stops existing, the destination so commit removes it
+        // before publishing the renamed entry instead of merging into it.
+        // The staged upper entry shadows the destination whiteout until then.
+        if crate::sys::fs::statat_in_root(&self.workdir, &old_rel, false).is_ok() {
             self.mark_deleted(&old_rel);
+        }
+        if crate::sys::fs::statat_in_root(&self.workdir, &new_rel, false).is_ok() {
+            self.mark_deleted(&new_rel);
         }
         Ok(true)
     }
@@ -1345,7 +1400,7 @@ mod tests {
         let old = abs(&branch, "existing.txt");
         let new = abs(&branch, "renamed.txt");
         let err = branch.handle_rename(&old, &new).unwrap_err();
-        assert!(matches!(err, BranchError::QuotaExceeded));
+        assert_eq!(err, libc::ENOSPC);
     }
 
     #[test]
@@ -2113,13 +2168,139 @@ mod tests {
         let wd = workdir.path().canonicalize().unwrap();
         let mut branch = SeccompCowBranch::create(&wd, Some(storage.path()), 0).unwrap();
         branch.mark_deleted("existing.txt");
-        assert!(matches!(
+        assert_eq!(
             branch.handle_rename(
                 &format!("{}/existing.txt", wd.display()),
                 &format!("{}/moved.txt", wd.display())
             ),
-            Err(BranchError::Deleted)
-        ));
+            Err(libc::ENOENT)
+        );
+    }
+
+    #[test]
+    fn rename_onto_nonempty_dir_is_enotempty() {
+        // #160 review follow-up: with lower-only a/{a1} and b/{b1}, a
+        // dir-onto-dir rename must refuse with ENOTEMPTY, never publish the
+        // union b = {a1, b1}.
+        let (workdir, storage) = setup_workdir();
+        let wd = workdir.path().canonicalize().unwrap();
+        fs::create_dir(wd.join("a")).unwrap();
+        fs::write(wd.join("a/a1"), "A").unwrap();
+        fs::create_dir(wd.join("b")).unwrap();
+        fs::write(wd.join("b/b1"), "B").unwrap();
+        let mut branch = SeccompCowBranch::create(&wd, Some(storage.path()), 0).unwrap();
+        assert_eq!(
+            branch.handle_rename(&format!("{}/a", wd.display()), &format!("{}/b", wd.display())),
+            Err(libc::ENOTEMPTY)
+        );
+        // The refusal must leave no trace: nothing staged, nothing whiteouted.
+        assert!(!branch.is_deleted("a"));
+        assert_eq!(branch.list_merged_dir("b"), vec!["b1".to_string()]);
+        branch.commit().unwrap();
+        assert_eq!(fs::read_to_string(wd.join("a/a1")).unwrap(), "A");
+        assert_eq!(fs::read_to_string(wd.join("b/b1")).unwrap(), "B");
+        assert!(!wd.join("b/a1").exists());
+    }
+
+    #[test]
+    fn rename_onto_empty_dir_replaces() {
+        let (workdir, storage) = setup_workdir();
+        let wd = workdir.path().canonicalize().unwrap();
+        fs::create_dir(wd.join("a")).unwrap();
+        fs::write(wd.join("a/a1"), "A").unwrap();
+        fs::create_dir(wd.join("b")).unwrap();
+        let mut branch = SeccompCowBranch::create(&wd, Some(storage.path()), 0).unwrap();
+        assert_eq!(
+            branch.handle_rename(&format!("{}/a", wd.display()), &format!("{}/b", wd.display())),
+            Ok(true)
+        );
+        assert!(branch.is_deleted("a"));
+        assert_eq!(branch.list_merged_dir("b"), vec!["a1".to_string()]);
+        branch.commit().unwrap();
+        assert!(!wd.join("a").exists());
+        assert_eq!(fs::read_to_string(wd.join("b/a1")).unwrap(), "A");
+    }
+
+    #[test]
+    fn rename_onto_lower_file_replaces_not_merges() {
+        // The destination's lower bytes must be gone after commit, replaced
+        // by the renamed entry, and the source name must stop existing.
+        let (workdir, storage) = setup_workdir();
+        let wd = workdir.path().canonicalize().unwrap();
+        fs::write(wd.join("target.txt"), "OLD").unwrap();
+        let mut branch = SeccompCowBranch::create(&wd, Some(storage.path()), 0).unwrap();
+        assert_eq!(
+            branch.handle_rename(
+                &format!("{}/existing.txt", wd.display()),
+                &format!("{}/target.txt", wd.display())
+            ),
+            Ok(true)
+        );
+        branch.commit().unwrap();
+        assert!(!wd.join("existing.txt").exists());
+        assert_eq!(fs::read_to_string(wd.join("target.txt")).unwrap(), "hello");
+    }
+
+    #[test]
+    fn rename_type_mismatch_refused() {
+        let (workdir, storage) = setup_workdir();
+        let wd = workdir.path().canonicalize().unwrap();
+        fs::create_dir(wd.join("d")).unwrap();
+        let mut branch = SeccompCowBranch::create(&wd, Some(storage.path()), 0).unwrap();
+        // File onto directory: EISDIR. Directory onto file: ENOTDIR.
+        assert_eq!(
+            branch.handle_rename(
+                &format!("{}/existing.txt", wd.display()),
+                &format!("{}/d", wd.display())
+            ),
+            Err(libc::EISDIR)
+        );
+        assert_eq!(
+            branch.handle_rename(
+                &format!("{}/d", wd.display()),
+                &format!("{}/existing.txt", wd.display())
+            ),
+            Err(libc::ENOTDIR)
+        );
+    }
+
+    #[test]
+    fn rename_onto_whiteouted_dest_is_plain_rename() {
+        // A whiteouted destination is absent in the merged view; the rename
+        // must succeed and expose only the renamed content.
+        let (workdir, storage) = setup_workdir();
+        let wd = workdir.path().canonicalize().unwrap();
+        fs::create_dir(wd.join("b")).unwrap();
+        fs::write(wd.join("b/b1"), "B").unwrap();
+        let mut branch = SeccompCowBranch::create(&wd, Some(storage.path()), 0).unwrap();
+        assert_eq!(branch.handle_unlink(&format!("{}/b/b1", wd.display()), false), Ok(true));
+        assert_eq!(branch.handle_unlink(&format!("{}/b", wd.display()), true), Ok(true));
+        assert_eq!(
+            branch.handle_rename(
+                &format!("{}/existing.txt", wd.display()),
+                &format!("{}/b", wd.display())
+            ),
+            Ok(true)
+        );
+        branch.commit().unwrap();
+        let meta = fs::metadata(wd.join("b")).unwrap();
+        assert!(meta.is_file());
+        assert_eq!(fs::read_to_string(wd.join("b")).unwrap(), "hello");
+        assert!(!wd.join("existing.txt").exists());
+    }
+
+    #[test]
+    fn rename_absent_source_is_enoent() {
+        let (workdir, storage) = setup_workdir();
+        let wd = workdir.path().canonicalize().unwrap();
+        let mut branch = SeccompCowBranch::create(&wd, Some(storage.path()), 0).unwrap();
+        assert_eq!(
+            branch.handle_rename(
+                &format!("{}/nope", wd.display()),
+                &format!("{}/dest", wd.display())
+            ),
+            Err(libc::ENOENT)
+        );
     }
 
     #[test]

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -2322,6 +2322,41 @@ mod tests {
     }
 
     #[test]
+    fn rename_onto_lower_symlink_dest_commits_as_regular_file() {
+        // The discriminating case for the destination whiteout: an empty-dir
+        // or regular-file destination commits identical bytes whether the
+        // rename replaces or merges, so only a special-file destination can
+        // tell the two apart. Without the whiteout the lower symlink survives
+        // into commit, whose O_NOFOLLOW publish refuses to write through it
+        // (and a FIFO destination would hang it, the #158 class).
+        let (workdir, storage) = setup_workdir();
+        let wd = workdir.path().canonicalize().unwrap();
+        fs::write(wd.join("real.txt"), "REAL").unwrap();
+        std::os::unix::fs::symlink("real.txt", wd.join("dest")).unwrap();
+
+        let mut branch = SeccompCowBranch::create(&wd, Some(storage.path()), 0).unwrap();
+        assert_eq!(
+            branch.handle_rename(
+                &format!("{}/existing.txt", wd.display()),
+                &format!("{}/dest", wd.display())
+            ),
+            Ok(true)
+        );
+        branch.commit().unwrap();
+
+        let meta = fs::symlink_metadata(wd.join("dest")).unwrap();
+        assert!(
+            meta.file_type().is_file(),
+            "dest must be the renamed regular file, not the surviving symlink"
+        );
+        assert_eq!(fs::read_to_string(wd.join("dest")).unwrap(), "hello");
+        assert!(!wd.join("existing.txt").exists());
+        // The link's old target is untouched: the rename replaced the link
+        // itself and never wrote through it.
+        assert_eq!(fs::read_to_string(wd.join("real.txt")).unwrap(), "REAL");
+    }
+
+    #[test]
     fn rename_type_mismatch_refused() {
         let (workdir, storage) = setup_workdir();
         let wd = workdir.path().canonicalize().unwrap();

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -464,13 +464,20 @@ impl SeccompCowBranch {
     /// seccomp supervisor) and prevents new opens once the quota is
     /// exhausted.
     pub fn handle_open(&mut self, path: &str, flags: u64) -> Result<Option<PathBuf>, BranchError> {
-        if flags & O_DIRECTORY != 0 {
-            return Ok(None);
-        }
         let rel = match self.safe_rel(path) {
             Some(r) => r,
             None => return Ok(None),
         };
+        if flags & O_DIRECTORY != 0 {
+            // A whiteouted directory must not fall through to the kernel:
+            // the lower directory still exists, so opendir would hand the
+            // child a live fd (and fstat its inode) where the merged answer
+            // is ENOENT.
+            if self.is_deleted(&rel) {
+                return Err(BranchError::Deleted);
+            }
+            return Ok(None);
+        }
 
         let is_write = flags & WRITE_FLAGS != 0;
 
@@ -531,6 +538,12 @@ impl SeccompCowBranch {
                 Some(r) => r,
                 None => return Ok(CowOpenPlan::Skip),
             };
+            // Same whiteout gate as the non-directory path: Skip would let
+            // the kernel open the still-existing lower directory where the
+            // merged answer is ENOENT.
+            if self.is_deleted(&rel) {
+                return Ok(CowOpenPlan::Deleted);
+            }
             let upper_dir = self.upper.join(&rel);
             let lower_dir = self.workdir.join(&rel);
             if upper_dir.is_dir() && !lower_dir.is_dir() {
@@ -1972,6 +1985,38 @@ mod tests {
         // Sibling boundary: d2 is not covered by the d whiteout.
         fs::write(workdir.path().join("d2"), "kept").unwrap();
         assert!(!branch.is_deleted("d2"));
+    }
+
+    #[test]
+    fn o_directory_open_of_whiteouted_dir_reports_deleted() {
+        // #159 review follow-up: opendir takes the O_DIRECTORY early-return,
+        // which used to skip the whiteout check entirely; the child got a
+        // live fd on the surviving lower directory (and could fstat its
+        // inode) where stat on the same path already said ENOENT.
+        let (workdir, storage) = setup_workdir();
+        let wd = workdir.path().canonicalize().unwrap();
+        fs::create_dir(wd.join("d")).unwrap();
+        fs::write(wd.join("d/x"), "x").unwrap();
+        let mut branch = SeccompCowBranch::create(&wd, Some(storage.path()), 0).unwrap();
+        branch.mark_deleted("d");
+        let path = format!("{}/d", wd.display());
+        let dirflag = libc::O_DIRECTORY as u64;
+        assert!(matches!(
+            branch.handle_open(&path, dirflag),
+            Err(BranchError::Deleted)
+        ));
+        assert!(matches!(
+            branch.prepare_open(&path, dirflag),
+            Ok(CowOpenPlan::Deleted)
+        ));
+        // Re-created in the upper: the shadow makes it visible again and the
+        // open goes back to the normal resolution.
+        assert!(branch.handle_mkdir(&path).unwrap());
+        assert!(matches!(branch.handle_open(&path, dirflag), Ok(None)));
+        assert!(!matches!(
+            branch.prepare_open(&path, dirflag),
+            Ok(CowOpenPlan::Deleted)
+        ));
     }
 
     #[test]

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -320,6 +320,12 @@ impl SeccompCowBranch {
             )
             .map_err(|e| BranchError::Operation(format!("create cow stub: {}", e)))?;
             unsafe { libc::close(fd) };
+            // Whiteout the lower entry the stub replaces. The stub already
+            // shadows it in the merged view; the whiteout makes commit
+            // unlink it before the publish walk, which would otherwise
+            // O_WRONLY-open the surviving FIFO and block on a reader that
+            // never comes (the publish half of issue #158).
+            self.mark_deleted(rel_path);
             return Ok(CowCopyPlan::Ready(upper_file));
         }
 
@@ -2571,6 +2577,42 @@ mod tests {
         let meta = fs::metadata(branch.upper_dir().join("pipe")).unwrap();
         assert!(meta.file_type().is_file(), "upper stub must be a regular file");
         assert_eq!(meta.len(), 0);
+    }
+
+    #[test]
+    fn commit_replaces_lower_fifo_with_stub_bytes() {
+        // The publish half of issue #158: the stub must whiteout the lower
+        // FIFO so commit's deletion pass unlinks it. Without the whiteout
+        // the publish walk O_WRONLY-opens the surviving FIFO as its
+        // destination and blocks on a reader that never comes. Commit runs
+        // on a thread with a timeout so a regression fails the test
+        // instead of hanging the suite.
+        let (workdir, storage) = setup_workdir();
+        let fifo = workdir.path().join("pipe");
+        let c = std::ffi::CString::new(fifo.to_str().unwrap()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(c.as_ptr(), 0o644) }, 0);
+
+        let wd = workdir.path().to_path_buf();
+        let sd = storage.path().to_path_buf();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let mut b = SeccompCowBranch::create(&wd, Some(&sd), 0).unwrap();
+            let wds = b.workdir_str().to_string();
+            let resolved = b
+                .handle_open(&format!("{}/pipe", wds), libc::O_WRONLY as u64)
+                .unwrap()
+                .unwrap();
+            fs::write(&resolved, "published").unwrap();
+            let _ = tx.send(b.commit());
+        });
+        match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => panic!("commit failed: {:?}", e),
+            Err(_) => panic!("commit hung on the lower FIFO (issue #158)"),
+        }
+        let meta = fs::symlink_metadata(workdir.path().join("pipe")).unwrap();
+        assert!(meta.file_type().is_file(), "lower FIFO must be replaced by the stub");
+        assert_eq!(fs::read_to_string(workdir.path().join("pipe")).unwrap(), "published");
     }
 
     #[test]

--- a/crates/sandlock-core/tests/integration/test_cow.rs
+++ b/crates/sandlock-core/tests/integration/test_cow.rs
@@ -313,6 +313,58 @@ async fn test_seccomp_cow_legacy_open_syscall() {
     let _ = fs::remove_file(&out_file);
 }
 
+/// Legacy stat/lstat/access must honor whiteouts.
+///
+/// Regression test: handle_cow_stat parsed every syscall with the at-variant
+/// layout (dirfd=args[0], path=args[1]), but the legacy x86_64 variants put
+/// the path in args[0]. The handler read the statbuf pointer as the path,
+/// never matched the workdir, and fell through to the kernel, so a
+/// static-libc child emitting legacy stat could see whiteouted lower entries
+/// that newfstatat already reported as ENOENT. On aarch64/riscv64 the
+/// helper's legacy-* commands fall back to newfstatat, keeping the test as
+/// an at-variant whiteout check there.
+#[tokio::test]
+async fn test_seccomp_cow_legacy_stat_honors_whiteout() {
+    let workdir = temp_dir("seccomp-legacy-stat");
+    fs::write(workdir.join("gone.txt"), "SECRET").unwrap();
+    let helper = helper_binary();
+    let helper_dir = helper.parent().unwrap().to_path_buf();
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr").fs_read("/lib").fs_read_if_exists("/lib64").fs_read("/bin").fs_read("/etc")
+        .fs_read("/proc").fs_read("/dev")
+        .fs_read(&helper_dir)
+        .fs_write(&workdir)
+        .workdir(&workdir)
+        .cwd(&workdir)
+        .on_exit(BranchAction::Abort)
+        .build()
+        .unwrap();
+
+    let script = "rm gone.txt ; legacy-stat gone.txt ; legacy-lstat gone.txt ; legacy-access gone.txt";
+    let result = policy.clone().with_name("test")
+        .run(&[helper.to_str().unwrap(), "sh", "-c", script]).await;
+    match result {
+        Ok(r) => {
+            let out = r.stdout_str().unwrap_or("").to_string();
+            println!("legacy_stat_whiteout: stdout={:?}", out);
+            assert_eq!(
+                out.matches("ERR 2").count(),
+                3,
+                "legacy stat/lstat/access of a whiteouted file must all be ENOENT: {:?}",
+                out
+            );
+            assert!(
+                !out.contains("OK"),
+                "whiteouted entry leaked through a legacy stat variant: {:?}",
+                out
+            );
+        }
+        Err(e) => eprintln!("legacy stat whiteout test skipped: {}", e),
+    }
+    let _ = fs::remove_dir_all(&workdir);
+}
+
 /// Test that O_CREAT|O_EXCL succeeds after unlink in COW mode.
 ///
 /// Regression test: after unlink marked a file as deleted, the subsequent

--- a/crates/sandlock-core/tests/integration/test_cow.rs
+++ b/crates/sandlock-core/tests/integration/test_cow.rs
@@ -612,3 +612,106 @@ async fn test_seccomp_cow_exec_packed_argv_relocation() {
 
     let _ = fs::remove_dir_all(&workdir);
 }
+
+// ============================================================
+// Deletion-model regressions (issues #159/#160/#161)
+// ============================================================
+
+/// A directory the child removed stays removed after commit, including its
+/// contents (issue #159: whiteouts cover the subtree).
+#[tokio::test]
+async fn test_cow_child_rm_r_directory_stays_deleted() {
+    let workdir = temp_dir("seccomp-rm-r");
+    fs::create_dir_all(workdir.join("d")).unwrap();
+    fs::write(workdir.join("d/secret.txt"), "SECRET").unwrap();
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr").fs_read("/lib").fs_read_if_exists("/lib64").fs_read("/bin").fs_read("/etc")
+        .fs_read("/proc")
+        .fs_write(&workdir)
+        .workdir(&workdir)
+        .on_exit(BranchAction::Commit)
+        .build()
+        .unwrap();
+
+    let cmd = format!("rm -r {}/d", workdir.display());
+    let result = policy.clone().with_name("test").run(&["sh", "-c", &cmd]).await;
+    match result {
+        Ok(r) => {
+            assert!(r.success(), "rm -r should succeed, stderr: {}", r.stderr_str().unwrap_or(""));
+            assert!(!workdir.join("d").exists(), "d should be gone after commit");
+            assert!(!workdir.join("d/secret.txt").exists());
+        }
+        Err(e) => eprintln!("Seccomp COW test skipped: {}", e),
+    }
+
+    let _ = fs::remove_dir_all(&workdir);
+}
+
+/// Renaming a directory preserves its contents through the commit
+/// (issue #160: the rename is staged with a recursive copy-up).
+#[tokio::test]
+async fn test_cow_child_mv_directory_preserves_contents() {
+    let workdir = temp_dir("seccomp-mv-dir");
+    fs::create_dir_all(workdir.join("d")).unwrap();
+    fs::write(workdir.join("d/inner.txt"), "PRECIOUS").unwrap();
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr").fs_read("/lib").fs_read_if_exists("/lib64").fs_read("/bin").fs_read("/etc")
+        .fs_read("/proc")
+        .fs_write(&workdir)
+        .workdir(&workdir)
+        .on_exit(BranchAction::Commit)
+        .build()
+        .unwrap();
+
+    let cmd = format!("mv {}/d {}/d2", workdir.display(), workdir.display());
+    let result = policy.clone().with_name("test").run(&["sh", "-c", &cmd]).await;
+    match result {
+        Ok(r) => {
+            assert!(r.success(), "mv should succeed, stderr: {}", r.stderr_str().unwrap_or(""));
+            assert!(!workdir.join("d").exists(), "d should be gone after commit");
+            assert_eq!(
+                fs::read_to_string(workdir.join("d2/inner.txt")).unwrap(),
+                "PRECIOUS",
+                "d2/inner.txt must survive the rename"
+            );
+        }
+        Err(e) => eprintln!("Seccomp COW test skipped: {}", e),
+    }
+
+    let _ = fs::remove_dir_all(&workdir);
+}
+
+/// rmdir on a non-empty directory fails inside the sandbox and the contents
+/// survive the commit (issue #161: ENOTEMPTY from the merged view).
+#[tokio::test]
+async fn test_cow_child_rmdir_nonempty_fails() {
+    let workdir = temp_dir("seccomp-rmdir-nonempty");
+    fs::create_dir_all(workdir.join("d")).unwrap();
+    fs::write(workdir.join("d/inner.txt"), "DATA").unwrap();
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr").fs_read("/lib").fs_read_if_exists("/lib64").fs_read("/bin").fs_read("/etc")
+        .fs_read("/proc")
+        .fs_write(&workdir)
+        .workdir(&workdir)
+        .on_exit(BranchAction::Commit)
+        .build()
+        .unwrap();
+
+    let cmd = format!("rmdir {}/d", workdir.display());
+    let result = policy.clone().with_name("test").run(&["sh", "-c", &cmd]).await;
+    match result {
+        Ok(r) => {
+            assert!(!r.success(), "rmdir of a non-empty directory must fail");
+            assert!(
+                workdir.join("d/inner.txt").exists(),
+                "contents must survive the failed rmdir and the commit"
+            );
+        }
+        Err(e) => eprintln!("Seccomp COW test skipped: {}", e),
+    }
+
+    let _ = fs::remove_dir_all(&workdir);
+}


### PR DESCRIPTION
Redesign of the seccomp COW branch's deletion model. The flat exact-match `HashSet<String>` (inherited from the Python-era `cowfs/_branch.py`, carried verbatim into the Rust rewrite) is replaced by a subtree-aware whiteout set, and copy-up becomes file-type-aware.

Fixes #158
Fixes #159
Fixes #160
Fixes #161

## The model

A new `DeletionSet` (`cow/deletions.rs`) owns whiteout semantics:

- `covers(rel)` matches per path component: a whiteout on `d` hides `d/x` and `d/x/y`, never `d2`.
- Entries are never removed. A path re-created after deletion is exposed by existing in the upper (upper presence shadows the whiteout), which makes `rmdir d; mkdir d` an opaque directory for free: the new `d` is visible, its old contents stay hidden.
- Every insertion is appended to `deleted.log` beside `upper/` and fdatasynced, so the deletion half of a change set is now self-describing on disk, like the upper already was. RAM stays the in-process source of truth; the log is the durability record a future recovery sweep (RFC #65 Phase 3, PR #148's preserved branches) can replay.

All merged-view queries (`is_deleted`, open/stat/readlink, `list_merged_dir`, `changes()`, `commit()`) route through it, instead of each handler re-implementing its own slice of overlay semantics.

## Per issue

- **#159**: whiteouts now cover the subtree; reads and listings under a deleted directory give ENOENT, and a write-open under it starts fresh instead of copying the deleted bytes up for `commit()` to republish. Also fixes a latent bug of the same family found during the work: `O_CREAT` on a whiteouted file used to resurrect the pre-delete lower bytes.
- **#161**: rmdir checks emptiness against the merged view and gives ENOTEMPTY, as the kernel would; the whiteout can no longer delete a subtree the child never emptied.
- **#160**: renaming a directory stages the whole tree in the upper via a recursive, confined, quota-accounted copy-up; contents survive the commit, and already-whiteouted children do not reappear under the new name. A whiteouted rename/link source now gives ENOENT instead of falling through to the kernel against the lower entry.
- **#158**: copy-up dispatches on file type and never opens a non-regular source. FIFOs, sockets and device nodes are virtualized as empty regular stubs in the upper, created without reading them, per the disposition suggested in the issue. This keeps the COW virtualization contract (`> /dev/null` inside a learn-mode tree needs no real permission on `/dev` and never touches the device) and removes the supervisor wedge. `execute_copy` additionally guards with `O_NONBLOCK` + fstat against the entry changing type between the classifying lstat and the open.

## The invariant

One test pins the property all four issues violated: the merged view the child observed during the run is exactly what `commit()` publishes. Plus each issue's own reproducer as a unit test, and three end-to-end regressions driving a real sandboxed child (`rm -r`, `mv dir`, `rmdir` non-empty).

## Compatibility

No public API, CLI, or SDK signature changes. Child-visible behavior changes only toward kernel semantics (ENOTEMPTY, ENOENT under deleted dirs, dir renames preserving contents). The branch storage dir gains `deleted.log`; the layout is internal.

Suites: 555 lib / 308 integration / 386 Python locally; the two `cli_test` failures on my machine (`test_learn_captures_openat2`, `test_write_collapse_skips_protected`) reproduce identically on main and are unrelated.
