### PR TITLE
Control socket follow-ups: inspect rename, collision hard-fail, API narrowing

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ sandlock run --name web.local --port-remap --net-allow-bind 8080 -r /usr -r /lib
 sandlock ps
 
 # Show effective policy for a running sandbox (JSON or TOML)
-sandlock config api.local
-sandlock config api.local --toml
+sandlock inspect api.local
+sandlock inspect api.local --toml
 
 # Kill a running sandbox by name
 sandlock kill web.local
@@ -770,7 +770,7 @@ NAME                                  PID        UPTIME  CMD
 api.local                           12345            5m  python3 server.py
 web.local                           12346            3m  python3 server.py
 
-$ sandlock config api.local --toml | head -10
+$ sandlock inspect api.local --toml | head -10
 [config]
 http_inject_ca = []
 

--- a/crates/sandlock-cli/src/main.rs
+++ b/crates/sandlock-cli/src/main.rs
@@ -23,7 +23,7 @@ enum Command {
     /// List all running sandboxes
     Ps,
     /// Show effective policy for a running sandbox
-    Config {
+    Inspect {
         /// Sandbox name (as shown by `sandlock ps`)
         name: String,
         /// Output TOML instead of JSON
@@ -285,7 +285,7 @@ async fn main() -> Result<()> {
             }
         }
 
-        Command::Config { name, toml } => {
+        Command::Inspect { name, toml } => {
             if let Err(e) = validate_cli_name(&name) {
                 eprintln!("sandlock: {e}");
                 std::process::exit(1);
@@ -307,16 +307,16 @@ async fn main() -> Result<()> {
                             println!("{}", json_str);
                         }
                     } else {
-                        eprintln!("sandlock: empty config response");
+                        eprintln!("sandlock: empty response from sandbox");
                         std::process::exit(1);
                     }
                 }
                 Ok(resp) => {
-                    eprintln!("sandlock: config error: {}", resp.err.as_deref().unwrap_or("unknown"));
+                    eprintln!("sandlock: inspect error: {}", resp.err.as_deref().unwrap_or("unknown"));
                     std::process::exit(1);
                 }
                 Err(e) => {
-                    eprintln!("sandlock: config failed: {}", e);
+                    eprintln!("sandlock: inspect failed: {}", e);
                     std::process::exit(1);
                 }
             }
@@ -943,7 +943,7 @@ fn parse_branch_action(flag: &str, s: &str) -> Result<BranchAction> {
 // /proc helpers for sandlock ps
 // ============================================================
 
-/// Validate a sandbox name coming from CLI argv (kill/config paths).
+/// Validate a sandbox name coming from CLI argv (kill/inspect paths).
 /// Mirrors `sandbox_validate_name` but returns a plain `Result` so the
 /// CLI can format its own error messages.
 fn validate_cli_name(name: &str) -> Result<(), String> {

--- a/crates/sandlock-cli/tests/cli_test.rs
+++ b/crates/sandlock-cli/tests/cli_test.rs
@@ -538,31 +538,31 @@ fn test_ps_no_sandboxes() {
 }
 
 #[test]
-fn test_config_returns_json_policy() {
+fn test_inspect_returns_json_policy() {
     let name = format!("test-config-cli-{}", std::process::id());
     let mut child = spawn_sandbox(&name);
 
     match wait_for_sandbox(&mut child, &name) {
         Ok(()) => {
             let out = sandlock_bin()
-                .args(["config", &name])
+                .args(["inspect", &name])
                 .output()
-                .expect("sandlock config");
+                .expect("sandlock inspect");
             assert!(
                 out.status.success(),
-                "config should succeed: stderr={}",
+                "inspect should succeed: stderr={}",
                 String::from_utf8_lossy(&out.stderr)
             );
             let stdout = String::from_utf8_lossy(&out.stdout);
             // JSON output should contain the filesystem section.
             assert!(
                 stdout.contains("filesystem"),
-                "config JSON should contain 'filesystem': {}",
+                "inspect JSON should contain 'filesystem': {}",
                 stdout
             );
             assert!(
                 stdout.contains("/usr"),
-                "config JSON should contain /usr in read list: {}",
+                "inspect JSON should contain /usr in read list: {}",
                 stdout
             );
         }
@@ -577,31 +577,31 @@ fn test_config_returns_json_policy() {
 }
 
 #[test]
-fn test_config_toml_flag_produces_toml() {
+fn test_inspect_toml_flag_produces_toml() {
     let name = format!("test-config-toml-cli-{}", std::process::id());
     let mut child = spawn_sandbox(&name);
 
     match wait_for_sandbox(&mut child, &name) {
         Ok(()) => {
             let out = sandlock_bin()
-                .args(["config", "--toml", &name])
+                .args(["inspect", "--toml", &name])
                 .output()
-                .expect("sandlock config --toml");
+                .expect("sandlock inspect --toml");
             assert!(
                 out.status.success(),
-                "config --toml should succeed: stderr={}",
+                "inspect --toml should succeed: stderr={}",
                 String::from_utf8_lossy(&out.stderr)
             );
             let stdout = String::from_utf8_lossy(&out.stdout);
             // TOML output should have section headers.
             assert!(
                 stdout.contains("[filesystem]"),
-                "config --toml should contain [filesystem]: {}",
+                "inspect --toml should contain [filesystem]: {}",
                 stdout
             );
             assert!(
                 stdout.contains("/usr"),
-                "config --toml should contain /usr: {}",
+                "inspect --toml should contain /usr: {}",
                 stdout
             );
         }
@@ -616,12 +616,12 @@ fn test_config_toml_flag_produces_toml() {
 }
 
 #[test]
-fn test_config_nonexistent_sandbox() {
+fn test_inspect_nonexistent_sandbox() {
     let out = sandlock_bin()
-        .args(["config", "nonexistent-sandbox-xyz-99999"])
+        .args(["inspect", "nonexistent-sandbox-xyz-99999"])
         .output()
-        .expect("sandlock config");
-    assert!(!out.status.success(), "config for nonexistent sandbox should fail");
+        .expect("sandlock inspect");
+    assert!(!out.status.success(), "inspect for nonexistent sandbox should fail");
 }
 
 #[test]
@@ -669,14 +669,14 @@ fn test_kill_nonexistent_sandbox() {
 }
 
 #[test]
-fn test_help_shows_ps_and_config() {
+fn test_help_shows_ps_and_inspect() {
     let out = sandlock_bin()
         .args(["--help"])
         .output()
         .expect("sandlock --help");
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("ps"), "--help should show 'ps' command");
-    assert!(stdout.contains("config"), "--help should show 'config' command");
+    assert!(stdout.contains("inspect"), "--help should show 'inspect' command");
     assert!(stdout.contains("kill"), "--help should show 'kill' command");
     // The old 'list' command should be gone.
     assert!(

--- a/crates/sandlock-core/src/control.rs
+++ b/crates/sandlock-core/src/control.rs
@@ -42,7 +42,7 @@ use crate::seccomp::ctx::SupervisorCtx;
 // ============================================================
 
 /// Return the per-user runtime directory root.
-pub fn runtime_dir_uid(uid: u32) -> PathBuf {
+pub(crate) fn runtime_dir_uid(uid: u32) -> PathBuf {
     PathBuf::from(format!("/dev/shm/sandlock-{}", uid))
 }
 
@@ -90,7 +90,7 @@ fn read_supervisor_pid(dir: &Path) -> Option<i32> {
 /// socket) instead of duplicating a bare `remove_dir_all` + `create_dir_all`
 /// that had no liveness check and would wipe a live sandbox's pid file on a
 /// name collision.
-pub fn setup_runtime_dir(
+pub(crate) fn setup_runtime_dir(
     name: &str,
     child_pid: i32,
     supervisor_pid: i32,
@@ -114,7 +114,7 @@ pub fn setup_runtime_dir(
 /// binding a control socket.  Used by the `no_supervisor` path (no socket
 /// exists) and as the common prefix of `setup_runtime_dir` for the supervisor
 /// path.
-pub fn setup_runtime_dir_no_socket(
+pub(crate) fn setup_runtime_dir_no_socket(
     name: &str,
     child_pid: i32,
     supervisor_pid: i32,
@@ -180,7 +180,7 @@ pub fn cleanup_runtime_dir(dir: &Path) {
 /// Takes ownership of `sandbox` (moved into the task) so the config snapshot
 /// lives for the lifetime of the control loop.  The sandbox clone has
 /// `init_fn = None` (FnOnce can't be cloned), so the value is `Send`.
-pub fn spawn_control_loop(
+pub(crate) fn spawn_control_loop(
     listener: UnixListener,
     ctx: Arc<SupervisorCtx>,
     sandbox: Sandbox,

--- a/crates/sandlock-core/src/lib.rs
+++ b/crates/sandlock-core/src/lib.rs
@@ -52,10 +52,10 @@ pub use recovery::{list_preserved, read_preserved, PreserveReason, PreservedBran
 pub use dry_run::{Change, ChangeKind, DryRunResult};
 // Sectioned-profile parsing types: ProfileInput is the top-level deserialization
 // target; ProgramSpec carries [program].exec/args (not a Sandbox field).
-pub use crate::profile::{
-    ProfileInput, ProgramSpec, format_net_rule, format_http_rule,
-    sandbox_to_profile, sandbox_to_toml, sandbox_to_json,
-};
+// format_net_rule renders a NetRule back into the --net-allow/--net-deny
+// grammar (the CLI round-trips profiles through it); the other reverse
+// serializers live unre-exported in `profile`.
+pub use crate::profile::{ProfileInput, ProgramSpec, format_net_rule};
 
 // Public extension API — see docs/extension-handlers.md.
 pub use seccomp::dispatch::{Handler, HandlerCtx, HandlerError};

--- a/crates/sandlock-core/src/profile.rs
+++ b/crates/sandlock-core/src/profile.rs
@@ -433,7 +433,7 @@ fn time_start_str(t: SystemTime) -> Option<String> {
 ///
 /// This is the reverse of `parse_input`: it flattens the `Sandbox` dataclass
 /// back into the sectioned profile shape so it can be serialized to JSON (the
-/// control-socket `config` verb) or TOML (`sandlock config <name> --toml`).
+/// control-socket `config` verb) or TOML (`sandlock inspect <name> --toml`).
 ///
 /// Runtime-only kwargs (`policy_fn`, `init_fn`, `work_fn`) are not `Sandbox`
 /// fields and so do not appear; the `config` handler emits a `"<callback>"`

--- a/crates/sandlock-core/src/profile.rs
+++ b/crates/sandlock-core/src/profile.rs
@@ -392,7 +392,7 @@ pub fn format_net_rule(rule: &crate::sandbox::NetRule) -> String {
 }
 
 /// Render an `HttpRule` back into `"METHOD host/path"` form.
-pub fn format_http_rule(rule: &crate::http::HttpRule) -> String {
+pub(crate) fn format_http_rule(rule: &crate::http::HttpRule) -> String {
     format!("{} {}{}", rule.method, rule.host, rule.path)
 }
 

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -1923,6 +1923,14 @@ impl Sandbox {
         // State remains `Created` until `do_start` writes ready_w to release
         // the child to execve.
 
+        let pidfd = match syscall::pidfd_open(pid as u32, 0) {
+            Ok(fd) => Some(fd),
+            Err(_) => None,
+        };
+
+        let notif_fd_num = read_u32_fd(pipes.notif_r.as_raw_fd())
+            .map_err(|e| SandboxRuntimeError::Child(format!("read notif fd from child: {}", e)))?;
+
         // Even for --no-supervisor sandboxes, write a pid file so sandlock ps
         // can discover and list them.  The control socket is only created when
         // a supervisor exists (inside the if-let below).  Honour the
@@ -1932,6 +1940,13 @@ impl Sandbox {
         // no-supervisor sandbox with the same name as a live sandbox must
         // refuse to start rather than unconditionally remove_dir_all the
         // live one's pid file.
+        //
+        // This must stay after the notif-fd read above.  Any error return
+        // from do_spawn relies on Drop's killpg to reap the child, which
+        // only works once the child has setpgid'd into its own group; the
+        // notif-fd write is the child's setup-complete signal, so returning
+        // before it races killpg against setpgid and can deadlock Drop's
+        // waitpid against a child parked on the ready pipe.
         if no_supervisor && self.control_socket {
             let sandbox_name = self.rt().name.clone();
             let supervisor_pid = std::process::id() as i32;
@@ -1943,6 +1958,16 @@ impl Sandbox {
                 Ok(dir) => {
                     self.rt_mut().control_dir = Some(dir);
                 }
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    // Name collision with a live sandbox — hard-fail, same as
+                    // the supervisor path.  Continuing would leave a second
+                    // sandbox running invisible to ps.
+                    return Err(SandboxRuntimeError::Child(format!(
+                        "sandbox '{}' is already running: {}",
+                        sandbox_name, e
+                    ))
+                    .into());
+                }
                 Err(e) => {
                     eprintln!(
                         "sandlock: runtime dir setup failed for '{}': {}",
@@ -1951,14 +1976,6 @@ impl Sandbox {
                 }
             }
         }
-
-        let pidfd = match syscall::pidfd_open(pid as u32, 0) {
-            Ok(fd) => Some(fd),
-            Err(_) => None,
-        };
-
-        let notif_fd_num = read_u32_fd(pipes.notif_r.as_raw_fd())
-            .map_err(|e| SandboxRuntimeError::Child(format!("read notif fd from child: {}", e)))?;
 
         let is_nested_mode = notif_fd_num == 0;
 

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -505,7 +505,7 @@ pub struct Sandbox {
     pub no_supervisor: bool,
 
     /// Enable the per-sandbox control socket for introspection (`sandlock ps`,
-    /// `sandlock config`, etc.). Defaults to `true`. Set to `false` to skip
+    /// `sandlock inspect`, etc.). Defaults to `true`. Set to `false` to skip
     /// the runtime dir, pid file, and control-socket tokio task entirely.
     #[serde(skip, default = "default_control_socket")]
     pub control_socket: bool,

--- a/crates/sandlock-core/src/sandbox/builder.rs
+++ b/crates/sandlock-core/src/sandbox/builder.rs
@@ -195,7 +195,7 @@ pub struct SandboxBuilder {
 
     /// Enable the per-sandbox control socket for introspection. Defaults to
     /// `true`. When `false`, no runtime dir, pid file, or control-socket task
-    /// is created — `sandlock ps` and `sandlock config` will not see this
+    /// is created — `sandlock ps` and `sandlock inspect` will not see this
     /// sandbox.
     #[cfg_attr(feature = "cli", clap(skip))]
     pub control_socket: bool,
@@ -679,7 +679,7 @@ impl SandboxBuilder {
 
     /// Enable or disable the per-sandbox control socket. Defaults to `true`.
     /// When `false`, no runtime dir, pid file, or control-socket task is
-    /// created — `sandlock ps` and `sandlock config` will not see this
+    /// created — `sandlock ps` and `sandlock inspect` will not see this
     /// sandbox.
     pub fn control_socket(mut self, v: bool) -> Self {
         self.control_socket = v;

--- a/crates/sandlock-core/tests/integration/test_control.rs
+++ b/crates/sandlock-core/tests/integration/test_control.rs
@@ -371,6 +371,47 @@ fn test_control_name_collision() {
 }
 
 #[test]
+fn test_control_name_collision_no_supervisor() {
+    // The no_supervisor path shares setup_runtime_dir_no_socket and must
+    // hard-fail on a live-name collision just like the supervisor path;
+    // continuing would leave a second sandbox running invisible to ps.
+    let name = format!("test-ctrl-collision-nosup-{}", std::process::id());
+    let mut first = start_sleep_sandbox(&name);
+
+    match wait_for_sandbox(&name) {
+        Ok(()) => {
+            let out = sandlock_bin()
+                .args([
+                    "run", "--name", &name, "--no-supervisor",
+                    "-r", "/usr", "-r", "/bin", "-r", "/etc",
+                    "-r", "/proc", "-r", "/dev",
+                    "--", "/bin/sleep", "5",
+                ])
+                .output()
+                .expect("sandlock run --no-supervisor (collision)");
+            assert!(
+                !out.status.success(),
+                "no_supervisor sandbox with a live name must fail"
+            );
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            assert!(
+                stderr.contains("already running"),
+                "error should indicate name collision: {}",
+                stderr
+            );
+        }
+        Err(e) => {
+            let stderr_output = child_stderr(&mut first);
+            let _ = first.kill();
+            panic!("{}; child stderr: {}", e, stderr_output);
+        }
+    }
+
+    let _ = first.kill();
+    let _ = first.wait();
+}
+
+#[test]
 fn test_control_no_supervisor() {
     let name = format!("test-ctrl-nosup-{}", std::process::id());
     let has_lib64 = std::path::Path::new("/lib64").exists();

--- a/crates/sandlock-core/tests/integration/test_control.rs
+++ b/crates/sandlock-core/tests/integration/test_control.rs
@@ -117,30 +117,30 @@ fn test_control_list_sandboxes_via_cli() {
 }
 
 #[test]
-fn test_control_config_returns_policy_via_cli() {
+fn test_control_inspect_returns_policy_via_cli() {
     let name = format!("test-ctrl-config-{}", std::process::id());
     let mut child = start_sleep_sandbox(&name);
 
     match wait_for_sandbox(&name) {
         Ok(()) => {
             let out = sandlock_bin()
-                .args(["config", &name])
+                .args(["inspect", &name])
                 .output()
-                .expect("sandlock config");
+                .expect("sandlock inspect");
             assert!(
                 out.status.success(),
-                "config should succeed: stderr={}",
+                "inspect should succeed: stderr={}",
                 String::from_utf8_lossy(&out.stderr)
             );
             let stdout = String::from_utf8_lossy(&out.stdout);
             assert!(
                 stdout.contains("filesystem"),
-                "config JSON should contain 'filesystem': {}",
+                "inspect JSON should contain 'filesystem': {}",
                 stdout
             );
             assert!(
                 stdout.contains("/usr"),
-                "config JSON should contain /usr: {}",
+                "inspect JSON should contain /usr: {}",
                 stdout
             );
         }
@@ -156,12 +156,12 @@ fn test_control_config_returns_policy_via_cli() {
 }
 
 #[test]
-fn test_control_config_nonexistent_sandbox() {
+fn test_control_inspect_nonexistent_sandbox() {
     let out = sandlock_bin()
-        .args(["config", "nonexistent-sandbox-xyz-99999"])
+        .args(["inspect", "nonexistent-sandbox-xyz-99999"])
         .output()
-        .expect("sandlock config");
-    assert!(!out.status.success(), "config for nonexistent sandbox should fail");
+        .expect("sandlock inspect");
+    assert!(!out.status.success(), "inspect for nonexistent sandbox should fail");
 }
 
 #[test]
@@ -578,20 +578,20 @@ fn test_control_cli_kill_rejects_bad_names() {
 }
 
 #[test]
-fn test_control_cli_config_rejects_bad_names() {
+fn test_control_cli_inspect_rejects_bad_names() {
     for bad in &["..", ".", "a/b"] {
         let out = sandlock_bin()
-            .args(["config", bad])
+            .args(["inspect", bad])
             .output()
-            .expect("sandlock config");
+            .expect("sandlock inspect");
         assert!(
             !out.status.success(),
-            "sandlock config {:?} should fail", bad
+            "sandlock inspect {:?} should fail", bad
         );
         let stderr = String::from_utf8_lossy(&out.stderr);
         assert!(
             stderr.contains("must not"),
-            "config {:?} should produce a validation error, got: {}",
+            "inspect {:?} should produce a validation error, got: {}",
             bad, stderr
         );
     }

--- a/crates/sandlock-core/tests/integration/test_control.rs
+++ b/crates/sandlock-core/tests/integration/test_control.rs
@@ -662,13 +662,7 @@ fn test_control_cli_kill_nonexistent() {
 
 #[test]
 fn test_control_single_line_pid_file_is_pruned() {
-    let uid = unsafe { libc::getuid() };
-    let root = sandlock_core::control::runtime_dir_uid(uid);
-    if !root.exists() {
-        std::fs::create_dir_all(&root).expect("create sandlock root");
-    }
-
-    let dir = root.join("test-single-line-pid");
+    let dir = sandlock_core::control::sandbox_dir("test-single-line-pid");
     std::fs::create_dir_all(&dir).expect("create test dir");
 
     // Write a pid file with only one line — the format that never shipped.

--- a/docs/sandbox-reference.md
+++ b/docs/sandbox-reference.md
@@ -366,7 +366,7 @@ and have no TOML counterpart.
 | `policy_fn` | `Callable \| None`| `None`  | Per-event dynamic policy callback. See the project README's "Dynamic Policy" section.                      |
 | `init_fn`   | `Callable \| None`| `None`  | Callback invoked once in the template process prior to COW fork.                                           |
 | `work_fn`   | `Callable \| None`| `None`  | Callback invoked in each COW clone; receives `clone_id` as its argument.                                   |
-| `control_socket` | `bool`        | `True`  | Enable the per-sandbox control socket for introspection (`sandlock ps`, `sandlock config`). When `False`, no runtime dir, pid file, or control-socket task is created — the sandbox is invisible to `sandlock ps` / `sandlock config`. `no_supervisor` sandboxes only create a control socket when `control_socket=True`. |
+| `control_socket` | `bool`        | `True`  | Enable the per-sandbox control socket for introspection (`sandlock ps`, `sandlock inspect`). When `False`, no runtime dir, pid file, or control-socket task is created: the sandbox is invisible to `sandlock ps` / `sandlock inspect`. `no_supervisor` sandboxes only create a control socket when `control_socket=True`. |
 
 ## Advanced
 


### PR DESCRIPTION
Follow-ups to #153 from its final review round.

## Changes

### `sandlock config` renamed to `sandlock inspect`

"config" universally reads as get/set of the tool's own configuration (git config, npm config) and collides conceptually with sandlock's profile management, while the container ecosystem convention for "show me everything about this running instance" is "inspect" (docker, podman). The new name also leaves room to later include runtime state (ports, uptime, pids) alongside policy. Hard break with no alias, done now while pre-1.0 makes it cheap. The control-socket wire verb stays `config` since it specifically fetches the effective policy.

### `no_supervisor` spawn hard-fails on a live name collision

The `no_supervisor` path warned and continued on `AlreadyExists`, leaving a second sandbox running invisible to `sandlock ps`, which is exactly the outcome the supervisor path already hard-fails to prevent. It now mirrors that arm; other runtime-dir errors (e.g. restricted `/dev/shm` in nested sandboxes) still warn and continue.

The runtime-dir setup also moves after the notif-fd read. An error return from `do_spawn` relies on `Drop`'s `killpg` to reap the forked child, which only works once the child has `setpgid`'d into its own group; the notif-fd write is the child's setup-complete signal. Returning before it races `killpg` against `setpgid`: `killpg` loses with ESRCH, and `Drop` then deadlocks its blocking `waitpid` against a child parked on the ready pipe whose write end `Drop` itself still holds. Found the hard way: the first version of this fix returned inside that window and hung reliably. A comment now pins the invariant, and `test_control_name_collision_no_supervisor` covers the path.

### `control` API narrowed to its external consumers

Everything in the control module was public, but `setup_runtime_dir`, `setup_runtime_dir_no_socket`, and `spawn_control_loop` are lifecycle plumbing only `sandbox.rs` may call; invoking them from outside would corrupt live sandbox state. They and `runtime_dir_uid` are now `pub(crate)`. What stays public each has a real consumer: the client API (`list_live_sandboxes`, `send_control_request`, `ControlResponse`), the on-disk layout helpers (`sandbox_dir`, `pid_path`, `sock_path`), and `cleanup_runtime_dir` (needed by `sandlock kill` because SIGKILL skips the supervisor's `Drop`). The crate root now re-exports only `format_net_rule` from the profile module; the reverse serializers stay reachable under `profile::` and `format_http_rule` becomes `pub(crate)`.

## Test plan

- Control integration tests: 21/21 pass (includes the new collision test, which deadlocked before the ordering fix)
- CLI integration tests: 31/31 pass
- Full release workspace build clean (covers sandlock-oci and sandlock-ffi consumers)