### PR TITLE
fix(sandbox): drain the capture pipes while the child runs (#149)

### DIFF
--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -255,6 +255,11 @@ struct Runtime {
     loadavg_handle: Option<JoinHandle<()>>,
     _stdout_read: Option<std::os::fd::OwnedFd>,
     _stderr_read: Option<std::os::fd::OwnedFd>,
+    // Tasks draining the capture pipes above while the child runs (see `wait`).
+    // They belong to the runtime, not to the `wait()` that started them, so a
+    // cancelled `wait()` does not take the output with it.
+    stdout_drain: Option<JoinHandle<Vec<u8>>>,
+    stderr_drain: Option<JoinHandle<Vec<u8>>>,
     // Parent-held write end of a piped stdin (popen). The caller takes it via
     // `Process::take_stdin`; closing it signals EOF to the child.
     _stdin_write: Option<std::os::fd::OwnedFd>,
@@ -743,24 +748,63 @@ impl Sandbox {
     }
 
     /// Wait for the child process to exit.
+    ///
+    /// Dropping the returned future does not cost the captured output: the pipe
+    /// drains belong to the `Sandbox`, so a caller that cancels this `wait()`
+    /// (a `timeout` or `select!` around it) and calls `wait()` again still gets
+    /// what the child wrote.
     pub async fn wait(&mut self) -> Result<crate::result::RunResult, crate::error::SandlockError> {
         use crate::error::SandboxRuntimeError;
         use crate::result::RunResult;
 
         let pid = self.rt().child_pid.ok_or(SandboxRuntimeError::NotRunning)?;
 
-        if let RuntimeState::Stopped(ref es) = self.rt().state {
-            return Ok(RunResult {
-                exit_status: es.clone(),
-                stdout: None,
-                stderr: None,
-            });
+        // Already reaped: hand back the same status again, plus whatever the
+        // drains collected. They outlive the `wait()` that started them, so a
+        // second call still reports the output of a first one that was
+        // cancelled — or that already returned it, in which case they are gone
+        // and both streams are `None`.
+        let stopped = match self.rt().state {
+            RuntimeState::Stopped(ref es) => Some(es.clone()),
+            _ => None,
+        };
+        if let Some(exit_status) = stopped {
+            let (stdout, stderr) = self.collect_pipe_drains().await;
+            return Ok(RunResult { exit_status, stdout, stderr });
         }
 
         // Deliver EOF to a piped stdin the caller never took: otherwise a child
         // that reads stdin (e.g. `cat`) blocks forever and this wait never
         // returns. A taken stdin is already None here (the caller owns it).
         drop(self.rt_mut()._stdin_write.take());
+
+        // Start draining the capture pipes BEFORE waiting for the child to exit.
+        //
+        // Reading them after the exit wait deadlocks the moment the child writes
+        // more than one pipe buffer (64 KiB by default): the pipe fills, the
+        // child blocks in `write()` and can never exit, while this function waits
+        // for exactly that exit. The run then hangs until the caller's timeout
+        // (forever if there is none) and the output is lost. Draining
+        // concurrently keeps the pipe moving, so the child can finish writing and
+        // exit, and the reads still end at EOF — which arrives once the child and
+        // every descendant holding the write end are gone.
+        //
+        // The drains are parked in the runtime rather than in this future: a
+        // caller that cancels `wait()` (a `timeout` or `select!` around it) must
+        // be able to `wait()` again and still be given the output. The
+        // `is_none()` guard is what makes that second call reuse them instead of
+        // starting a second reader. A stream the caller took through
+        // `Process::take_stdout`/`take_stderr` is `None` here and stays theirs.
+        if self.rt().stdout_drain.is_none() {
+            if let Some(fd) = self.rt_mut()._stdout_read.take() {
+                self.rt_mut().stdout_drain = sandbox_spawn_pipe_drain(fd);
+            }
+        }
+        if self.rt().stderr_drain.is_none() {
+            if let Some(fd) = self.rt_mut()._stderr_read.take() {
+                self.rt_mut().stderr_drain = sandbox_spawn_pipe_drain(fd);
+            }
+        }
 
         // Wait for the top-level child to exit. Prefer the child's pidfd via
         // `AsyncFd`: pidfd readiness fires only on *exit*, so — unlike a
@@ -787,10 +831,30 @@ impl Sandbox {
             self.rt_mut().seccomp_cow = cow.branch.take();
         }
 
-        let stdout = self.rt_mut()._stdout_read.take().map(sandbox_read_fd_to_end);
-        let stderr = self.rt_mut()._stderr_read.take().map(sandbox_read_fd_to_end);
+        let (stdout, stderr) = self.collect_pipe_drains().await;
 
         Ok(RunResult { exit_status, stdout, stderr })
+    }
+
+    /// Join the capture-pipe drains, if this runtime still holds them.
+    ///
+    /// Only called once the child has been reaped, so the EOF each drain is
+    /// reading towards is already reachable. `None` means the stream was never
+    /// piped, was taken by the caller, or was already collected by an earlier
+    /// `wait()`; a drain that panicked or was aborted yields no output rather
+    /// than failing the run.
+    async fn collect_pipe_drains(&mut self) -> (Option<Vec<u8>>, Option<Vec<u8>>) {
+        let out = self.rt_mut().stdout_drain.take();
+        let err = self.rt_mut().stderr_drain.take();
+        let stdout = match out {
+            Some(h) => Some(h.await.unwrap_or_default()),
+            None => None,
+        };
+        let stderr = match err {
+            Some(h) => Some(h.await.unwrap_or_default()),
+            None => None,
+        };
+        (stdout, stderr)
     }
 
     /// Fork the sandboxed child and install policy (seccomp + notif
@@ -1315,6 +1379,8 @@ impl Sandbox {
                 loadavg_handle: None,
                 _stdout_read: None,
                 _stderr_read: None,
+                stdout_drain: None,
+                stderr_drain: None,
                 _stdin_write: None,
                 seccomp_cow: None,
                 supervisor_resource: None,
@@ -1409,6 +1475,8 @@ impl Sandbox {
             loadavg_handle: None,
             _stdout_read: None,
             _stderr_read: None,
+            stdout_drain: None,
+            stderr_drain: None,
             _stdin_write: None,
             seccomp_cow: None,
             supervisor_resource: None,
@@ -2079,6 +2147,9 @@ impl Drop for Sandbox {
             if let Some(h) = rt.notif_handle.take() { h.abort(); }
             if let Some(h) = rt.throttle_handle.take() { h.abort(); }
             if let Some(h) = rt.loadavg_handle.take() { h.abort(); }
+            // Nobody is left to collect these; aborting closes the read ends.
+            if let Some(h) = rt.stdout_drain.take() { h.abort(); }
+            if let Some(h) = rt.stderr_drain.take() { h.abort(); }
 
             let is_error = matches!(
                 rt.state,
@@ -2237,6 +2308,36 @@ unsafe fn wire_child_stdio(mode: StdioMode, target: i32, pipe_src: Option<i32>, 
             }
         }
     }
+}
+
+/// Spawn a task that reads one capture pipe to EOF, for `wait` to join once the
+/// child has been reaped.
+///
+/// An ordinary task, not `spawn_blocking`: a blocking read would hold a thread
+/// of the shared blocking pool for the child's entire lifetime — even for a
+/// child that writes nothing — and that pool is also what the COW copier and
+/// the fork-tracking worker need *while* a child is alive, so a saturated pool
+/// is a deadlock rather than a slowdown.
+///
+/// `Receiver::from_owned_fd` sets O_NONBLOCK on this fd and registers it with
+/// the runtime's I/O driver (which `wait` needs anyway, for the pidfd). The
+/// flag belongs to the open file description behind the *read* end; the child
+/// writes to the write end, a separate description, so its `write()`s stay
+/// blocking — which is what keeps the pipe applying back-pressure rather than
+/// dropping output. The conversion can only fail if the fd is not a readable
+/// pipe, which cannot happen for the pipes `do_create_stdio` creates; if it
+/// somehow did, the stream is left uncaptured rather than the run failing.
+fn sandbox_spawn_pipe_drain(fd: std::os::fd::OwnedFd) -> Option<JoinHandle<Vec<u8>>> {
+    let mut rx = match tokio::net::unix::pipe::Receiver::from_owned_fd(fd) {
+        Ok(rx) => rx,
+        Err(_) => return None,
+    };
+    Some(tokio::spawn(async move {
+        use tokio::io::AsyncReadExt;
+        let mut buf = Vec::new();
+        let _ = rx.read_to_end(&mut buf).await;
+        buf
+    }))
 }
 
 fn sandbox_read_fd_to_end(fd: std::os::fd::OwnedFd) -> Vec<u8> {

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -255,11 +255,12 @@ struct Runtime {
     loadavg_handle: Option<JoinHandle<()>>,
     _stdout_read: Option<std::os::fd::OwnedFd>,
     _stderr_read: Option<std::os::fd::OwnedFd>,
-    // Tasks draining the capture pipes above while the child runs (see `wait`).
-    // They belong to the runtime, not to the `wait()` that started them, so a
-    // cancelled `wait()` does not take the output with it.
-    stdout_drain: Option<JoinHandle<Vec<u8>>>,
-    stderr_drain: Option<JoinHandle<Vec<u8>>>,
+    // Drains of the capture pipes above, each holding either the task still
+    // reading or the bytes it finished with (see `wait`). Both states belong to
+    // the runtime rather than to the `wait()` that started them, so a cancelled
+    // `wait()` takes neither the reader nor what it has already produced.
+    stdout_drain: Option<ParkedDrain>,
+    stderr_drain: Option<ParkedDrain>,
     // Parent-held write end of a piped stdin (popen). The caller takes it via
     // `Process::take_stdin`; closing it signals EOF to the child.
     _stdin_write: Option<std::os::fd::OwnedFd>,
@@ -853,10 +854,14 @@ impl Sandbox {
     /// already collected by an earlier `wait()`; a drain that panicked or was
     /// aborted yields no output rather than failing the run.
     async fn collect_pipe_drains(&mut self) -> (Option<Vec<u8>>, Option<Vec<u8>>) {
-        // One statement per stream: each borrow of the runtime ends with it, so
-        // the second join is free to borrow again.
-        let stdout = join_parked_drain(&mut self.rt_mut().stdout_drain).await;
-        let stderr = join_parked_drain(&mut self.rt_mut().stderr_drain).await;
+        // Finish both first — each stores its bytes into the runtime as it
+        // completes — and only then take them out. A cancellation between the
+        // two joins therefore loses nothing: whatever finished is parked.
+        // One statement per stream: each borrow of the runtime ends with it.
+        finish_parked_drain(&mut self.rt_mut().stdout_drain).await;
+        finish_parked_drain(&mut self.rt_mut().stderr_drain).await;
+        let stdout = take_drained(&mut self.rt_mut().stdout_drain);
+        let stderr = take_drained(&mut self.rt_mut().stderr_drain);
         (stdout, stderr)
     }
 
@@ -2151,8 +2156,11 @@ impl Drop for Sandbox {
             if let Some(h) = rt.throttle_handle.take() { h.abort(); }
             if let Some(h) = rt.loadavg_handle.take() { h.abort(); }
             // Nobody is left to collect these; aborting closes the read ends.
-            if let Some(h) = rt.stdout_drain.take() { h.abort(); }
-            if let Some(h) = rt.stderr_drain.take() { h.abort(); }
+            // A drain that already finished holds only bytes, dropped with the
+            // runtime.
+            for slot in [rt.stdout_drain.take(), rt.stderr_drain.take()] {
+                if let Some(ParkedDrain::Running(h)) = slot { h.abort(); }
+            }
 
             let is_error = matches!(
                 rt.state,
@@ -2330,17 +2338,31 @@ unsafe fn wire_child_stdio(mode: StdioMode, target: i32, pipe_src: Option<i32>, 
 /// dropping output. The conversion can only fail if the fd is not a readable
 /// pipe, which cannot happen for the pipes `do_create_stdio` creates; if it
 /// somehow did, the stream is left uncaptured rather than the run failing.
-fn sandbox_spawn_pipe_drain(fd: std::os::fd::OwnedFd) -> Option<JoinHandle<Vec<u8>>> {
+/// A capture pipe's drain, parked on the `Runtime`: the task while it reads,
+/// then the bytes it read.
+///
+/// Both states have to be parked, not just the first. Handing the finished
+/// bytes back to the `wait()` future and clearing the slot would leave them in
+/// a stack local of a cancellable future — and the sibling stream is joined
+/// after it, which is a suspension point whenever that one is still draining.
+/// A timeout landing there would then destroy a capture that had already been
+/// read in full, with nothing left on the runtime to recover it from.
+enum ParkedDrain {
+    Running(JoinHandle<Vec<u8>>),
+    Done(Vec<u8>),
+}
+
+fn sandbox_spawn_pipe_drain(fd: std::os::fd::OwnedFd) -> Option<ParkedDrain> {
     let mut rx = match tokio::net::unix::pipe::Receiver::from_owned_fd(fd) {
         Ok(rx) => rx,
         Err(_) => return None,
     };
-    Some(tokio::spawn(async move {
+    Some(ParkedDrain::Running(tokio::spawn(async move {
         use tokio::io::AsyncReadExt;
         let mut buf = Vec::new();
         let _ = rx.read_to_end(&mut buf).await;
         buf
-    }))
+    })))
 }
 
 /// Join one parked capture drain, leaving it parked if the join is cancelled.
@@ -2357,12 +2379,31 @@ fn sandbox_spawn_pipe_drain(fd: std::os::fd::OwnedFd) -> Option<JoinHandle<Vec<u
 ///
 /// `None` means there was nothing parked. A drain that panicked or was aborted
 /// yields no output rather than failing the run, and is unparked all the same.
-async fn join_parked_drain(slot: &mut Option<JoinHandle<Vec<u8>>>) -> Option<Vec<u8>> {
-    let handle = slot.as_mut()?;
-    // `JoinHandle` is `Unpin`, so it can be polled through `&mut`.
-    let buf = handle.await.unwrap_or_default();
-    *slot = None;
-    Some(buf)
+/// Drive one parked drain to completion, leaving its bytes in the slot.
+///
+/// The store happens in the same step as the await resolving, so there is no
+/// point at which the bytes exist only inside this future: cancelling it leaves
+/// either the still-running task or the finished bytes parked for the next
+/// `wait()`. `JoinHandle` is `Unpin`, so it can be polled through `&mut`, and
+/// dropping this future does not abort the task.
+async fn finish_parked_drain(slot: &mut Option<ParkedDrain>) {
+    if let Some(ParkedDrain::Running(handle)) = slot.as_mut() {
+        let buf = handle.await.unwrap_or_default();
+        *slot = Some(ParkedDrain::Done(buf));
+    }
+}
+
+/// Unpark the bytes of a drain that has finished. Not async on purpose: it runs
+/// after every join, so no cancellation can land between the two streams.
+fn take_drained(slot: &mut Option<ParkedDrain>) -> Option<Vec<u8>> {
+    match slot.take() {
+        Some(ParkedDrain::Done(buf)) => Some(buf),
+        // Still running (nothing joined it) — leave it parked.
+        other => {
+            *slot = other;
+            None
+        }
+    }
 }
 
 fn sandbox_read_fd_to_end(fd: std::os::fd::OwnedFd) -> Vec<u8> {

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -752,7 +752,10 @@ impl Sandbox {
     /// Dropping the returned future does not cost the captured output: the pipe
     /// drains belong to the `Sandbox`, so a caller that cancels this `wait()`
     /// (a `timeout` or `select!` around it) and calls `wait()` again still gets
-    /// what the child wrote.
+    /// what the child wrote. That holds wherever the cancellation lands —
+    /// before the drains start, while the child is still running, or while the
+    /// final join is blocked because a descendant is still holding the write
+    /// end open past the child's own exit.
     pub async fn wait(&mut self) -> Result<crate::result::RunResult, crate::error::SandlockError> {
         use crate::error::SandboxRuntimeError;
         use crate::result::RunResult;
@@ -762,8 +765,9 @@ impl Sandbox {
         // Already reaped: hand back the same status again, plus whatever the
         // drains collected. They outlive the `wait()` that started them, so a
         // second call still reports the output of a first one that was
-        // cancelled — or that already returned it, in which case they are gone
-        // and both streams are `None`.
+        // cancelled — including one cancelled while joining them here, since a
+        // join only unparks a drain once it has completed. A `wait()` that ran
+        // to the end took them with it, and both streams are then `None`.
         let stopped = match self.rt().state {
             RuntimeState::Stopped(ref es) => Some(es.clone()),
             _ => None,
@@ -839,21 +843,20 @@ impl Sandbox {
     /// Join the capture-pipe drains, if this runtime still holds them.
     ///
     /// Only called once the child has been reaped, so the EOF each drain is
-    /// reading towards is already reachable. `None` means the stream was never
-    /// piped, was taken by the caller, or was already collected by an earlier
-    /// `wait()`; a drain that panicked or was aborted yields no output rather
-    /// than failing the run.
+    /// reading towards is already reachable — but not necessarily *reached*: a
+    /// descendant that inherited the write end keeps the join blocked for as
+    /// long as it lives, which is exactly when a caller's timeout fires. So
+    /// each handle is joined in place and only unparked once that join
+    /// completes; see `join_parked_drain`.
+    ///
+    /// `None` means the stream was never piped, was taken by the caller, or was
+    /// already collected by an earlier `wait()`; a drain that panicked or was
+    /// aborted yields no output rather than failing the run.
     async fn collect_pipe_drains(&mut self) -> (Option<Vec<u8>>, Option<Vec<u8>>) {
-        let out = self.rt_mut().stdout_drain.take();
-        let err = self.rt_mut().stderr_drain.take();
-        let stdout = match out {
-            Some(h) => Some(h.await.unwrap_or_default()),
-            None => None,
-        };
-        let stderr = match err {
-            Some(h) => Some(h.await.unwrap_or_default()),
-            None => None,
-        };
+        // One statement per stream: each borrow of the runtime ends with it, so
+        // the second join is free to borrow again.
+        let stdout = join_parked_drain(&mut self.rt_mut().stdout_drain).await;
+        let stderr = join_parked_drain(&mut self.rt_mut().stderr_drain).await;
         (stdout, stderr)
     }
 
@@ -2338,6 +2341,28 @@ fn sandbox_spawn_pipe_drain(fd: std::os::fd::OwnedFd) -> Option<JoinHandle<Vec<u
         let _ = rx.read_to_end(&mut buf).await;
         buf
     }))
+}
+
+/// Join one parked capture drain, leaving it parked if the join is cancelled.
+///
+/// The handle is awaited *through* the slot and the slot is cleared only once
+/// the await has produced a value. Taking the handle out first would hand it to
+/// the awaiting future, so dropping that future — which is all a caller's
+/// `timeout` or `select!` does — would drop the handle with it and every later
+/// `wait()` would report no output. This join is not instantaneous: the child
+/// is reaped by the time it runs, but a descendant still holding the write end
+/// keeps the read short of EOF, which is precisely the case a caller times out
+/// on. Dropping the returned future does not abort the drain task, so the
+/// handle left behind is still reading and a later `wait()` picks it up.
+///
+/// `None` means there was nothing parked. A drain that panicked or was aborted
+/// yields no output rather than failing the run, and is unparked all the same.
+async fn join_parked_drain(slot: &mut Option<JoinHandle<Vec<u8>>>) -> Option<Vec<u8>> {
+    let handle = slot.as_mut()?;
+    // `JoinHandle` is `Unpin`, so it can be polled through `&mut`.
+    let buf = handle.await.unwrap_or_default();
+    *slot = None;
+    Some(buf)
 }
 
 fn sandbox_read_fd_to_end(fd: std::os::fd::OwnedFd) -> Vec<u8> {

--- a/crates/sandlock-core/src/sandbox/tests.rs
+++ b/crates/sandlock-core/src/sandbox/tests.rs
@@ -325,3 +325,36 @@ fn relocate_high_moves_fd_above_stdio_range() {
 
     unsafe { libc::close(hi) };
 }
+
+/// A `wait()` cancelled while it is joining the drains must leave the handle
+/// parked, so a later `wait()` still returns the capture. Reaching that state
+/// end-to-end needs a descendant holding the write end past the child's exit,
+/// which is inherently racy (the integration test retries for it), so the
+/// contract itself is pinned here: joining through the slot, and clearing it
+/// only once the await has produced a value.
+#[tokio::test]
+async fn join_parked_drain_keeps_the_handle_when_cancelled() {
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let mut slot = Some(tokio::spawn(async move {
+        let _ = rx.await;
+        b"hello".to_vec()
+    }));
+
+    // The task cannot finish while the sender is held, so this join is still
+    // pending when the timeout drops it — that drop is the cancellation.
+    let cancelled = tokio::time::timeout(
+        std::time::Duration::from_millis(50),
+        join_parked_drain(&mut slot),
+    )
+    .await;
+    assert!(cancelled.is_err(), "the join must still have been pending");
+    assert!(slot.is_some(), "a cancelled join must leave the handle parked");
+
+    // Releasing the task: the parked handle still yields what it read.
+    tx.send(()).unwrap();
+    assert_eq!(
+        join_parked_drain(&mut slot).await.as_deref(),
+        Some(&b"hello"[..]),
+    );
+    assert!(slot.is_none(), "a completed join must clear the slot");
+}

--- a/crates/sandlock-core/src/sandbox/tests.rs
+++ b/crates/sandlock-core/src/sandbox/tests.rs
@@ -326,35 +326,70 @@ fn relocate_high_moves_fd_above_stdio_range() {
     unsafe { libc::close(hi) };
 }
 
-/// A `wait()` cancelled while it is joining the drains must leave the handle
+/// A `wait()` cancelled while it is joining the drains must leave the drain
 /// parked, so a later `wait()` still returns the capture. Reaching that state
-/// end-to-end needs a descendant holding the write end past the child's exit,
+/// end to end needs a descendant holding the write end past the child's exit,
 /// which is inherently racy (the integration test retries for it), so the
-/// contract itself is pinned here: joining through the slot, and clearing it
-/// only once the await has produced a value.
+/// contract itself is pinned here: a pending join leaves the task parked, a
+/// finished one leaves the bytes parked, and only an explicit take hands them
+/// over.
 #[tokio::test]
-async fn join_parked_drain_keeps_the_handle_when_cancelled() {
+async fn a_cancelled_join_leaves_the_drain_parked() {
     let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-    let mut slot = Some(tokio::spawn(async move {
+    let mut slot = Some(ParkedDrain::Running(tokio::spawn(async move {
         let _ = rx.await;
         b"hello".to_vec()
-    }));
+    })));
 
     // The task cannot finish while the sender is held, so this join is still
     // pending when the timeout drops it — that drop is the cancellation.
     let cancelled = tokio::time::timeout(
         std::time::Duration::from_millis(50),
-        join_parked_drain(&mut slot),
+        finish_parked_drain(&mut slot),
     )
     .await;
     assert!(cancelled.is_err(), "the join must still have been pending");
-    assert!(slot.is_some(), "a cancelled join must leave the handle parked");
-
-    // Releasing the task: the parked handle still yields what it read.
-    tx.send(()).unwrap();
-    assert_eq!(
-        join_parked_drain(&mut slot).await.as_deref(),
-        Some(&b"hello"[..]),
+    assert!(
+        matches!(slot, Some(ParkedDrain::Running(_))),
+        "a cancelled join must leave the task parked",
     );
-    assert!(slot.is_none(), "a completed join must clear the slot");
+
+    // Releasing it parks the bytes rather than handing them out.
+    tx.send(()).unwrap();
+    finish_parked_drain(&mut slot).await;
+    assert!(
+        matches!(slot, Some(ParkedDrain::Done(ref buf)) if buf == b"hello"),
+        "a finished join must park its bytes in the slot",
+    );
+
+    assert_eq!(take_drained(&mut slot).as_deref(), Some(&b"hello"[..]));
+    assert!(slot.is_none(), "taking the bytes must empty the slot");
+}
+
+/// The reason the bytes are parked rather than returned: the two streams are
+/// joined one after the other, so the second join is a suspension point for a
+/// capture the first one has already read in full. A cancellation there must
+/// not take it.
+#[tokio::test]
+async fn a_finished_capture_survives_a_cancellation_at_the_sibling_join() {
+    let mut stdout = Some(ParkedDrain::Running(tokio::spawn(async { b"hello".to_vec() })));
+    // Held for the whole test, so this drain never finishes.
+    let (_tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let mut stderr = Some(ParkedDrain::Running(tokio::spawn(async move {
+        let _ = rx.await;
+        Vec::new()
+    })));
+
+    // The shape of `collect_pipe_drains`: finish one, then the other.
+    let cancelled = tokio::time::timeout(std::time::Duration::from_millis(50), async {
+        finish_parked_drain(&mut stdout).await;
+        finish_parked_drain(&mut stderr).await;
+    })
+    .await;
+    assert!(cancelled.is_err(), "the second join must still have been pending");
+
+    assert!(
+        matches!(stdout, Some(ParkedDrain::Done(ref buf)) if buf == b"hello"),
+        "a capture that finished before the cancellation must still be parked",
+    );
 }

--- a/crates/sandlock-core/tests/integration/test_popen.rs
+++ b/crates/sandlock-core/tests/integration/test_popen.rs
@@ -232,3 +232,36 @@ async fn test_popen_rejects_second_spawn() {
         .await;
     assert!(second.is_err(), "second popen on a used Sandbox must error, not reuse state");
 }
+
+/// A stream the caller took stays the caller's: `wait()` must not drain it (or
+/// steal its bytes into the `RunResult`) behind the caller's back, and must
+/// report `None` for it. The untaken piped stream on the same process is still
+/// collected as usual, so the two paths are exercised together.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_popen_taken_stdout_is_not_drained_by_wait() {
+    let mut sb = base().with_name("popen-taken-stdout");
+    let mut child = sb
+        .popen(
+            &["sh", "-c", "printf out; printf err 1>&2"],
+            StdioMode::Inherit,
+            StdioMode::Piped,
+            StdioMode::Piped,
+        )
+        .await
+        .unwrap();
+
+    let mut stdout = File::from(child.take_stdout().expect("taking stdout must yield the stream"));
+
+    let mut out = String::new();
+    stdout.read_to_string(&mut out).unwrap();
+    assert_eq!(out, "out", "the taken stream must still carry the child's output");
+
+    let res = child.wait().await.unwrap();
+    assert!(res.success());
+    assert!(res.stdout.is_none(), "a taken stdout must be None in the RunResult");
+    assert_eq!(
+        res.stderr.as_deref(),
+        Some(&b"err"[..]),
+        "the untaken piped stderr must still be captured",
+    );
+}

--- a/crates/sandlock-core/tests/integration/test_sandbox.rs
+++ b/crates/sandlock-core/tests/integration/test_sandbox.rs
@@ -692,3 +692,191 @@ async fn test_chroot() {
 
     let _ = std::fs::remove_dir_all(&chroot_dir);
 }
+
+// ============================================================
+// Capture pipes must be drained while the child runs, not after it exits.
+//
+// A child that writes more than one pipe buffer (64 KiB by default) blocks in
+// `write()` once the pipe fills. If `wait()` only reads the pipes after the
+// child has exited, the child can never reach that exit and the run hangs until
+// the caller's timeout — forever if there is none — losing the output.
+//
+// Each test bounds itself with `tokio::time::timeout` so the regression fails
+// the test instead of hanging the suite; dropping the `Sandbox` on that path
+// SIGKILLs the child's process group.
+// ============================================================
+
+/// Payload comfortably larger than the default 64 KiB pipe buffer.
+const OVER_PIPE_BUFFER: usize = 1024 * 1024;
+
+fn capture_policy() -> Sandbox {
+    Sandbox::builder()
+        .fs_read("/usr")
+        .fs_read("/lib")
+        .fs_read_if_exists("/lib64")
+        .fs_read("/bin")
+        .fs_read("/etc")
+        .fs_read("/proc")
+        .fs_read("/dev")
+        .build()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn test_run_captures_stdout_larger_than_the_pipe_buffer() {
+    let cmd = format!("head -c {} /dev/zero | tr '\\0' 'X'", OVER_PIPE_BUFFER);
+    let mut sb = capture_policy().with_name("test");
+    let args = ["sh", "-c", cmd.as_str()];
+    let fut = sb.run(&args);
+    let result = tokio::time::timeout(std::time::Duration::from_secs(60), fut)
+        .await
+        .expect("run() hung: the capture pipe filled and the child could not exit")
+        .unwrap();
+
+    assert!(result.success(), "child should exit 0");
+    assert_eq!(
+        result.stdout.as_ref().map(|b| b.len()),
+        Some(OVER_PIPE_BUFFER),
+        "the whole payload must be captured, not just the first pipe buffer",
+    );
+    assert!(
+        result.stdout.as_ref().unwrap().iter().all(|&b| b == b'X'),
+        "captured stdout must be the payload itself, not spliced or reordered bytes",
+    );
+}
+
+#[tokio::test]
+async fn test_run_captures_stderr_larger_than_the_pipe_buffer() {
+    let cmd = format!("head -c {} /dev/zero | tr '\\0' 'E' 1>&2", OVER_PIPE_BUFFER);
+    let mut sb = capture_policy().with_name("test");
+    let args = ["sh", "-c", cmd.as_str()];
+    let fut = sb.run(&args);
+    let result = tokio::time::timeout(std::time::Duration::from_secs(60), fut)
+        .await
+        .expect("run() hung on a stderr payload larger than the pipe buffer")
+        .unwrap();
+
+    assert!(result.success(), "child should exit 0");
+    assert_eq!(
+        result.stderr.as_ref().map(|b| b.len()),
+        Some(OVER_PIPE_BUFFER),
+        "the whole stderr payload must be captured",
+    );
+    assert!(
+        result.stderr.as_ref().unwrap().iter().all(|&b| b == b'E'),
+        "captured stderr must be the payload itself",
+    );
+}
+
+/// Both streams over the buffer at once. This is the case a *sequential* drain
+/// (finish stdout, then start stderr) still deadlocks on: stdout only reaches
+/// EOF when the child exits, and the child is blocked writing stderr.
+#[tokio::test]
+async fn test_run_captures_large_stdout_and_stderr_together() {
+    let cmd = format!(
+        "head -c {n} /dev/zero | tr '\\0' 'O'; head -c {n} /dev/zero | tr '\\0' 'E' 1>&2",
+        n = OVER_PIPE_BUFFER
+    );
+    let mut sb = capture_policy().with_name("test");
+    let args = ["sh", "-c", cmd.as_str()];
+    let fut = sb.run(&args);
+    let result = tokio::time::timeout(std::time::Duration::from_secs(60), fut)
+        .await
+        .expect("run() hung with both streams over the pipe buffer")
+        .unwrap();
+
+    assert!(result.success(), "child should exit 0");
+    assert_eq!(result.stdout.as_ref().map(|b| b.len()), Some(OVER_PIPE_BUFFER));
+    assert_eq!(result.stderr.as_ref().map(|b| b.len()), Some(OVER_PIPE_BUFFER));
+    assert!(
+        result.stdout.as_ref().unwrap().iter().all(|&b| b == b'O'),
+        "stdout must hold only its own payload",
+    );
+    assert!(
+        result.stderr.as_ref().unwrap().iter().all(|&b| b == b'E'),
+        "stderr must hold only its own payload — the two streams must not be crossed",
+    );
+}
+
+/// A `wait()` the caller cancels must not destroy the capture: the drains
+/// belong to the `Sandbox`, so a later `wait()` still returns what they read.
+///
+/// Cancelling a `wait()` is a normal in-tree idiom (a `tokio::time::timeout`
+/// or `select!` around it, then `kill()` and wait again). If the first poll
+/// moved the pipe read ends into detached readers that the cancelled future
+/// owned, they would be lost with it and every later `wait()` would report no
+/// output at all. Nothing here is large enough to fill a pipe buffer — this is
+/// about ownership of the drains, not about the deadlock above.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_cancelled_wait_keeps_the_capture_for_the_next_wait() {
+    let mut sb = capture_policy().with_name("drain-cancel");
+    sb.spawn(&["sh", "-c", "printf hello; sleep 5"]).await.unwrap();
+
+    // The child sleeps well past this, so the first wait is cancelled mid-flight.
+    let first = tokio::time::timeout(std::time::Duration::from_millis(500), sb.wait()).await;
+    assert!(first.is_err(), "the child sleeps 5s: this wait must be cancelled, not complete");
+
+    sb.kill().unwrap();
+
+    let result = tokio::time::timeout(std::time::Duration::from_secs(30), sb.wait())
+        .await
+        .expect("the second wait() hung")
+        .unwrap();
+
+    assert_eq!(
+        result.stdout.as_deref(),
+        Some(&b"hello"[..]),
+        "the cancelled wait() must not have consumed and discarded the child's output",
+    );
+}
+
+/// A capture-mode `wait()` must not park threads of the shared blocking pool
+/// for the child's whole lifetime.
+///
+/// That pool is also what the COW copier and the fork-tracking worker run on,
+/// and both must make progress *while* a child is alive — so a `wait()` that
+/// holds pool threads until its child exits can starve a second, unrelated
+/// sandbox into a deadlock rather than merely slowing it down. The runtime here
+/// is deliberately small so that a two-thread-per-wait cost is fatal; with
+/// drains that cost no pool threads, the second run finishes normally.
+///
+/// Own runtime, so `max_blocking_threads` can be set (`#[tokio::test]` cannot).
+#[test]
+fn test_capture_wait_does_not_park_blocking_pool_threads() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .max_blocking_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        // A long-lived child that writes nothing at all: any pool thread this
+        // costs is held purely for being alive.
+        let mut idle = capture_policy().with_name("drain-idle");
+        idle.spawn(&["sh", "-c", "sleep 60"]).await.unwrap();
+
+        let mut quick = capture_policy().with_name("drain-quick");
+
+        let idle_wait = idle.wait();
+        let quick_run = quick.run(&["echo", "hi"]);
+        tokio::pin!(idle_wait);
+        tokio::pin!(quick_run);
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(60), async {
+            tokio::select! {
+                biased;
+                // Polled first, so its drains are in flight before the second
+                // sandbox starts.
+                _ = &mut idle_wait => panic!("the idle child sleeps 60s; it must not exit first"),
+                r = &mut quick_run => r,
+            }
+        })
+        .await
+        .expect("a second sandbox deadlocked while the first was merely alive")
+        .unwrap();
+
+        assert!(result.success());
+        assert_eq!(result.stdout.as_deref(), Some(&b"hi\n"[..]));
+    });
+}

--- a/crates/sandlock-core/tests/integration/test_sandbox.rs
+++ b/crates/sandlock-core/tests/integration/test_sandbox.rs
@@ -937,3 +937,44 @@ fn test_capture_wait_does_not_park_blocking_pool_threads() {
         assert_eq!(result.stdout.as_deref(), Some(&b"hi\n"[..]));
     });
 }
+
+/// The streams are joined one after the other, so the second join is a
+/// suspension point for a capture the first one has already read in full. A
+/// caller's timeout landing there must not destroy it.
+///
+/// The survivor closes fd 1 but keeps fd 2, so stdout reaches EOF while stderr
+/// cannot: the first join completes, the second blocks, and the cancellation
+/// lands exactly between them. An attempt whose first `wait()` completes had no
+/// survivor and is retried; never reaching that state at all is a failure.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_a_finished_capture_survives_a_cancel_at_the_other_join() {
+    // `exec 1>&-` closes the subshell's stdout, so only stderr stays held. The
+    // counting loop keeps the parent shell alive past its background job's
+    // start-up (a survivor racing the parent's exit never takes the fd).
+    const CMD: &str =
+        "printf hello; (exec 1>&-; while :; do :; done) & i=0; while [ $i -lt 20000 ]; do i=$((i+1)); done";
+
+    for _ in 0..8 {
+        let mut sb = capture_policy().with_name("sibling-join-cancel");
+        sb.spawn(&["sh", "-c", CMD]).await.unwrap();
+
+        let first = tokio::time::timeout(std::time::Duration::from_millis(600), sb.wait()).await;
+        if first.is_ok() {
+            continue;
+        }
+
+        sb.kill().unwrap();
+        let result = tokio::time::timeout(std::time::Duration::from_secs(30), sb.wait())
+            .await
+            .expect("the second wait() hung")
+            .unwrap();
+
+        assert_eq!(
+            result.stdout.as_deref(),
+            Some(&b"hello"[..]),
+            "a capture that finished before the cancellation must survive it",
+        );
+        return;
+    }
+    panic!("no attempt reached the cancellation between the two joins");
+}

--- a/crates/sandlock-core/tests/integration/test_sandbox.rs
+++ b/crates/sandlock-core/tests/integration/test_sandbox.rs
@@ -830,6 +830,63 @@ async fn test_cancelled_wait_keeps_the_capture_for_the_next_wait() {
     );
 }
 
+/// The same promise, for a `wait()` cancelled while it is *joining* the drains.
+///
+/// The child exits promptly, so the exit wait completes and `wait()` gets as
+/// far as the final join — which then blocks, because a background subshell
+/// inherited the write end of stdout and the read cannot reach EOF while it
+/// lives. That is the documented slow case, and it is where a caller's timeout
+/// lands. A join that took the handles out of the runtime before awaiting them
+/// would drop them with the cancelled future, and the next `wait()` would
+/// report no output at all even though the drain had read it.
+///
+/// Keeping that survivor alive takes some care. It has to be a subshell rather
+/// than a backgrounded external command, because an `execve` from a background
+/// job is not guaranteed to succeed under every policy — and a survivor that
+/// never starts leaves the join unblocked and this test vacuous. A shell also
+/// reopens a background job's stdin before running it, and the supervisor stops
+/// answering once the top-level child is reaped, so the shell is kept busy for
+/// a while after forking to let that finish first. An attempt whose first
+/// `wait()` completes anyway says nothing about the join and is retried;
+/// never blocking at all is a failure, not a pass. The contract this exercises
+/// is also pinned deterministically as a unit test on `join_parked_drain`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_wait_cancelled_during_the_drain_join_keeps_the_capture() {
+    // The subshell holds fd 1 open and execs nothing of its own; the counting
+    // loop is the parent shell outliving its own background job's start-up.
+    const CMD: &str =
+        "printf hello; (while :; do :; done) & i=0; while [ $i -lt 20000 ]; do i=$((i+1)); done";
+
+    for _ in 0..8 {
+        let mut sb = capture_policy().with_name("drain-join-cancel");
+        sb.spawn(&["sh", "-c", CMD]).await.unwrap();
+
+        // The child exits, but the drain cannot: this cancellation lands on the
+        // join. A wait that completes means no survivor took the write end.
+        let first = tokio::time::timeout(std::time::Duration::from_millis(500), sb.wait()).await;
+        if first.is_ok() {
+            continue;
+        }
+
+        // Kills the whole process group, so the surviving subshell releases the
+        // write end and the parked drain can finally see EOF.
+        sb.kill().unwrap();
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(30), sb.wait())
+            .await
+            .expect("the second wait() hung")
+            .unwrap();
+
+        assert_eq!(
+            result.stdout.as_deref(),
+            Some(&b"hello"[..]),
+            "a wait() cancelled during the join must leave the drain parked for the next one",
+        );
+        return;
+    }
+    panic!("no attempt kept a descendant on the write end: the join was never cancelled");
+}
+
 /// A capture-mode `wait()` must not park threads of the shared blocking pool
 /// for the child's whole lifetime.
 ///


### PR DESCRIPTION
Fixes #149.

`wait()` read the capture pipes only after awaiting child exit. A child that writes more than one pipe buffer — 64 KiB by default — blocks in `write()` once the pipe fills, so it never reaches the exit `wait()` is waiting for: the run hangs until the caller's timeout, forever if there is none, and the output is lost. On current main, 64 KiB returns in 17 ms and 1 MiB never returns.

The drains now start before the exit wait and are joined after it. They are ordinary async tasks (`tokio::net::unix::pipe::Receiver`), so no blocking-pool threads and no new OS threads are used — which also keeps `run()` usable where thread creation is refused (#47). `O_NONBLOCK` is set on the supervisor's read end only; the child writes the *write* end, a separate open file description, so its writes stay blocking and back-pressure is preserved.

The handles are parked on the `Sandbox` rather than on the `wait()` future, so cancelling `wait()` no longer loses the capture: a later `wait()` joins the drains and returns the complete output. Before this change a retry returned only what had fit in one pipe buffer, and the `RuntimeState::Stopped` early return reported nothing at all. `Drop` aborts the drains.

Streams taken through `Process::take_stdout` / `take_stderr` are unaffected and remain the caller's to drain.

## Scope

Covers every path that captures through `wait()`: `run`, `run_interactive`, `run_with_handlers`, `dry_run`, `Process::wait`.

Not covered: `Pipeline::run` / `Gather::run`, which read their own pipes after the stage-wait loop, and `fork` / `reduce`, which blocks in `sandbox_read_exact` before the reducer drains the clone pipes. Same defect, deliberately unchanged here — happy to follow up separately if you want it in one go.

## Properties worth stating

**EOF liveness is unchanged.** The drains end at EOF, which requires every holder of the write end to close it, so a descendant that inherited fd 1/2 and outlives the child still keeps `wait()` blocked. That is exactly the previous behaviour — the old post-exit `read_to_end` blocked on the same condition, inline and uncancellable.

**Memory trade.** Capture is now bounded by the workload rather than by the pipe: `wait()` holds the whole stream in memory, where the pipe buffer previously stopped it at 64 KiB by hanging. Callers running output-unbounded workloads should take the stream and cap it themselves. A `capture_limit` builder option would be a reasonable follow-up; note that a capped reader must still drain to EOF or it reintroduces this issue.

## Tests

Three over-buffer cases — stdout, stderr, and both at once. The combined one is the discriminating case: a *sequential* drain still deadlocks on it, because stdout only reaches EOF when the child exits and the child is blocked writing stderr.

Two more for the properties above: cancel-then-retry must still return the capture, and a runtime with `max_blocking_threads(2)` must not deadlock a second capture-mode run while a zero-output sandbox is alive.

Each fails without its part of the change, and all are timeout-bounded so a regression fails the test instead of hanging CI.
