### PR TITLE
Make learning sandboxes visible and clean up inspect output

### DIFF
--- a/crates/sandlock-cli/src/learn.rs
+++ b/crates/sandlock-cli/src/learn.rs
@@ -512,8 +512,8 @@ pub async fn run(args: LearnArgs) -> Result<()> {
         // the real filesystem's perspective.
         .on_exit(BranchAction::Abort)
         .on_error(BranchAction::Abort)
+        // A scheme-less "*" covers TCP and UDP; ICMP always needs its own rule.
         .net_allow("*")
-        .net_allow("udp://*")
         .net_allow("icmp://*")
         .max_memory(sandlock_core::sandbox::ByteSize(1 << 43)) // 8 TiB
         .policy_fn(move |event, _ctx| observer_cb.on_event(event))

--- a/crates/sandlock-cli/src/learn.rs
+++ b/crates/sandlock-cli/src/learn.rs
@@ -500,6 +500,12 @@ pub async fn run(args: LearnArgs) -> Result<()> {
     let observer = LearnObserver::new();
     let observer_cb = observer.clone();
     let policy = Sandbox::builder()
+        // Name + mode mark this as a learning sandbox in `sandlock ps`: the
+        // observation policy below (read "/", allow-all network) would
+        // otherwise look like a dangerously permissive run. One learn
+        // sandbox per CLI process, so the pid keeps names unique.
+        .name(format!("learn-{}", std::process::id()))
+        .mode("learn")
         .fs_read("/")
         .workdir("/")
         // Discard all COW changes after observation; learn is read-only from
@@ -518,8 +524,6 @@ pub async fn run(args: LearnArgs) -> Result<()> {
 
     // Use the three-step lifecycle (create/start/wait) so we can get the child
     // PID from sandbox.pid() and sample /proc/<pid> for resource peaks.
-    // No explicit name: the auto-generated sandbox-<pid>-<counter> is unique,
-    // so concurrent learn invocations never collide on the runtime dir.
     let mut sandbox = policy;
     sandbox.create_interactive(&cmd_refs).await
         .map_err(|e| anyhow!("sandbox error: {e}"))?;

--- a/crates/sandlock-cli/src/main.rs
+++ b/crates/sandlock-cli/src/main.rs
@@ -265,16 +265,18 @@ async fn main() -> Result<()> {
                 }
                 Ok(sandboxes) => {
                     println!(
-                        "{:<32} {:>8}  {:>12}  {:<24}  {}",
-                        "NAME", "PID", "UPTIME", "PORTS", "CMD"
+                        "{:<32} {:>8}  {:>12}  {:<10}  {:<24}  {}",
+                        "NAME", "PID", "UPTIME", "STATUS", "PORTS", "CMD"
                     );
                     for (name, pid) in &sandboxes {
                         let uptime = proc_uptime(*pid).unwrap_or_else(|| "?".to_string());
                         let cmd = proc_cmdline(*pid).unwrap_or_else(|| "?".to_string());
                         let ports = query_ports(name);
+                        let status = sandlock_core::control::sandbox_mode(name)
+                            .unwrap_or_else(|| "running".to_string());
                         println!(
-                            "{:<32} {:>8}  {:>12}  {:<24}  {}",
-                            name, pid, uptime, ports, cmd
+                            "{:<32} {:>8}  {:>12}  {:<10}  {:<24}  {}",
+                            name, pid, uptime, status, ports, cmd
                         );
                     }
                 }

--- a/crates/sandlock-core/src/control.rs
+++ b/crates/sandlock-core/src/control.rs
@@ -62,6 +62,14 @@ pub fn sock_path(dir: &Path) -> PathBuf {
     dir.join("control.sock")
 }
 
+/// Read a sandbox's operating-mode marker (e.g. "learn") from its runtime
+/// dir. `None` for ordinary runs, which write no mode file.
+pub fn sandbox_mode(name: &str) -> Option<String> {
+    let s = std::fs::read_to_string(sandbox_dir(name).join("mode")).ok()?;
+    let s = s.trim();
+    if s.is_empty() { None } else { Some(s.to_string()) }
+}
+
 /// Read the supervisor PID from a runtime dir's pid file.
 /// Returns `None` if the file is missing, unparseable, or does not
 /// contain two lines (child_pid\nsupervisor_pid\n).
@@ -94,8 +102,9 @@ pub(crate) fn setup_runtime_dir(
     name: &str,
     child_pid: i32,
     supervisor_pid: i32,
+    mode: Option<&str>,
 ) -> Result<(UnixListener, PathBuf), std::io::Error> {
-    let dir = setup_runtime_dir_no_socket(name, child_pid, supervisor_pid)?;
+    let dir = setup_runtime_dir_no_socket(name, child_pid, supervisor_pid, mode)?;
 
     // Bind control socket.
     let sp = sock_path(&dir);
@@ -118,6 +127,7 @@ pub(crate) fn setup_runtime_dir_no_socket(
     name: &str,
     child_pid: i32,
     supervisor_pid: i32,
+    mode: Option<&str>,
 ) -> Result<PathBuf, std::io::Error> {
     let dir = sandbox_dir(name);
 
@@ -146,6 +156,12 @@ pub(crate) fn setup_runtime_dir_no_socket(
 
     // Write pid file atomically via temp + rename so list_live_sandboxes
     // never sees a partially-written or empty pid file.
+    // Operating-mode marker for the `sandlock ps` STATUS column. Written
+    // before the pid file so a listing never sees the sandbox without it.
+    if let Some(m) = mode {
+        std::fs::write(dir.join("mode"), m)?;
+    }
+
     let pid_path = pid_path(&dir);
     let tmp_path = dir.join(".pid.tmp");
     std::fs::write(&tmp_path, format!("{}\n{}\n", child_pid, supervisor_pid))?;
@@ -633,6 +649,21 @@ mod tests {
         let dir = sandbox_dir("test-sandbox");
         assert!(dir.to_string_lossy().contains("test-sandbox"));
         assert!(dir.to_string_lossy().contains("sandlock-"));
+    }
+
+    #[test]
+    fn test_runtime_dir_mode_file_roundtrip() {
+        // Unique name: sandbox names are uid-wide, never reuse a fixed one.
+        let name = format!("test-mode-{}", std::process::id());
+        let pid = std::process::id() as i32;
+
+        let dir = setup_runtime_dir_no_socket(&name, pid, pid, Some("learn")).unwrap();
+        assert_eq!(sandbox_mode(&name).as_deref(), Some("learn"));
+        cleanup_runtime_dir(&dir);
+
+        let dir = setup_runtime_dir_no_socket(&name, pid, pid, None).unwrap();
+        assert_eq!(sandbox_mode(&name), None);
+        cleanup_runtime_dir(&dir);
     }
 
     #[test]

--- a/crates/sandlock-core/src/profile.rs
+++ b/crates/sandlock-core/src/profile.rs
@@ -441,6 +441,12 @@ fn time_start_str(t: SystemTime) -> Option<String> {
 ///
 /// `extra_denied` carries dynamic `policy_fn`-issued `deny_path()` calls so
 /// the effective policy reflects runtime mutations (RFC acceptance criterion).
+/// Collect rendered rule specs, dropping duplicates while preserving order.
+fn dedup_rendered(rules: impl Iterator<Item = String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    rules.filter(|r| seen.insert(r.clone())).collect()
+}
+
 pub fn sandbox_to_profile(s: &Sandbox, extra_denied: &[String]) -> ProfileInput {
     let mut mount_specs: Vec<String> = Vec::new();
     for (virt, host) in &s.fs_mount {
@@ -462,8 +468,11 @@ pub fn sandbox_to_profile(s: &Sandbox, extra_denied: &[String]) -> ProfileInput 
         }
     }
 
-    let net_allow: Vec<String> = s.net_allow.iter().map(format_net_rule).collect();
-    let net_deny: Vec<String> = s.net_deny.iter().map(format_net_rule).collect();
+    // Distinct rules can render to the same spec: a scheme-less "*" expands
+    // to a tcp://* + udp://* pair at parse time, so an explicit udp://* rule
+    // next to it repeats the rendered form. List each spec once.
+    let net_allow = dedup_rendered(s.net_allow.iter().map(format_net_rule));
+    let net_deny = dedup_rendered(s.net_deny.iter().map(format_net_rule));
     let http_allow: Vec<String> = s.http_allow.iter().map(format_http_rule).collect();
     let http_deny: Vec<String> = s.http_deny.iter().map(format_http_rule).collect();
 

--- a/crates/sandlock-core/src/profile.rs
+++ b/crates/sandlock-core/src/profile.rs
@@ -503,7 +503,11 @@ pub fn sandbox_to_profile(s: &Sandbox, extra_denied: &[String]) -> ProfileInput 
             no_huge_pages: s.no_huge_pages,
         },
         filesystem: FilesystemSection {
-            read: s.fs_readable.clone(),
+            // The COW upper dir grant is spawn-time plumbing, not user policy.
+            read: s.fs_readable.iter()
+                .filter(|p| Some(p.as_path()) != s.cow_upper.as_deref())
+                .cloned()
+                .collect(),
             write: s.fs_writable.clone(),
             deny: fs_deny,
             chroot: s.chroot.clone(),
@@ -615,6 +619,24 @@ pub fn list_profiles() -> Result<Vec<String>, SandlockError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sandbox_to_profile_hides_cow_upper_grant() {
+        // Simulate the spawn-time upper grant: pushed into fs_readable with
+        // cow_upper recording which entry is internal.
+        let mut sb = crate::Sandbox::builder().fs_read("/usr").build().unwrap();
+        let upper = PathBuf::from("/run/user/1000/sandlock-cow/deadbeef/upper");
+        sb.fs_readable.push(upper.clone());
+        sb.cow_upper = Some(upper.clone());
+
+        let profile = sandbox_to_profile(&sb, &[]);
+        assert!(profile.filesystem.read.contains(&PathBuf::from("/usr")));
+        assert!(
+            !profile.filesystem.read.contains(&upper),
+            "internal COW upper grant leaked into profile: {:?}",
+            profile.filesystem.read
+        );
+    }
 
     #[test]
     fn list_profiles_empty_dir() {

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -533,6 +533,14 @@ pub struct Sandbox {
     #[serde(skip)]
     pub name: Option<String>,
 
+    /// Operating-mode marker (e.g. "learn") written to the runtime dir at
+    /// spawn time and shown as STATUS by `sandlock ps`, so an operator sees
+    /// why a sandbox exists (learn's read-everything observation run would
+    /// otherwise be indistinguishable from a dangerously permissive one).
+    /// Instance metadata like `name`, not policy — never serialized.
+    #[serde(skip)]
+    pub mode: Option<String>,
+
     // COW fork init function — runs once in the child before COW cloning.
     // Not serialized; not cloned (FnOnce can't be cloned — drops to None on clone).
     #[serde(skip)]
@@ -630,6 +638,7 @@ impl Clone for Sandbox {
             user: self.user,
             policy_fn: self.policy_fn.clone(),
             name: self.name.clone(),
+            mode: self.mode.clone(),
             // init_fn (FnOnce) cannot be cloned — the clone gets None.
             // If the clone also needs an init function, set it explicitly.
             init_fn: None,
@@ -1973,6 +1982,7 @@ impl Sandbox {
                 &sandbox_name,
                 pid,
                 supervisor_pid,
+                self.mode.as_deref(),
             ) {
                 Ok(dir) => {
                     self.rt_mut().control_dir = Some(dir);
@@ -2032,6 +2042,7 @@ impl Sandbox {
                     &sandbox_name,
                     pid,
                     supervisor_pid,
+                    self.mode.as_deref(),
                 ) {
                     Ok((listener, control_dir)) => {
                         self.rt_mut().control_dir = Some(control_dir);

--- a/crates/sandlock-core/src/sandbox.rs
+++ b/crates/sandlock-core/src/sandbox.rs
@@ -470,6 +470,13 @@ pub struct Sandbox {
     pub no_coredump: bool,
     pub deterministic_dirs: bool,
 
+    /// The COW upper dir granted read+exec at spawn time so Landlock can
+    /// execute binaries the workload creates in the workdir. An internal
+    /// grant, not user policy: recorded here so `sandbox_to_profile` can
+    /// keep it out of inspect output. Spawn-time state, not serialized.
+    #[serde(skip)]
+    pub(crate) cow_upper: Option<PathBuf>,
+
     // Filesystem branch
     pub workdir: Option<PathBuf>,
     pub cwd: Option<PathBuf>,
@@ -617,6 +624,9 @@ impl Clone for Sandbox {
             no_huge_pages: self.no_huge_pages,
             no_coredump: self.no_coredump,
             deterministic_dirs: self.deterministic_dirs,
+            // Cloned for the control-loop snapshot, which is taken after the
+            // spawn-time upper grant lands in fs_readable.
+            cow_upper: self.cow_upper.clone(),
             workdir: self.workdir.clone(),
             cwd: self.cwd.clone(),
             fs_storage: self.fs_storage.clone(),
@@ -1785,6 +1795,7 @@ impl Sandbox {
         let shared_cow = self.rt().shared_cow.clone();
         let seccomp_cow_branch = if let Some(ref shared) = shared_cow {
             self.fs_readable.push(shared.upper_dir.clone());
+            self.cow_upper = Some(shared.upper_dir.clone());
             None
         } else if !no_supervisor && self.workdir.is_some() {
             let workdir = self.workdir.as_ref().unwrap().clone();
@@ -1806,6 +1817,7 @@ impl Sandbox {
                         self.on_exit == BranchAction::Keep || self.on_error == BranchAction::Keep,
                     );
                     self.fs_readable.push(branch.upper_dir().to_path_buf());
+                    self.cow_upper = Some(branch.upper_dir().to_path_buf());
                     Some(branch)
                 }
                 Err(e) => {

--- a/crates/sandlock-core/src/sandbox/builder.rs
+++ b/crates/sandlock-core/src/sandbox/builder.rs
@@ -221,6 +221,12 @@ pub struct SandboxBuilder {
     #[cfg_attr(feature = "cli", clap(skip))]
     pub name: Option<String>,
 
+    // Operating-mode marker (e.g. "learn") shown as STATUS by `sandlock ps`:
+    // gives operators context for otherwise alarming sandboxes like learn's
+    // read-everything observation run.
+    #[cfg_attr(feature = "cli", clap(skip))]
+    pub mode: Option<String>,
+
     // COW fork init function: runs once in the child before COW cloning.
     #[cfg_attr(feature = "cli", clap(skip))]
     pub(crate) init_fn: Option<Box<dyn FnOnce() + Send + 'static>>,
@@ -294,6 +300,7 @@ impl Default for SandboxBuilder {
             protection_policy: ProtectionPolicy::default(),
             policy_fn: None,
             name: None,
+            mode: None,
             init_fn: None,
             work_fn: None,
         }
@@ -356,6 +363,7 @@ impl Clone for SandboxBuilder {
             protection_policy: self.protection_policy.clone(),
             policy_fn: self.policy_fn.clone(),
             name: self.name.clone(),
+            mode: self.mode.clone(),
             // init_fn (FnOnce) cannot be cloned; drop to None.
             init_fn: None,
             // work_fn is Arc-wrapped; clone bumps the reference count.
@@ -754,6 +762,13 @@ impl SandboxBuilder {
         self
     }
 
+    /// Set the operating-mode marker shown as STATUS in `sandlock ps`
+    /// output (e.g. `"learn"`).
+    pub fn mode(mut self, mode: impl Into<String>) -> Self {
+        self.mode = Some(mode.into());
+        self
+    }
+
     /// Set the COW-fork init function.
     ///
     /// The init function runs once in the child process before any COW clones
@@ -1031,6 +1046,7 @@ impl SandboxBuilder {
             user: self.user,
             policy_fn: self.policy_fn,
             name: self.name,
+            mode: self.mode,
             init_fn: self.init_fn,
             work_fn: self.work_fn,
             runtime: None,

--- a/crates/sandlock-core/src/sandbox/builder.rs
+++ b/crates/sandlock-core/src/sandbox/builder.rs
@@ -1047,6 +1047,7 @@ impl SandboxBuilder {
             policy_fn: self.policy_fn,
             name: self.name,
             mode: self.mode,
+            cow_upper: None,
             init_fn: self.init_fn,
             work_fn: self.work_fn,
             runtime: None,

--- a/crates/sandlock-core/tests/integration/test_control.rs
+++ b/crates/sandlock-core/tests/integration/test_control.rs
@@ -287,6 +287,25 @@ fn test_control_sandbox_mode_absent_for_plain_runs() {
 }
 
 #[test]
+fn test_control_sandbox_to_profile_dedups_net_rules() {
+    // "*" expands to tcp://* + udp://* at parse time, so the explicit
+    // udp://* renders as a duplicate spec.
+    let sb = sandlock_core::Sandbox::builder()
+        .net_allow("*")
+        .net_allow("udp://*")
+        .net_allow("icmp://*")
+        .build()
+        .unwrap();
+
+    let profile = sandlock_core::profile::sandbox_to_profile(&sb, &[]);
+    let allow = &profile.network.allow;
+    let unique: std::collections::HashSet<&String> = allow.iter().collect();
+    assert_eq!(allow.len(), unique.len(), "duplicate net rules in {allow:?}");
+    assert!(allow.contains(&"udp://*".to_string()));
+    assert!(allow.contains(&"icmp://*".to_string()));
+}
+
+#[test]
 fn test_control_sandbox_to_profile_merges_dynamic_denies() {
     let sb = sandlock_core::Sandbox::builder()
         .fs_read("/usr")

--- a/crates/sandlock-core/tests/integration/test_control.rs
+++ b/crates/sandlock-core/tests/integration/test_control.rs
@@ -268,6 +268,25 @@ fn test_control_sandbox_to_profile() {
 }
 
 #[test]
+fn test_control_mode_stays_out_of_profile() {
+    // The mode marker is ps metadata, not policy: inspect output (a
+    // ProfileInput) must not carry it.
+    let sb = sandlock_core::Sandbox::builder()
+        .fs_read("/usr")
+        .mode("learn")
+        .build()
+        .unwrap();
+
+    let toml_str = sandlock_core::profile::sandbox_to_toml(&sb, &[]).unwrap();
+    assert!(!toml_str.contains("mode"), "mode leaked into profile: {toml_str}");
+}
+
+#[test]
+fn test_control_sandbox_mode_absent_for_plain_runs() {
+    assert_eq!(sandlock_core::control::sandbox_mode("no-such-sandbox-mode"), None);
+}
+
+#[test]
 fn test_control_sandbox_to_profile_merges_dynamic_denies() {
     let sb = sandlock_core::Sandbox::builder()
         .fs_read("/usr")


### PR DESCRIPTION
Running \`sandlock inspect\` against a \`sandlock learn\` sandbox works, but the output had three problems, fixed here one commit each:

1. **ps: mark learning sandboxes with a status column.** A learn sandbox runs with read access to /, a COW workdir on /, and an allow-all network policy, yet ps listed it under an anonymous sandbox-\<pid\> name indistinguishable from a dangerously permissive run. The sandbox now carries an optional mode marker written into the runtime dir next to the pid file, shown in a new ps STATUS column ("running" when absent). Learn sets mode "learn" and names its sandboxes learn-\<pid\>. The marker is instance metadata, not policy, so it stays out of the profile that inspect renders.

2. **inspect: list each network rule spec once.** A scheme-less net-allow spec like "*" expands to a tcp://* + udp://* rule pair at parse time, so a sandbox that also names udp://* directly repeated the spec in inspect output. The rendered specs are now deduped, order preserved, and learn dropped its redundant udp://* rule.

3. **inspect: keep the internal COW upper grant out of the profile.** Spawning with a COW workdir pushes the branch's upper dir into fs_readable so Landlock can execute binaries created in the workdir. Inspect showed that internal path (/run/user/.../sandlock-cow/\<id\>/upper) in filesystem.read as if the user had asked for it. The grant is now recorded in a dedicated field and filtered from the profile's read list.

Before / after for a running \`sandlock learn -- sleep 10\`:

\`\`\`
NAME               PID      UPTIME  STATUS   PORTS  CMD
learn-2248604  2248608          2s  learn    -      sleep 10
\`\`\`

\`\`\`toml
[config]
workdir = "/"

[filesystem]
read = ["/"]
on_exit = "abort"
on_error = "abort"

[network]
allow = ["tcp://*", "udp://*", "icmp://*"]

[limits]
memory = "8192G"
\`\`\`

Tested: full sandlock-core suite (700 lib + 395 integration), learn CLI tests (11 + 29), plus manual end-to-end ps/inspect runs against live learn sandboxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)