### PR TITLE
core: stop stealing the tty foreground group from embedding processes

### DIFF
--- a/crates/sandlock-core/src/context.rs
+++ b/crates/sandlock-core/src/context.rs
@@ -239,6 +239,11 @@ pub(crate) struct ChildSpawnArgs<'a> {
     /// parent death in the child without assuming PID 1 is always init
     /// (incorrect in containers where the entrypoint runs as PID 1).
     pub parent_pid: libc::pid_t,
+    /// Make the child the terminal's foreground process group before exec.
+    /// Only interactive (fully inherited) stdio wants this; a captured or
+    /// piped run taking the foreground demotes the embedding process to a
+    /// background job, and its next tty read stops it with SIGTTIN.
+    pub foreground: bool,
 }
 
 /// Set the calling thread/process name (`/proc/<pid>/comm`, shown by `ps`). The
@@ -263,6 +268,7 @@ pub(crate) fn confine_child(args: ChildSpawnArgs<'_>) -> ! {
         sandbox_name,
         extra_syscalls,
         parent_pid,
+        foreground,
     } = args;
     // Helper: abort child on error. Includes the OS error automatically.
     macro_rules! fail {
@@ -280,11 +286,13 @@ pub(crate) fn confine_child(args: ChildSpawnArgs<'_>) -> ! {
         fail!("setpgid");
     }
 
-    // 1b. If stdin is a terminal, become the foreground process group
-    //     so interactive shells can read from the TTY.
+    // 1b. Interactive runs only: if stdin is a terminal, become the
+    //     foreground process group so interactive shells can read from the
+    //     TTY. Captured/piped runs must not: the embedding process keeps
+    //     the terminal (issue #164).
     //     Must ignore SIGTTOU first — a background pgrp calling tcsetpgrp
     //     gets stopped by SIGTTOU otherwise.
-    if unsafe { libc::isatty(0) } == 1 {
+    if foreground && unsafe { libc::isatty(0) } == 1 {
         unsafe {
             libc::signal(libc::SIGTTOU, libc::SIG_IGN);
             libc::tcsetpgrp(0, libc::getpgrp());

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -241,6 +241,14 @@ impl StdioSpec {
     fn inherit() -> Self {
         StdioSpec { stdin: StdioMode::Inherit, stdout: StdioMode::Inherit, stderr: StdioMode::Inherit }
     }
+
+    /// True when every stream inherits, i.e. the run is interactive and the
+    /// child may take the terminal foreground group.
+    fn all_inherit(&self) -> bool {
+        self.stdin == StdioMode::Inherit
+            && self.stdout == StdioMode::Inherit
+            && self.stderr == StdioMode::Inherit
+    }
 }
 
 /// Private runtime state.  Only allocated after `start()` / `run()` is
@@ -1780,6 +1788,7 @@ impl Sandbox {
                 sandbox_name: Some(sandbox_name.as_str()),
                 extra_syscalls: &extra_syscalls,
                 parent_pid,
+                foreground: stdio.all_inherit(),
             });
         }
 

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -285,6 +285,9 @@ struct Runtime {
     on_bind: Option<Box<dyn Fn(&HashMap<u16, u16>) + Send + Sync>>,
     handlers: Vec<(i64, Arc<dyn crate::seccomp::dispatch::Handler>)>,
     ready_w: Option<std::os::fd::OwnedFd>,
+    // The interactive child took the terminal's foreground process group at
+    // spawn; whoever reaps it must hand the foreground back to this process.
+    tty_foreground_taken: bool,
 }
 
 /// Lifecycle state for the runtime.
@@ -833,6 +836,11 @@ impl Sandbox {
         };
 
         self.rt_mut().state = RuntimeState::Stopped(exit_status.clone());
+
+        if self.rt().tty_foreground_taken {
+            sandbox_restore_tty_foreground(pid);
+            self.rt_mut().tty_foreground_taken = false;
+        }
 
         let rt = self.rt_mut();
         if let Some(h) = rt.notif_handle.take() { h.abort(); }
@@ -1410,6 +1418,7 @@ impl Sandbox {
                 on_bind: None,
                 handlers: Vec::new(),
                 ready_w: None,
+                tty_foreground_taken: false,
             }));
             clones.push(clone_sb);
         }
@@ -1506,6 +1515,7 @@ impl Sandbox {
             on_bind: None,
             handlers: Vec::new(),
             ready_w: None,
+            tty_foreground_taken: false,
         }));
         Ok(())
     }
@@ -1710,6 +1720,12 @@ impl Sandbox {
         // without assuming PID 1 is always init (wrong in containers).
         let parent_pid = unsafe { libc::getpid() };
 
+        // Interactive (fully inherited) stdio on a terminal: the child will
+        // take the tty foreground group, and this process must take it back
+        // once the child is reaped.
+        let foreground = stdio.all_inherit();
+        let tty_foreground_taken = foreground && unsafe { libc::isatty(0) } == 1;
+
         let pid = unsafe { libc::fork() };
         if pid < 0 {
             return Err(SandboxRuntimeError::Fork(std::io::Error::last_os_error()).into());
@@ -1788,7 +1804,7 @@ impl Sandbox {
                 sandbox_name: Some(sandbox_name.as_str()),
                 extra_syscalls: &extra_syscalls,
                 parent_pid,
-                foreground: stdio.all_inherit(),
+                foreground,
             });
         }
 
@@ -1801,6 +1817,7 @@ impl Sandbox {
         self.rt_mut()._stderr_read = stderr_p.map(|(r, _w)| r);
 
         self.rt_mut().child_pid = Some(pid);
+        self.rt_mut().tty_foreground_taken = tty_foreground_taken;
         // State remains `Created` until `do_start` writes ready_w to release
         // the child to execve.
 
@@ -2146,6 +2163,27 @@ impl Process<'_> {
     }
 }
 
+/// Hand the terminal's foreground process group back to this process after
+/// reaping an interactive child that took it. Restores only while the child's
+/// group still owns the terminal, so a foreground the caller has since given
+/// to someone else is left alone. SIGTTOU is blocked around `tcsetpgrp`:
+/// this process is a background group at that moment, and an unblocked
+/// SIGTTOU would stop it, which is the exact symptom being prevented.
+fn sandbox_restore_tty_foreground(child_pid: i32) {
+    unsafe {
+        if libc::isatty(0) != 1 || libc::tcgetpgrp(0) != child_pid {
+            return;
+        }
+        let mut block: libc::sigset_t = std::mem::zeroed();
+        libc::sigemptyset(&mut block);
+        libc::sigaddset(&mut block, libc::SIGTTOU);
+        let mut old: libc::sigset_t = std::mem::zeroed();
+        libc::pthread_sigmask(libc::SIG_BLOCK, &block, &mut old);
+        libc::tcsetpgrp(0, libc::getpgrp());
+        libc::pthread_sigmask(libc::SIG_SETMASK, &old, std::ptr::null_mut());
+    }
+}
+
 // ================================================================
 // Drop for Sandbox — kills and reaps child if still running
 // ================================================================
@@ -2158,6 +2196,10 @@ impl Drop for Sandbox {
                     unsafe { libc::killpg(pid, libc::SIGKILL) };
                     let mut status: i32 = 0;
                     unsafe { libc::waitpid(pid, &mut status, 0) };
+                }
+                if rt.tty_foreground_taken {
+                    sandbox_restore_tty_foreground(pid);
+                    rt.tty_foreground_taken = false;
                 }
             }
 

--- a/crates/sandlock-core/tests/integration.rs
+++ b/crates/sandlock-core/tests/integration.rs
@@ -72,3 +72,6 @@ mod test_restore_stub;
 
 #[path = "integration/test_popen.rs"]
 mod test_popen;
+
+#[path = "integration/test_tty.rs"]
+mod test_tty;

--- a/crates/sandlock-core/tests/integration/test_tty.rs
+++ b/crates/sandlock-core/tests/integration/test_tty.rs
@@ -6,6 +6,7 @@ const EXIT_NOT_FOREGROUND_AT_START: i32 = 10;
 const EXIT_RUN_FAILED: i32 = 11;
 const EXIT_FOREGROUND_STOLEN: i32 = 12;
 const EXIT_FOREGROUND_NOT_TAKEN: i32 = 13;
+const EXIT_FOREGROUND_NOT_RESTORED: i32 = 14;
 
 /// Fork a child into a fresh session whose controlling terminal is a new
 /// pty (slave on stdin), then run `f` there and return its exit code.
@@ -107,11 +108,12 @@ fn captured_run_leaves_tty_foreground_with_caller() {
     );
 }
 
-/// Interactive runs hand the terminal to the sandboxed child so shells can
-/// read from the tty. The foreground group observed after the run is the
-/// child's, not the caller's.
+/// After an interactive run completes, the terminal foreground group must
+/// be back with the caller. The CLI's parent shell restores itself when the
+/// whole process exits, but an API user embedding an interactive run keeps
+/// living on the same terminal afterward.
 #[test]
-fn interactive_run_hands_tty_foreground_to_child() {
+fn interactive_run_returns_tty_foreground_after_exit() {
     let code = run_in_pty_session(|| {
         let mut policy = test_policy().with_name("tty-interactive");
         let result = block_on(policy.run_interactive(&["true"]));
@@ -119,14 +121,51 @@ fn interactive_run_hands_tty_foreground_to_child() {
             Ok(r) if r.success() => {}
             _ => return EXIT_RUN_FAILED,
         }
-        if unsafe { libc::tcgetpgrp(0) == libc::getpgrp() } {
-            return EXIT_FOREGROUND_NOT_TAKEN;
+        if unsafe { libc::tcgetpgrp(0) != libc::getpgrp() } {
+            return EXIT_FOREGROUND_NOT_RESTORED;
         }
         EXIT_OK
     });
     assert_eq!(
         code, EXIT_OK,
         "helper exit {code} (10=no tty foreground at start, 11=run failed, \
-         13=interactive run did not hand the tty foreground to the child)"
+         14=tty foreground not returned to the caller after the run)"
+    );
+}
+
+/// Interactive runs hand the terminal to the sandboxed child while it is
+/// alive (so shells can read from the tty), and return it to the caller
+/// once the child is reaped, including the kill path.
+#[test]
+fn interactive_run_hands_tty_foreground_to_child_while_alive() {
+    let code = run_in_pty_session(|| {
+        block_on(async {
+            let mut policy = test_policy().with_name("tty-handover");
+            if policy.spawn_interactive(&["sleep", "30"]).await.is_err() {
+                return EXIT_RUN_FAILED;
+            }
+            let child = match policy.pid() {
+                Some(p) => p,
+                None => return EXIT_RUN_FAILED,
+            };
+            if unsafe { libc::tcgetpgrp(0) } != child {
+                return EXIT_FOREGROUND_NOT_TAKEN;
+            }
+            if policy.kill().is_err() {
+                return EXIT_RUN_FAILED;
+            }
+            if policy.wait().await.is_err() {
+                return EXIT_RUN_FAILED;
+            }
+            if unsafe { libc::tcgetpgrp(0) != libc::getpgrp() } {
+                return EXIT_FOREGROUND_NOT_RESTORED;
+            }
+            EXIT_OK
+        })
+    });
+    assert_eq!(
+        code, EXIT_OK,
+        "helper exit {code} (10=no tty foreground at start, 11=spawn/kill/wait failed, \
+         13=child never got the tty foreground, 14=tty foreground not returned after reap)"
     );
 }

--- a/crates/sandlock-core/tests/integration/test_tty.rs
+++ b/crates/sandlock-core/tests/integration/test_tty.rs
@@ -1,0 +1,132 @@
+use sandlock_core::Sandbox;
+
+// Exit codes for the pty-session helper child, so a failure names its cause.
+const EXIT_OK: i32 = 0;
+const EXIT_NOT_FOREGROUND_AT_START: i32 = 10;
+const EXIT_RUN_FAILED: i32 = 11;
+const EXIT_FOREGROUND_STOLEN: i32 = 12;
+const EXIT_FOREGROUND_NOT_TAKEN: i32 = 13;
+
+/// Fork a child into a fresh session whose controlling terminal is a new
+/// pty (slave on stdin), then run `f` there and return its exit code.
+///
+/// The tty-foreground behavior under test only manifests when stdin is the
+/// controlling terminal of the sandbox parent's session: `tcsetpgrp` from
+/// the sandboxed child is a no-op otherwise. The test binary has no
+/// controlling tty of its own to give up, so each test gets one this way.
+fn run_in_pty_session(f: fn() -> i32) -> i32 {
+    let mut master: libc::c_int = -1;
+    let mut slave: libc::c_int = -1;
+    let ret = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(ret, 0, "openpty failed: {}", std::io::Error::last_os_error());
+
+    let pid = unsafe { libc::fork() };
+    assert!(pid >= 0, "fork failed: {}", std::io::Error::last_os_error());
+
+    if pid == 0 {
+        unsafe {
+            libc::close(master);
+            if libc::setsid() < 0 {
+                libc::_exit(100);
+            }
+            if libc::ioctl(slave, libc::TIOCSCTTY, 0) != 0 {
+                libc::_exit(101);
+            }
+            if libc::dup2(slave, 0) < 0 {
+                libc::_exit(102);
+            }
+            if slave != 0 {
+                libc::close(slave);
+            }
+            if libc::tcgetpgrp(0) != libc::getpgrp() {
+                libc::_exit(EXIT_NOT_FOREGROUND_AT_START);
+            }
+            libc::_exit(f());
+        }
+    }
+
+    unsafe { libc::close(slave) };
+    let mut status: i32 = 0;
+    let ret = unsafe { libc::waitpid(pid, &mut status, 0) };
+    // Close the master only after the child exits, so the slave side stays
+    // a live terminal for the whole run.
+    unsafe { libc::close(master) };
+    assert_eq!(ret, pid, "waitpid failed: {}", std::io::Error::last_os_error());
+    assert!(libc::WIFEXITED(status), "helper child did not exit normally: status {status}");
+    libc::WEXITSTATUS(status)
+}
+
+fn test_policy() -> Sandbox {
+    Sandbox::builder()
+        .fs_read("/usr")
+        .fs_read("/lib")
+        .fs_read_if_exists("/lib64")
+        .fs_read("/bin")
+        .fs_read("/etc")
+        .build()
+        .unwrap()
+}
+
+fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(fut)
+}
+
+/// A captured (non-interactive) `run` must leave the terminal's foreground
+/// process group with the caller. Stealing it demotes the caller to a
+/// background job: its next stdin read raises SIGTTIN and a job-control
+/// shell reports it "Stopped" (issue #164, problem 2).
+#[test]
+fn captured_run_leaves_tty_foreground_with_caller() {
+    let code = run_in_pty_session(|| {
+        let result = block_on(test_policy().with_name("tty-captured").run(&["true"]));
+        match result {
+            Ok(r) if r.success() => {}
+            _ => return EXIT_RUN_FAILED,
+        }
+        if unsafe { libc::tcgetpgrp(0) != libc::getpgrp() } {
+            return EXIT_FOREGROUND_STOLEN;
+        }
+        EXIT_OK
+    });
+    assert_eq!(
+        code, EXIT_OK,
+        "helper exit {code} (10=no tty foreground at start, 11=run failed, \
+         12=captured run stole the tty foreground group)"
+    );
+}
+
+/// Interactive runs hand the terminal to the sandboxed child so shells can
+/// read from the tty. The foreground group observed after the run is the
+/// child's, not the caller's.
+#[test]
+fn interactive_run_hands_tty_foreground_to_child() {
+    let code = run_in_pty_session(|| {
+        let mut policy = test_policy().with_name("tty-interactive");
+        let result = block_on(policy.run_interactive(&["true"]));
+        match result {
+            Ok(r) if r.success() => {}
+            _ => return EXIT_RUN_FAILED,
+        }
+        if unsafe { libc::tcgetpgrp(0) == libc::getpgrp() } {
+            return EXIT_FOREGROUND_NOT_TAKEN;
+        }
+        EXIT_OK
+    });
+    assert_eq!(
+        code, EXIT_OK,
+        "helper exit {code} (10=no tty foreground at start, 11=run failed, \
+         13=interactive run did not hand the tty foreground to the child)"
+    );
+}


### PR DESCRIPTION
Fixes the second problem reported in #164 (the first, the empty sandlock list, is addressed by the control-socket work in #153).

## Problem

The confined child made itself the terminal's foreground process group whenever stdin was a tty, regardless of how the sandbox was spawned. For the captured run()/spawn() paths used by the SDKs, this silently demoted the embedding process (a Python REPL in the report) to a background job: its next stdin read raised SIGTTIN and the shell reported it as Stopped, and nothing ever returned the foreground group after the child exited.

Reproduced on main with a pty harness: after Sandbox.run() returns, tcgetpgrp(0) points at the dead sandbox child's group instead of the caller's, on both the success and failure paths.

## Fix (two commits)

1. Captured runs never touch the terminal. The parent threads the stdio intent into the child setup (ChildSpawnArgs.foreground, true only when every stream is inherited), and the tcsetpgrp grab is gated on it.
2. Interactive runs give the terminal back. The runtime records that the child took the foreground; whoever reaps the child (wait() or Drop) restores it to the calling process. The restore only fires while the child's group still owns the terminal, and blocks SIGTTOU around tcsetpgrp since the caller is a background group at that moment. This matters for API users embedding run_interactive(): the CLI's parent shell hides the leak, but an embedding process lives on the same terminal afterward.

## Tests

New integration tests in test_tty.rs run each case inside a fresh session whose controlling terminal is a private pty:

- captured run leaves the tty foreground with the caller (failed with "foreground stolen" before commit 1)
- interactive run returns the foreground after exit (failed before commit 2)
- interactive child owns the foreground while alive, and the caller gets it back after kill() + wait() (also covers the kill path)

Full Rust workspace suite and all 386 Python tests pass. CLI behavior verified end to end: a non-job-control script that runs "sandlock run -i ... -- /bin/true" and then reads stdin gets stopped with a main-built binary and reads normally with this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)