### PR TITLE
seccomp: accept syscall group names in both --extra-deny-syscall and --extra-allow-syscall

### DIFF
--- a/crates/sandlock-core/src/context/tests.rs
+++ b/crates/sandlock-core/src/context/tests.rs
@@ -224,12 +224,19 @@ fn test_blocklist_syscall_numbers_default_with_sysv_ipc_allowed() {
     assert!(!nrs.contains(&(libc::SYS_semget as u32)));
 }
 
+// The expansion tests below inject the group deny after build(): with
+// allow "sysv_ipc" set, the !allows_sysv_ipc() fallback in
+// resolve_blocklist is skipped, so the members can appear only through
+// group expansion of the deny entry. Going through build() instead
+// would either trip the allow/deny conflict check or (deny-only) let
+// the fallback add the members and mask a broken expansion.
 #[test]
 fn test_blocklist_syscall_numbers_expands_deny_group() {
-    let policy = Sandbox::builder()
-        .extra_deny_syscalls(vec!["sysv_ipc".into()])
+    let mut policy = Sandbox::builder()
+        .extra_allow_syscalls(vec!["sysv_ipc".into()])
         .build()
         .unwrap();
+    policy.extra_deny_syscalls = vec!["sysv_ipc".into()];
     let nrs = blocklist_syscall_numbers(&policy);
     assert!(nrs.contains(&(libc::SYS_shmget as u32)));
     assert!(nrs.contains(&(libc::SYS_msgget as u32)));
@@ -239,12 +246,11 @@ fn test_blocklist_syscall_numbers_expands_deny_group() {
 
 #[test]
 fn test_no_supervisor_blocklist_expands_deny_group() {
-    // The relaxed no-supervisor list omits SysV IPC append only when the
-    // group is allowed; an explicit group deny must still expand here.
-    let policy = Sandbox::builder()
-        .extra_deny_syscalls(vec!["sysv_ipc".into()])
+    let mut policy = Sandbox::builder()
+        .extra_allow_syscalls(vec!["sysv_ipc".into()])
         .build()
         .unwrap();
+    policy.extra_deny_syscalls = vec!["sysv_ipc".into()];
     let nrs = no_supervisor_blocklist_syscall_numbers(&policy);
     assert!(nrs.contains(&(libc::SYS_shmget as u32)));
     assert!(nrs.contains(&(libc::SYS_msgctl as u32)));

--- a/crates/sandlock-core/src/context/tests.rs
+++ b/crates/sandlock-core/src/context/tests.rs
@@ -225,6 +225,32 @@ fn test_blocklist_syscall_numbers_default_with_sysv_ipc_allowed() {
 }
 
 #[test]
+fn test_blocklist_syscall_numbers_expands_deny_group() {
+    let policy = Sandbox::builder()
+        .extra_deny_syscalls(vec!["sysv_ipc".into()])
+        .build()
+        .unwrap();
+    let nrs = blocklist_syscall_numbers(&policy);
+    assert!(nrs.contains(&(libc::SYS_shmget as u32)));
+    assert!(nrs.contains(&(libc::SYS_msgget as u32)));
+    assert!(nrs.contains(&(libc::SYS_semget as u32)));
+    assert!(nrs.contains(&(libc::SYS_semtimedop as u32)));
+}
+
+#[test]
+fn test_no_supervisor_blocklist_expands_deny_group() {
+    // The relaxed no-supervisor list omits SysV IPC append only when the
+    // group is allowed; an explicit group deny must still expand here.
+    let policy = Sandbox::builder()
+        .extra_deny_syscalls(vec!["sysv_ipc".into()])
+        .build()
+        .unwrap();
+    let nrs = no_supervisor_blocklist_syscall_numbers(&policy);
+    assert!(nrs.contains(&(libc::SYS_shmget as u32)));
+    assert!(nrs.contains(&(libc::SYS_msgctl as u32)));
+}
+
+#[test]
 fn test_no_supervisor_blocklist_includes_sysv_ipc_by_default() {
     let policy = Sandbox::builder().build().unwrap();
     let nrs = no_supervisor_blocklist_syscall_numbers(&policy);

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -2839,16 +2839,78 @@ fn validate_syscall_names(names: &[String]) -> Result<(), SandboxError> {
     let unknown: Vec<&str> = names
         .iter()
         .map(String::as_str)
-        .filter(|name| crate::seccomp::syscall::syscall_name_to_nr(name).is_none())
+        .filter(|name| {
+            crate::sys::structs::syscall_group(name).is_none()
+                && crate::seccomp::syscall::syscall_name_to_nr(name).is_none()
+        })
         .collect();
     if unknown.is_empty() {
         Ok(())
     } else {
         Err(SandboxError::Invalid(format!(
-            "unknown syscall name(s): {}",
+            "unknown syscall or group name(s): {}",
             unknown.join(", ")
         )))
     }
+}
+
+fn known_group_names() -> String {
+    crate::sys::structs::SYSCALL_GROUPS
+        .iter()
+        .map(|(group, _)| *group)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn validate_allow_groups(names: &[String]) -> Result<(), SandboxError> {
+    let unknown: Vec<&str> = names
+        .iter()
+        .map(String::as_str)
+        .filter(|name| crate::sys::structs::syscall_group(name).is_none())
+        .collect();
+    if unknown.is_empty() {
+        Ok(())
+    } else {
+        Err(SandboxError::Invalid(format!(
+            "unknown syscall group name(s): {} (known groups: {}); \
+             individual syscalls cannot be re-allowed",
+            unknown.join(", "),
+            known_group_names()
+        )))
+    }
+}
+
+/// Reject a syscall appearing on both sides. The BPF layout places notif
+/// JEQs before deny JEQs, so a syscall that an allowed group routes to
+/// notif would silently bypass a kernel-level deny of the same syscall.
+fn validate_allow_deny_disjoint(
+    allow_groups: &[String],
+    deny: &[String],
+) -> Result<(), SandboxError> {
+    let denied: std::collections::HashSet<&str> = deny
+        .iter()
+        .flat_map(|name| match crate::sys::structs::syscall_group(name) {
+            Some(members) => members.iter().copied().collect::<Vec<_>>(),
+            None => vec![name.as_str()],
+        })
+        .collect();
+    for group in allow_groups {
+        if deny.iter().any(|d| d == group) {
+            return Err(SandboxError::Invalid(format!(
+                "syscall group `{}` is both allowed and denied",
+                group
+            )));
+        }
+        if let Some(members) = crate::sys::structs::syscall_group(group) {
+            if let Some(overlap) = members.iter().find(|m| denied.contains(**m)) {
+                return Err(SandboxError::Invalid(format!(
+                    "syscall `{}` is denied but belongs to allowed group `{}`",
+                    overlap, group
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Parse `--net-allow-bind` specs. Accepts the `*` wildcard (any port),

--- a/crates/sandlock-core/src/sandbox/builder.rs
+++ b/crates/sandlock-core/src/sandbox/builder.rs
@@ -16,12 +16,15 @@ pub struct SandboxBuilder {
     #[cfg_attr(feature = "cli", arg(long = "fs-deny", value_name = "PATH"))]
     pub fs_denied: Vec<PathBuf>,
 
-    /// Extra syscall names to deny (in addition to Sandlock's default blocklist)
-    #[cfg_attr(feature = "cli", arg(long = "extra-deny-syscall", value_name = "NAME"))]
+    /// Extra syscall or syscall-group name to deny, in addition to Sandlock's
+    /// default blocklist (groups: sysv_ipc). Repeatable.
+    #[cfg_attr(feature = "cli", arg(long = "extra-deny-syscall", value_name = "NAME|GROUP"))]
     pub extra_deny_syscalls: Vec<String>,
 
-    /// Extra syscall group names to allow (e.g. sysv_ipc)
-    #[cfg_attr(feature = "cli", arg(long = "extra-allow-syscall", value_name = "NAME"))]
+    /// Syscall group name to allow back from the default blocklist
+    /// (groups: sysv_ipc). Individual syscalls cannot be re-allowed.
+    /// Repeatable.
+    #[cfg_attr(feature = "cli", arg(long = "extra-allow-syscall", value_name = "GROUP"))]
     pub extra_allow_syscalls: Vec<String>,
 
     /// Outbound endpoint allow rule. Repeatable. Each value is
@@ -775,6 +778,8 @@ impl SandboxBuilder {
     /// construct sandboxes violating cross-section invariants.
     pub fn build_unchecked(self) -> Result<Sandbox, SandboxError> {
         validate_syscall_names(&self.extra_deny_syscalls)?;
+        validate_allow_groups(&self.extra_allow_syscalls)?;
+        validate_allow_deny_disjoint(&self.extra_allow_syscalls, &self.extra_deny_syscalls)?;
 
         // Reject disable(FsRefer): the kernel denies REFER (cross-directory
         // rename/link) by default in every ruleset even when REFER is not

--- a/crates/sandlock-core/src/sandbox/tests.rs
+++ b/crates/sandlock-core/src/sandbox/tests.rs
@@ -165,11 +165,55 @@ fn allows_sysv_ipc_reads_extra_allow_syscalls() {
     let p2 = Sandbox::builder().build().unwrap();
     assert!(!p2.allows_sysv_ipc());
 
-    let p3 = Sandbox::builder()
+    let err = Sandbox::builder()
         .extra_allow_syscalls(vec!["other_group".into()])
         .build()
+        .unwrap_err();
+    assert!(err.to_string().contains("unknown syscall group"));
+}
+
+#[test]
+fn extra_allow_rejects_individual_syscall_names() {
+    let err = Sandbox::builder()
+        .extra_allow_syscalls(vec!["io_uring_setup".into()])
+        .build()
+        .unwrap_err();
+    assert!(err.to_string().contains("unknown syscall group"));
+}
+
+#[test]
+fn extra_deny_accepts_group_names() {
+    let p = Sandbox::builder()
+        .extra_deny_syscalls(vec!["sysv_ipc".into()])
+        .build()
         .unwrap();
-    assert!(!p3.allows_sysv_ipc());
+    assert_eq!(p.extra_deny_syscalls, vec!["sysv_ipc".to_string()]);
+
+    let err = Sandbox::builder()
+        .extra_deny_syscalls(vec!["not_a_syscall_or_group".into()])
+        .build()
+        .unwrap_err();
+    assert!(err.to_string().contains("unknown syscall or group"));
+}
+
+#[test]
+fn extra_allow_and_deny_of_same_group_conflict() {
+    let err = Sandbox::builder()
+        .extra_allow_syscalls(vec!["sysv_ipc".into()])
+        .extra_deny_syscalls(vec!["sysv_ipc".into()])
+        .build()
+        .unwrap_err();
+    assert!(err.to_string().contains("both allowed and denied"));
+}
+
+#[test]
+fn extra_deny_of_member_syscall_conflicts_with_allowed_group() {
+    let err = Sandbox::builder()
+        .extra_allow_syscalls(vec!["sysv_ipc".into()])
+        .extra_deny_syscalls(vec!["shmget".into()])
+        .build()
+        .unwrap_err();
+    assert!(err.to_string().contains("belongs to allowed group"));
 }
 
 #[test]

--- a/crates/sandlock-core/src/seccomp_plan.rs
+++ b/crates/sandlock-core/src/seccomp_plan.rs
@@ -419,17 +419,24 @@ pub(crate) fn notif_syscalls_resolved(resolved: &ResolvedSandbox) -> Vec<u32> {
 
 /// Resolve `base` syscall names plus policy extras (and SysV IPC syscalls when
 /// `policy.allows_sysv_ipc()` is false) to a deduplicated, ascending list of
-/// numbers for the current architecture.
+/// numbers for the current architecture. Extras naming a syscall group
+/// expand to the group's members.
 ///
 /// A `SysnoSet` accumulates the membership: it dedups inherently (so SysV IPC
 /// folds in with a plain `insert`) and iterates in ascending syscall order.
 /// Names that do not exist on this architecture resolve to nothing and are
 /// skipped, so the result stays arch-correct.
 fn resolve_blocklist(base: &[&str], policy: &Sandbox) -> Vec<u32> {
+    let extra_denies = policy.extra_deny_syscalls.iter().flat_map(|name| {
+        match crate::sys::structs::syscall_group(name) {
+            Some(members) => members.iter().copied().collect::<Vec<_>>(),
+            None => vec![name.as_str()],
+        }
+    });
     let mut set: SysnoSet = base
         .iter()
         .copied()
-        .chain(policy.extra_deny_syscalls.iter().map(String::as_str))
+        .chain(extra_denies)
         .filter_map(|n| n.parse::<Sysno>().ok())
         .collect();
     if !policy.allows_sysv_ipc() {

--- a/crates/sandlock-core/src/sys/structs.rs
+++ b/crates/sandlock-core/src/sys/structs.rs
@@ -288,6 +288,22 @@ pub const SYSV_IPC_BLOCKLIST_SYSCALLS: &[&str] = &[
     "semtimedop",
 ];
 
+/// Named syscall groups shared by `--extra-deny-syscall` and
+/// `--extra-allow-syscall`. Deny accepts a group name (expanded to its
+/// members) or an individual syscall name; allow accepts group names only,
+/// because re-allowing arbitrary single syscalls from the default blocklist
+/// could punch holes in the mediation boundary (e.g. io_uring bypasses
+/// per-syscall seccomp entirely).
+pub const SYSCALL_GROUPS: &[(&str, &[&str])] = &[("sysv_ipc", SYSV_IPC_BLOCKLIST_SYSCALLS)];
+
+/// Look up a syscall group by name.
+pub fn syscall_group(name: &str) -> Option<&'static [&'static str]> {
+    SYSCALL_GROUPS
+        .iter()
+        .find(|(group, _)| *group == name)
+        .map(|(_, members)| *members)
+}
+
 pub const DEFAULT_BLOCKLIST_SYSCALLS: &[&str] = &[
     "mount",
     "umount2",

--- a/docs/sandbox-reference.md
+++ b/docs/sandbox-reference.md
@@ -334,8 +334,8 @@ blocklist is applied unconditionally; the fields below alter it.
 
 | Python                 | TOML          | Type            | Default | Description                                                                          |
 | ---------------------- | ------------- | --------------- | ------- | ------------------------------------------------------------------------------------ |
-| `extra_allow_syscalls` | `extra_allow` | `Sequence[str]` | `()`    | Syscall group names to re-allow (e.g. `"sysv_ipc"`).                                 |
-| `extra_deny_syscalls`  | `extra_deny`  | `Sequence[str]` | `()`    | Additional syscall names to block on top of the default blocklist.                   |
+| `extra_allow_syscalls` | `extra_allow` | `Sequence[str]` | `()`    | Syscall group names to re-allow (groups: `"sysv_ipc"`). Unknown groups and individual syscall names are rejected. |
+| `extra_deny_syscalls`  | `extra_deny`  | `Sequence[str]` | `()`    | Additional syscall or syscall-group names to block on top of the default blocklist. Groups expand to their member syscalls. |
 
 ## `[limits]`
 

--- a/python/README.md
+++ b/python/README.md
@@ -192,8 +192,8 @@ sandbox = Sandbox(
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `extra_deny_syscalls` | `list[str]` | `[]` | Extra syscall names to block in addition to Sandlock defaults |
-| `extra_allow_syscalls` | `list[str]` | `[]` | Syscall groups to allow that are blocked by default (e.g. `"sysv_ipc"` to enable SysV shared memory, semaphores, and message queues) |
+| `extra_deny_syscalls` | `list[str]` | `[]` | Extra syscall or syscall-group names to block in addition to Sandlock defaults (groups expand to their member syscalls) |
+| `extra_allow_syscalls` | `list[str]` | `[]` | Syscall groups to allow that are blocked by default (e.g. `"sysv_ipc"` to enable SysV shared memory, semaphores, and message queues); unknown groups and individual syscall names are rejected |
 
 Sandlock always applies its default syscall blocklist.
 


### PR DESCRIPTION
`--extra-deny-syscall` and `--extra-allow-syscall` treated group names asymmetrically, and the allow side failed silently:

- deny accepted only individual syscall names, so denying SysV IPC took four flags naming each member syscall;
- allow accepted group names but validated nothing: a typo (`--extra-allow-syscall sysvipc`) built a sandbox that silently kept the group blocked, and the existing unit test even asserted that no-op.

Both flags now resolve names through a shared `SYSCALL_GROUPS` table (currently just `sysv_ipc`):

- `--extra-deny-syscall` accepts a syscall name or a group name; groups expand to their member syscalls in `resolve_blocklist`, for both the supervised and no-supervisor blocklists.
- `--extra-allow-syscall` accepts group names only; unknown names are rejected with the known-group list in the error. Individual syscalls stay non-re-allowable on purpose: punching single-syscall holes in the default blocklist can bypass the mediation boundary (io_uring being the canonical example).
- Allow/deny conflicts fail at build time: the same group on both sides, or a deny of a member syscall of an allowed group. The check has to be up front because the BPF layout places notif JEQs before deny JEQs, so an allowed group routing a syscall to notif would silently shadow a kernel-level deny of that same syscall.

Docs updated (sandbox-reference.md, python README). New unit tests cover group expansion in both blocklists, unknown-name rejection on both flags, rejection of individual syscall names on the allow side, and both conflict shapes.
