### PR TITLE
learn/cow: fix the two cli_test failures CI never saw; run the full workspace suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,11 @@ jobs:
       - name: Build
         run: cargo build --release
 
+      # timeout-minutes: the suite finishes in a few minutes; a hang here is
+      # the known supervisor wedge under load, and should fail fast rather
+      # than hold the job for the 6-hour default.
       - name: Run all tests
+        timeout-minutes: 20
         run: cargo test --release --workspace --no-fail-fast -- --test-threads=1
 
   rust-low-abi:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,8 @@ jobs:
       - name: Build
         run: cargo build --release
 
-      - name: Run unit tests
-        run: cargo test --release --lib -- --test-threads=1
-
-      - name: Run integration tests
-        run: cargo test --release --test integration -- --test-threads=1
+      - name: Run all tests
+        run: cargo test --release --workspace --no-fail-fast -- --test-threads=1
 
   rust-low-abi:
     name: Rust low-ABI (ubuntu-22.04)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,13 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
 
+      # Ubuntu 24.04 images restrict unprivileged user namespaces via
+      # AppArmor: unshare(CLONE_NEWUSER) yields a capability-less namespace,
+      # the child's uid_map write fails, and the uid-mapping tests see the
+      # overflow uid (65534) instead of the mapped one.
+      - name: Allow unprivileged user namespaces
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
       - name: Build
         run: cargo build --release
 

--- a/crates/sandlock-cli/src/learn.rs
+++ b/crates/sandlock-cli/src/learn.rs
@@ -498,6 +498,19 @@ pub async fn run(args: LearnArgs) -> Result<()> {
 
     let reads_raw: Vec<PathBuf> = observer.reads.lock().unwrap().iter()
         .filter(|p| p.exists() && !is_junk_path(p))
+        .filter(|p| {
+            // Same guard the write side has: "/" is never a grant. A child
+            // whose cwd is the workdir root lists it routinely (python's -c
+            // puts the cwd on sys.path), and granting it would subsume every
+            // other read in the profile.
+            if p.as_path() == std::path::Path::new("/") {
+                eprintln!(
+                    "sandlock learn: WARNING: observed a read of '/', refusing to grant it"
+                );
+                return false;
+            }
+            true
+        })
         .cloned()
         .collect();
     let writes_raw = observer.writes.lock().unwrap();

--- a/crates/sandlock-core/src/context.rs
+++ b/crates/sandlock-core/src/context.rs
@@ -176,10 +176,22 @@ fn close_fds_above(min_fd: RawFd, keep: &[RawFd]) {
 /// `real_uid`/`real_gid` must be captured *before* unshare(CLONE_NEWUSER),
 /// since getuid()/getgid() return the overflow id (65534) after unshare.
 /// `target_uid`/`target_gid` are the UIDs visible inside the namespace.
-fn write_id_maps(real_uid: u32, real_gid: u32, target_uid: u32, target_gid: u32) {
-    let _ = std::fs::write("/proc/self/uid_map", format!("{} {} 1\n", target_uid, real_uid));
-    let _ = std::fs::write("/proc/self/setgroups", "deny\n");
-    let _ = std::fs::write("/proc/self/gid_map", format!("{} {} 1\n", target_gid, real_gid));
+///
+/// Errors must reach the caller: mapping only happens when the caller asked
+/// for a specific identity, and a failed write would otherwise leave the
+/// child running as the overflow uid (65534) with no indication. Ubuntu
+/// 24.04's default AppArmor restriction on unprivileged user namespaces
+/// produces exactly that: unshare succeeds, the map write fails.
+fn write_id_maps(
+    real_uid: u32,
+    real_gid: u32,
+    target_uid: u32,
+    target_gid: u32,
+) -> std::io::Result<()> {
+    std::fs::write("/proc/self/uid_map", format!("{} {} 1\n", target_uid, real_uid))?;
+    std::fs::write("/proc/self/setgroups", "deny\n")?;
+    std::fs::write("/proc/self/gid_map", format!("{} {} 1\n", target_gid, real_gid))?;
+    Ok(())
 }
 
 // ============================================================
@@ -362,7 +374,12 @@ pub(crate) fn confine_child(args: ChildSpawnArgs<'_>) -> ! {
             if unsafe { libc::unshare(libc::CLONE_NEWUSER) } != 0 {
                 fail!("unshare(CLONE_NEWUSER)");
             }
-            write_id_maps(real_uid, real_gid, run_as.uid, run_as.gid);
+            if write_id_maps(real_uid, real_gid, run_as.uid, run_as.gid).is_err() {
+                fail!(
+                    "uid_map/gid_map write (is unprivileged userns restricted? \
+                     e.g. kernel.apparmor_restrict_unprivileged_userns=1)"
+                );
+            }
         }
     }
 

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -234,7 +234,12 @@ impl SeccompCowBranch {
         let st = match crate::sys::fs::statat_in_root(&self.workdir, rel_path, false) {
             Ok(st) => st,
             // Absent or confined-out: treat as a new file created in upper.
-            Err(libc::ENOENT) => {
+            // EACCES gets the same disposition as execute_copy's source-open
+            // gives it: the supervisor cannot see inside the lower directory
+            // (e.g. /root under a workdir of "/"), so the write proceeds on
+            // an empty upper file rather than falling through to a real
+            // permission error the virtualized child was promised not to hit.
+            Err(libc::ENOENT) | Err(libc::EACCES) => {
                 self.check_quota(0)?;
                 return Ok(CowCopyPlan::Ready(upper_file));
             }
@@ -1704,5 +1709,30 @@ mod tests {
             !outside.path().join("sandlock_escape_dir").exists(),
             "upper write escaped through symlinked parent into the outside dir"
         );
+    }
+
+    #[test]
+    fn write_open_in_unreadable_dir_virtualizes() {
+        // The supervisor may not be able to stat inside a 0o000 lower dir
+        // (as with /root under learn's workdir="/"). The write must still
+        // virtualize onto an empty upper file instead of erroring out and
+        // letting the child hit the real permission wall.
+        use std::os::unix::fs::PermissionsExt;
+        let (workdir, storage) = setup_workdir();
+        fs::create_dir(workdir.path().join("locked")).unwrap();
+        fs::write(workdir.path().join("locked/f"), "x").unwrap();
+        let locked = workdir.path().join("locked");
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        let result = branch.ensure_cow_copy("locked/f");
+        // Restore before asserting so the tempdir can be cleaned up either way.
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let upper = result.unwrap();
+        assert_eq!(upper, branch.upper_dir().join("locked/f"));
+        // Nothing was readable to copy, so the plan is a fresh (absent or
+        // empty) upper entry, never the lower bytes and never an error.
+        assert!(!upper.exists() || fs::read(&upper).unwrap().is_empty());
     }
 }

--- a/crates/sandlock-core/src/freeze.rs
+++ b/crates/sandlock-core/src/freeze.rs
@@ -73,36 +73,49 @@ fn read_task_state(tid: i32) -> Option<char> {
     line.split_whitespace().nth(1).and_then(|s| s.chars().next())
 }
 
-/// `PTRACE_SEIZE` + `PTRACE_INTERRUPT` a single tid and wait for the
-/// confirmed ptrace-stop. Returns `Ok(true)` if the tid is now
-/// ptrace-stopped (and must be detached later), `Ok(false)` if the
-/// tid does not need to be ptrace-attached (already exited, or held
-/// in an uninterruptible kernel wait where it cannot mutate user
-/// memory), or an error if ptrace refused.
+/// What `seize_and_interrupt` did with one tid.
+#[derive(Debug, PartialEq, Eq)]
+enum SeizeOutcome {
+    /// Confirmed ptrace-stopped; must be detached later.
+    Frozen,
+    /// No attachment exists (already exited, or held in an uninterruptible
+    /// kernel wait without ever being seized): nothing to release.
+    NotNeeded,
+    /// Seized with the interrupt queued, but the task entered an
+    /// uninterruptible kernel wait before stopping. It cannot run user code
+    /// (so it cannot mutate argv), and it will trap into ptrace-stop the
+    /// moment its wait clears. The caller must reap and detach it AFTER the
+    /// execve response is sent — for the vfork parent, the wait clears only
+    /// once that very execve resolves.
+    PendingStop,
+}
+
+/// `PTRACE_SEIZE` + `PTRACE_INTERRUPT` a single tid and reap the confirmed
+/// ptrace-stop without ever blocking unboundedly.
 ///
-/// # Why we read `/proc/<tid>/status` first
+/// # Why the reap must be bounded
 ///
-/// A task in `TASK_UNINTERRUPTIBLE` (`State: D`) — most commonly the
-/// vfork parent of the execve caller, suspended in `kernel_clone`
-/// until its child execs — cannot enter ptrace-stop until its
-/// kernel wait clears. For vfork specifically, the wait won't clear
-/// until we send Continue, but we can't send Continue while we're
-/// blocked in `waitpid` for that exact task. Naively waitpid'ing
-/// would deadlock the supervisor.
-///
-/// Such tasks also don't *need* to be ptrace-attached: they can't
-/// run user code while in uninterruptible wait, and therefore can't
-/// mutate argv. The kernel is already holding them for us. We skip
-/// the seize entirely and return `Ok(false)` so the caller does not
-/// add them to the detach list.
+/// A task in `TASK_UNINTERRUPTIBLE` (`State: D`) — most commonly the vfork
+/// parent of the execve caller, suspended in `kernel_clone` until its child
+/// execs — cannot enter ptrace-stop until its kernel wait clears. For vfork
+/// specifically, the wait won't clear until we send Continue, but we can't
+/// send Continue while we're blocked in `waitpid` for that exact task: an
+/// unbounded waitpid here deadlocks the whole supervisor. The pre-check on
+/// `/proc/<tid>/status` catches a task already parked in `D`, but it RACES
+/// the tracee — the vfork parent can pass the check runnable and park
+/// before the interrupt lands (seen in the wild under CPU load). So after
+/// arming the interrupt the reap polls with `WNOHANG`, and a task observed
+/// in `D` is handed back as [`SeizeOutcome::PendingStop`] instead of being
+/// waited for.
 ///
 /// On a partial-progress failure (PTRACE_SEIZE succeeded but
 /// PTRACE_INTERRUPT did not), the function detaches itself before
 /// returning so the caller doesn't have to track partial state.
-fn seize_and_interrupt(tid: i32) -> io::Result<bool> {
-    // Skip tasks the kernel is already holding for us. See doc above.
+fn seize_and_interrupt(tid: i32) -> io::Result<SeizeOutcome> {
+    // Fast path: the kernel is already holding this task; it cannot mutate
+    // user memory and does not need an attachment.
     if read_task_state(tid) == Some('D') {
-        return Ok(false);
+        return Ok(SeizeOutcome::NotNeeded);
     }
 
     let ret = unsafe {
@@ -111,7 +124,7 @@ fn seize_and_interrupt(tid: i32) -> io::Result<bool> {
     if ret < 0 {
         let err = io::Error::last_os_error();
         if err.raw_os_error() == Some(libc::ESRCH) {
-            return Ok(false); // already exited — nothing to freeze
+            return Ok(SeizeOutcome::NotNeeded); // already exited
         }
         return Err(err);
     }
@@ -125,19 +138,44 @@ fn seize_and_interrupt(tid: i32) -> io::Result<bool> {
         let err = io::Error::last_os_error();
         let _ = unsafe { libc::ptrace(libc::PTRACE_DETACH, tid, 0, 0) };
         if err.raw_os_error() == Some(libc::ESRCH) {
-            return Ok(false);
+            return Ok(SeizeOutcome::NotNeeded);
         }
         return Err(err);
     }
 
-    // Wait for the confirmed ptrace-stop. The task was not in
-    // uninterruptible wait when we checked, so PTRACE_INTERRUPT
-    // delivers within microseconds. `__WALL` is needed because
-    // siblings are threads (not children of the supervisor in the
-    // traditional fork sense) and waitpid(2) by default ignores them.
-    let mut status: i32 = 0;
-    let _ = unsafe { libc::waitpid(tid, &mut status, libc::__WALL) };
-    Ok(true)
+    // Bounded reap. A runnable task stops within a scheduling quantum; the
+    // budget only exists so a starved box still converges. `__WALL` because
+    // siblings are threads, which waitpid(2) ignores by default.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+    loop {
+        let mut status: i32 = 0;
+        let r = unsafe { libc::waitpid(tid, &mut status, libc::__WALL | libc::WNOHANG) };
+        if r == tid {
+            if libc::WIFEXITED(status) || libc::WIFSIGNALED(status) {
+                return Ok(SeizeOutcome::NotNeeded);
+            }
+            if libc::WIFSTOPPED(status) {
+                return Ok(SeizeOutcome::Frozen);
+            }
+        } else if r < 0 {
+            let e = io::Error::last_os_error();
+            if e.raw_os_error() != Some(libc::EINTR) {
+                // Reaped elsewhere or gone: nothing left to hold.
+                return Ok(SeizeOutcome::NotNeeded);
+            }
+        }
+        if read_task_state(tid) == Some('D') {
+            return Ok(SeizeOutcome::PendingStop);
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = unsafe { libc::ptrace(libc::PTRACE_DETACH, tid, 0, 0) };
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!("tid {tid} did not enter ptrace-stop within the freeze budget"),
+            ));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
 }
 
 /// Detach a previously-frozen task. Used to roll back partial
@@ -200,6 +238,28 @@ pub(crate) struct SandboxFreeze {
     /// execve and must be detached so they can resume normal
     /// execution.
     pub peer_tids: Vec<i32>,
+    /// TIDs seized with a queued interrupt that had entered an
+    /// uninterruptible kernel wait before stopping (the vfork parent racing
+    /// the freeze). Kernel-held for the duration of the freeze window; must
+    /// be reaped with [`reap_pending`] after the execve response is sent.
+    pub pending_tids: Vec<i32>,
+}
+
+/// A freeze that could not be completed. Carries any tasks that were left
+/// with a queued interrupt and could not be released during rollback (they
+/// had not entered ptrace-stop yet); the caller must [`reap_pending`] them
+/// after sending its deny response, for the same reason the freeze itself
+/// could not wait for them.
+#[derive(Debug)]
+pub(crate) struct FreezeError {
+    pub error: io::Error,
+    pub pending_tids: Vec<i32>,
+}
+
+impl std::fmt::Display for FreezeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.error.fmt(f)
+    }
 }
 
 /// Freeze every sandbox thread that could mutate execve argv before
@@ -224,13 +284,15 @@ pub(crate) struct SandboxFreeze {
 pub(crate) fn freeze_sandbox_for_execve(
     processes: &crate::seccomp::state::ProcessIndex,
     caller_tid: i32,
-) -> io::Result<SandboxFreeze> {
-    let caller_tgid = read_tgid_of_tid(caller_tid)?;
+) -> Result<SandboxFreeze, FreezeError> {
+    let no_pending = |error| FreezeError { error, pending_tids: Vec::new() };
+    let caller_tgid = read_tgid_of_tid(caller_tid).map_err(no_pending)?;
     let mut tgids: HashSet<i32> = processes.pids_snapshot();
     tgids.insert(caller_tgid);
 
     let mut sibling_tids: Vec<i32> = Vec::new();
     let mut peer_tids: Vec<i32> = Vec::new();
+    let mut pending_tids: Vec<i32> = Vec::new();
 
     for tgid in &tgids {
         // /proc/<tgid>/task may disappear if the TGID exited between
@@ -244,24 +306,28 @@ pub(crate) fn freeze_sandbox_for_execve(
                 continue;
             }
             match seize_and_interrupt(tid) {
-                Ok(true) => {
+                Ok(SeizeOutcome::Frozen) => {
                     if *tgid == caller_tgid {
                         sibling_tids.push(tid);
                     } else {
                         peer_tids.push(tid);
                     }
                 }
-                Ok(false) => continue, // already exited — fine
+                Ok(SeizeOutcome::PendingStop) => pending_tids.push(tid),
+                Ok(SeizeOutcome::NotNeeded) => continue,
                 Err(e) => {
                     // Roll back: detach every task we already froze
-                    // (siblings + peers) so they resume normally.
+                    // (siblings + peers) so they resume normally. Pending
+                    // tasks cannot be detached until they stop, which
+                    // requires the caller's response to go out first —
+                    // hand them back through the error.
                     for t in &sibling_tids {
                         detach(*t);
                     }
                     for t in &peer_tids {
                         detach(*t);
                     }
-                    return Err(e);
+                    return Err(FreezeError { error: e, pending_tids });
                 }
             }
         }
@@ -270,7 +336,46 @@ pub(crate) fn freeze_sandbox_for_execve(
     Ok(SandboxFreeze {
         sibling_tids,
         peer_tids,
+        pending_tids,
     })
+}
+
+/// Reap and detach tasks that were seized with a queued interrupt while in
+/// an uninterruptible kernel wait. Called strictly AFTER the execve
+/// response is sent: for the vfork parent the wait clears as soon as that
+/// execve resolves, so the queued interrupt fires promptly. Bounded so an
+/// unrelated long uninterruptible wait cannot stall the supervisor loop;
+/// on expiry the attachment is abandoned loudly rather than silently.
+pub(crate) fn reap_pending(pending: &[i32]) {
+    for &tid in pending {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            let mut status: i32 = 0;
+            let r = unsafe { libc::waitpid(tid, &mut status, libc::__WALL | libc::WNOHANG) };
+            if r == tid {
+                if libc::WIFEXITED(status) || libc::WIFSIGNALED(status) {
+                    break;
+                }
+                if libc::WIFSTOPPED(status) {
+                    detach(tid);
+                    break;
+                }
+            } else if r < 0 {
+                let e = io::Error::last_os_error();
+                if e.raw_os_error() != Some(libc::EINTR) {
+                    break; // reaped elsewhere or gone
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                eprintln!(
+                    "sandlock: tid {tid} never left its kernel wait; \
+                     abandoning its ptrace attachment"
+                );
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+    }
 }
 
 /// Detach peer TIDs after the kernel has re-read execve argv. Errors

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -2138,6 +2138,14 @@ async fn handle_notification(
                     notif.pid, e
                 );
                 action = NotifAction::Errno(libc::EPERM);
+                // Rollback could not release tasks that had not entered
+                // ptrace-stop yet; carry them to the post-send reap.
+                if !e.pending_tids.is_empty() {
+                    exec_freeze = Some(crate::freeze::SandboxFreeze {
+                        pending_tids: e.pending_tids,
+                        ..Default::default()
+                    });
+                }
             }
         }
     }
@@ -2244,6 +2252,10 @@ async fn handle_notification(
         } else {
             crate::freeze::detach_all(&freeze);
         }
+        // Now that the response is out, the kernel wait holding any pending
+        // task (the vfork parent waiting on this very execve) can clear;
+        // reap the queued interrupts and detach.
+        crate::freeze::reap_pending(&freeze.pending_tids);
     }
 }
 
@@ -2329,6 +2341,15 @@ pub async fn supervisor(
                     let notif = match recv_notif(fd) {
                         Ok(n) => n,
                         Err(e) if e.raw_os_error() == Some(libc::EINTR) => continue,
+                        // The notification the probe saw can be withdrawn
+                        // before RECV picks it up: the target was killed
+                        // while the notification was being generated
+                        // (seccomp_unotify(2), RECV ENOENT). Other tasks'
+                        // notifications may still be queued or coming, so
+                        // this is an empty probe, not a dead fd. Breaking
+                        // here retired the whole supervisor and parked
+                        // every later intercepted syscall forever.
+                        Err(e) if e.raw_os_error() == Some(libc::ENOENT) => continue,
                         Err(_) => break 'outer,
                     };
                     handle_notification(notif, &ctx, &dispatch_table, fd, &defer_sem).await;


### PR DESCRIPTION
Started as a fix for the two cli_test failures CI never saw; running the full workspace suite in CI then surfaced two deeper product bugs, both fixed here. Four fixes total plus the CI changes.

## 1. test_write_collapse_skips_protected: COW virtualization gap

A child under learn's `workdir="/"` write-opens `/root/<file>`. `prepare_copy`'s confined lstat of the lower path gets EACCES (the supervisor cannot traverse 0700 `/root`) and treated every errno except ENOENT as an error, so the open fell through to the kernel and the child hit a real permission failure, breaking the COW promise that writes under the workdir never need real permission on the lower entry. `prepare_copy` now gives EACCES the same disposition `execute_copy` already documents (fresh empty upper file), with a 0o000-directory unit test.

## 2. test_learn_captures_openat2: learn granted read on "/"

The sandbox sets the child cwd to the workdir, so under learn the cwd is `/`; python's `-c` mode puts the cwd on `sys.path`, `import ctypes` lists it, and learn recorded `openat("/", O_DIRECTORY)` as a read grant of `/`, which `dedup_subsumed` then let swallow every other read (`read = ["/"]`). Reads now get the same guard the write side always had: `/` is never a grant, warned on stderr.

## 3. --uid silently degraded to 65534 on stock Ubuntu 24.04

Surfaced by the first full-suite CI run: with `kernel.apparmor_restrict_unprivileged_userns=1` (the 24.04 default), unshare(CLONE_NEWUSER) yields a capability-less namespace and the child's `uid_map` write fails behind a `let _ =`, leaving the child running as the overflow uid with no indication. Mapping only runs when the caller explicitly requested an identity, so a failed map write now fails the spawn through the child's `fail!` path, naming the likely sysctl. CI lifts the restriction so the mapping tests exercise the real feature.

## 4. Supervisor deadlock: freeze racing a vfork parent

Surfaced as a CI hang and reproduced locally under CPU load (stress harness, wedged within 2 iterations). `seize_and_interrupt` skips tasks already in `TASK_UNINTERRUPTIBLE`, but the `/proc` state check races the tracee: a vfork parent can pass the check runnable and park in `kernel_clone` before the interrupt lands. The freeze then blocked in an unbounded `waitpid` on the supervisor loop for a task whose wait only clears when the very execve being frozen resolves. Captured live: supervisor in `do_wait`, vfork parent `D` in `kernel_clone`, grandchild parked in `seccomp_do_user_notification`.

The fix arms the interrupt first and reaps with a bounded `WNOHANG` loop; a task seen in `D` after arming becomes `PendingStop` (kernel-held, cannot mutate argv, traps the queued interrupt when its wait clears) and is reaped after the execve response is sent. This also narrows a small pre-existing argv-TOCTOU window: a task that passes the check runnable and then parks in `D` used to be skipped with nothing queued, so it could wake and run user code mid-freeze; it now carries the interrupt and traps before returning to user code. A task already in `D` at the pre-check is still skipped without an attachment (seizing an arbitrary uninterruptible task, e.g. one stuck on slow IO, could strand a ptrace attachment past the bounded reap), so that sliver of the window remains open. The same commit hardens the recv loop against the documented `SECCOMP_IOCTL_NOTIF_RECV` ENOENT race (target killed while its notification was being generated), which previously retired the whole supervisor loop.

Validation: 20/20 stress iterations clean where unfixed code wedged by iteration 2; 530 lib / 305 integration / 50 cli tests pass locally.

## CI

- Run the full workspace suite (`--workspace --no-fail-fast --test-threads=1`): cli, ffi, and oci suites were previously never run in CI, which is how items 1 and 2 shipped invisibly.
- Lift the Ubuntu 24.04 AppArmor userns restriction so uid-mapping tests test the feature.
- Bound the test step at 20 minutes so a hang fails fast with the test name visible.

Note: the `prepare_copy` hunk is adjacent to changes in #162; whichever merges second needs a trivial rebase, and the semantics compose (the whiteout guard sits above the lower lstat).
