### PR TITLE
fix(chroot): require write authority on both sides of a hard link

### DIFF
--- a/crates/sandlock-core/src/chroot/dispatch.rs
+++ b/crates/sandlock-core/src/chroot/dispatch.rs
@@ -1268,12 +1268,25 @@ pub(crate) async fn handle_chroot_write(
         // never follows either.
         let follow_old = (notif.data.args[4] & libc::AT_SYMLINK_FOLLOW as u64) != 0;
         let old_resolved = if follow_old {
-            resolve_chroot_path(notif, notif.data.args[0] as i64, &old_path, ctx)
+            // The source has to resolve as a path that already exists, which
+            // is what pins the result inside the root: the O_CREAT-style
+            // fallback in resolve_chroot_path walks the parent and then appends
+            // the last component verbatim, so a symlink whose target does not
+            // exist inside the root comes back as the symlink's own name. The
+            // supervisor runs outside the chroot, so handing that name to the
+            // host linkat below would resolve the guest's symlink from the real
+            // root and hard-link a host file into the sandbox.
+            resolve_chroot_path_existing(notif, notif.data.args[0] as i64, &old_path, ctx)
         } else {
             resolve_chroot_path_nofollow(notif, notif.data.args[0] as i64, &old_path, ctx)
         };
         let (old_host, _) = match old_resolved {
             Some(r) => r,
+            // A followed source that will not resolve is either missing or
+            // pointing out of the root, and the sandbox says the same thing
+            // about both: ENOENT is also what the kernel reports natively for
+            // AT_SYMLINK_FOLLOW on a dangling symlink.
+            None if follow_old => return NotifAction::Errno(libc::ENOENT),
             None => return NotifAction::Errno(libc::EACCES),
         };
         let (new_host, new_vp) = match resolve_chroot_path_nofollow(notif, notif.data.args[2] as i64, &new_path, ctx) {
@@ -1298,7 +1311,16 @@ pub(crate) async fn handle_chroot_write(
 
         let c_old = match path_cstr(&old_host, libc::EINVAL) { Ok(c) => c, Err(a) => return a };
         let c_new = match path_cstr(&new_host, libc::EINVAL) { Ok(c) => c, Err(a) => return a };
-        let flags = notif.data.args[4] as i32;
+        // Both defined flags describe a source this code has already resolved,
+        // so neither is forwarded. AT_SYMLINK_FOLLOW was consumed by the branch
+        // above; leaving it set would make the host kernel resolve the last
+        // component a second time, unconfined, which is both an escape and a
+        // window for the child to swap that component after the check.
+        // AT_EMPTY_PATH names a dirfd, and the path below is never empty.
+        // Anything else the child passes stays, so the kernel keeps rejecting
+        // unknown flags with EINVAL exactly as it would without the sandbox.
+        let flags =
+            notif.data.args[4] as i32 & !(libc::AT_EMPTY_PATH | libc::AT_SYMLINK_FOLLOW);
         return if unsafe { libc::linkat(libc::AT_FDCWD, c_old.as_ptr(), libc::AT_FDCWD, c_new.as_ptr(), flags) } < 0 {
             NotifAction::Errno(last_errno(libc::EIO))
         } else {

--- a/crates/sandlock-core/src/chroot/dispatch.rs
+++ b/crates/sandlock-core/src/chroot/dispatch.rs
@@ -1276,11 +1276,19 @@ pub(crate) async fn handle_chroot_write(
             // supervisor runs outside the chroot, so handing that name to the
             // host linkat below would resolve the guest's symlink from the real
             // root and hard-link a host file into the sandbox.
+            //
+            // The virtual path is re-derived from the resolved host path
+            // because a resolution under a mount reports the name the child
+            // asked for, not the name it reached. The gate below has to read
+            // the name of the inode being linked: a symlink inside a mount
+            // would otherwise be judged by the link's own name, and a denied
+            // or read-only target would pass under any allowed spelling.
             resolve_chroot_path_existing(notif, notif.data.args[0] as i64, &old_path, ctx)
+                .and_then(|(host, _)| ctx.host_to_virtual(&host).map(|vp| (host, vp)))
         } else {
             resolve_chroot_path_nofollow(notif, notif.data.args[0] as i64, &old_path, ctx)
         };
-        let (old_host, _) = match old_resolved {
+        let (old_host, old_vp) = match old_resolved {
             Some(r) => r,
             // A followed source that will not resolve is either missing or
             // pointing out of the root, and the sandbox says the same thing
@@ -1293,7 +1301,17 @@ pub(crate) async fn handle_chroot_write(
             Some(r) => r,
             None => return NotifAction::Errno(libc::EACCES),
         };
-        if !ctx.can_write(&new_vp) { return NotifAction::Errno(libc::EACCES); }
+        // A hard link is a second name for one inode, so afterwards the
+        // authority over that inode is the union of the policy on both names.
+        // Gating the destination alone lets a guest re-file a readable but
+        // unwritable file (a read-only mount, a denied path) under a writable
+        // prefix and then write to it there. Requiring write on the source too
+        // keeps the weaker name from being upgraded, the same rule rename
+        // already applies to the name it destroys. Off the chroot path
+        // Landlock enforces this already: linking needs REFER on both sides.
+        if !ctx.can_write(&old_vp) || !ctx.can_write(&new_vp) {
+            return NotifAction::Errno(libc::EACCES);
+        }
 
         {
             let mut cs = cow_state.lock().await;

--- a/crates/sandlock-core/src/chroot/dispatch.rs
+++ b/crates/sandlock-core/src/chroot/dispatch.rs
@@ -1316,13 +1316,20 @@ pub(crate) async fn handle_chroot_write(
         {
             let mut cs = cow_state.lock().await;
             if let Some(cow) = cs.branch.as_mut() {
-                let s = new_host.to_string_lossy();
-                if cow.matches(&s) {
-                    match cow.handle_link(&old_host.to_string_lossy(), &s) {
-                        Ok(true) => return NotifAction::ReturnValue(0),
-                        Err(crate::error::BranchError::QuotaExceeded) => return NotifAction::Errno(libc::ENOSPC),
-                        _ => {}
-                    }
+                let old_s = old_host.to_string_lossy();
+                let new_s = new_host.to_string_lossy();
+                // A hard link cannot be half staged. With one name inside the
+                // branch and the other below it there is nothing to stage:
+                // linking in would create the name in the workdir the branch
+                // promised to leave untouched, and linking out would hand the
+                // child an alias for the lower inode that survives an abort.
+                // EXDEV is what the kernel says about a link that cannot span
+                // the two sides.
+                if cow.matches(&old_s) != cow.matches(&new_s) {
+                    return NotifAction::Errno(libc::EXDEV);
+                }
+                if cow.matches(&new_s) {
+                    return crate::cow::dispatch::link_result(cow.handle_link(&old_s, &new_s));
                 }
             }
         }

--- a/crates/sandlock-core/src/cow/dispatch.rs
+++ b/crates/sandlock-core/src/cow/dispatch.rs
@@ -498,6 +498,28 @@ fn cow_result(r: Result<bool, crate::error::BranchError>) -> NotifAction {
     }
 }
 
+/// Map a `handle_link` result to a NotifAction, for both the async dispatcher
+/// here and the chroot one.
+///
+/// Unlike [`cow_result`] this never falls through. A hard link whose
+/// destination the branch owns has to be answered by the branch: letting the
+/// original syscall run would give the child a second name for the *lower*
+/// inode, so a write through it would edit the file the branch promised to
+/// leave alone, and the name itself would outlive an aborted branch.
+pub(crate) fn link_result(r: Result<bool, crate::error::BranchError>) -> NotifAction {
+    match r {
+        Ok(true) => NotifAction::ReturnValue(0),
+        // The branch declined: the source is a directory (EPERM is the
+        // kernel's own answer for that) or the upper-layer link failed.
+        Ok(false) => NotifAction::Errno(libc::EPERM),
+        Err(crate::error::BranchError::QuotaExceeded) => NotifAction::Errno(libc::ENOSPC),
+        Err(crate::error::BranchError::Deleted) => NotifAction::Errno(libc::ENOENT),
+        Err(crate::error::BranchError::Denied) => NotifAction::Errno(libc::EPERM),
+        Err(crate::error::BranchError::Exists) => NotifAction::Errno(libc::EEXIST),
+        Err(_) => NotifAction::Errno(libc::EIO),
+    }
+}
+
 /// Map an errno-style handler result (unlink, rename) to a NotifAction.
 fn unlink_result(r: Result<bool, i32>) -> NotifAction {
     match r {
@@ -638,8 +660,17 @@ pub(crate) async fn handle_cow_write(
             cow_result(cow.handle_symlink(target, linkpath))
         }
         CowWriteOp::Link { ref old_path, ref new_path } => {
+            // A hard link cannot be half staged. With one name inside the
+            // branch and the other below it there is nothing to stage: linking
+            // in would create the name in the workdir the branch promised to
+            // leave untouched, and linking out would hand the child an alias
+            // for the lower inode that survives an abort. EXDEV is what the
+            // kernel says about a link that cannot span the two sides.
+            if cow.matches(old_path) != cow.matches(new_path) {
+                return NotifAction::Errno(libc::EXDEV);
+            }
             if !cow.matches(new_path) { return NotifAction::Continue; }
-            cow_result(cow.handle_link(old_path, new_path))
+            link_result(cow.handle_link(old_path, new_path))
         }
         CowWriteOp::Chmod { ref path, mode } => {
             if !cow.matches(path) { return NotifAction::Continue; }

--- a/crates/sandlock-core/tests/integration/test_chroot.rs
+++ b/crates/sandlock-core/tests/integration/test_chroot.rs
@@ -1510,3 +1510,187 @@ async fn test_max_open_files_chroot_ignores_parent_fd_density() {
 
     cleanup_rootfs(&rootfs);
 }
+
+/// AT_SYMLINK_FOLLOW asks for the inode behind a symlink, and the supervisor
+/// performs the link itself from outside the chroot. If the source is resolved
+/// by walking its parent and appending the last component, a symlink whose
+/// target does not exist inside the root comes back as the symlink itself, and
+/// the host kernel then resolves it a second time against the real root: the
+/// guest picks any host path it likes and gets a hard link to it inside the
+/// sandbox, readable and writable.
+#[tokio::test]
+async fn test_chroot_hardlink_follow_cannot_reach_a_host_file() {
+    use std::os::unix::fs::MetadataExt;
+
+    let rootfs = build_test_rootfs("hardlink-follow-escape");
+    fs::create_dir_all(rootfs.join("work")).unwrap();
+
+    // Outside the rootfs and outside every grant, but on the same filesystem,
+    // so a hard link to it is physically possible and the refusal below is the
+    // only thing standing in the way.
+    let host_dir = temp_dir("hardlink-follow-host");
+    let host_secret = host_dir.join("host-only.txt");
+    fs::write(&host_secret, "HOST-ONLY").unwrap();
+
+    let policy = minimal_exec_policy(&rootfs)
+        .fs_read("/work")
+        .fs_write("/work")
+        .build()
+        .unwrap();
+
+    let bait = host_secret.to_string_lossy().to_string();
+    let planted = match policy
+        .clone()
+        .run(&["rootfs-helper", "ln", "-s", &bait, "/work/bait"])
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Chroot test skipped: {}", e);
+            cleanup_rootfs(&rootfs);
+            let _ = fs::remove_dir_all(&host_dir);
+            return;
+        }
+    };
+    // A symlink is just a string, so planting it is allowed; the target is
+    // meaningless inside the root. Without this the refusal below would prove
+    // nothing.
+    assert!(
+        planted.success(),
+        "planting the symlink should be allowed, exit={:?} stderr={}",
+        planted.code(),
+        planted.stderr_str().unwrap_or("")
+    );
+
+    let followed = policy
+        .clone()
+        .run(&["rootfs-helper", "linkat", "/work/bait", "/work/pwn", "follow"])
+        .await
+        .expect("second run should launch once the first did");
+    assert!(
+        !followed.success(),
+        "following a symlink out of the root should be refused, exit={:?} stderr={}",
+        followed.code(),
+        followed.stderr_str().unwrap_or("")
+    );
+    // The sandbox says the same thing about a target that is missing and one
+    // that lives outside the root: from inside, the outside does not exist.
+    assert!(
+        followed
+            .stderr_str()
+            .unwrap_or("")
+            .contains("No such file or directory"),
+        "the refusal should report the target as absent, stderr={}",
+        followed.stderr_str().unwrap_or("")
+    );
+    assert_eq!(
+        fs::metadata(&host_secret).unwrap().nlink(),
+        1,
+        "the host file gained a second name inside the sandbox"
+    );
+
+    let read_back = policy
+        .clone()
+        .run(&["rootfs-helper", "cat", "/work/pwn"])
+        .await
+        .expect("third run should launch once the first did");
+    assert!(
+        !read_back.stdout_str().unwrap_or("").contains("HOST-ONLY"),
+        "host file contents were read from inside the sandbox: {}",
+        read_back.stdout_str().unwrap_or("")
+    );
+
+    // The write side of the same escape: the destination name is writable by
+    // policy, so this run succeeds either way. What it proves is which inode
+    // that name refers to.
+    let write_back = policy
+        .clone()
+        .run(&["rootfs-helper", "write", "/work/pwn", "OWNED"])
+        .await
+        .expect("fourth run should launch once the first did");
+    assert!(
+        write_back.success(),
+        "writing the destination name should be allowed by policy, exit={:?} stderr={}",
+        write_back.code(),
+        write_back.stderr_str().unwrap_or("")
+    );
+    assert_eq!(
+        fs::read_to_string(&host_secret).unwrap().trim(),
+        "HOST-ONLY",
+        "a write inside the sandbox reached the host file, so the link landed \
+         on the host inode"
+    );
+
+    cleanup_rootfs(&rootfs);
+    let _ = fs::remove_dir_all(&host_dir);
+}
+
+/// The other side of the same branch: a symlink whose target does resolve
+/// inside the root still links the target's inode, not the symlink. Pins that
+/// the confined resolution above did not turn AT_SYMLINK_FOLLOW into a blanket
+/// refusal, and that the flag is honoured rather than quietly dropped.
+#[tokio::test]
+async fn test_chroot_hardlink_follow_links_the_target_inode() {
+    use std::os::unix::fs::MetadataExt;
+
+    let rootfs = build_test_rootfs("hardlink-follow-target");
+    fs::create_dir_all(rootfs.join("work")).unwrap();
+
+    let policy = minimal_exec_policy(&rootfs)
+        .fs_read("/work")
+        .fs_write("/work")
+        .build()
+        .unwrap();
+
+    let setup = match policy
+        .clone()
+        .run(&[
+            "rootfs-helper",
+            "sh",
+            "-c",
+            "write /work/orig.txt PAYLOAD && ln -s orig.txt /work/link",
+        ])
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Chroot test skipped: {}", e);
+            cleanup_rootfs(&rootfs);
+            return;
+        }
+    };
+    assert!(
+        setup.success(),
+        "creating the file and the symlink should succeed, exit={:?} stderr={}",
+        setup.code(),
+        setup.stderr_str().unwrap_or("")
+    );
+
+    let linked = policy
+        .clone()
+        .run(&["rootfs-helper", "linkat", "/work/link", "/work/alias.txt", "follow"])
+        .await
+        .expect("second run should launch once the first did");
+    assert!(
+        linked.success(),
+        "following a symlink that resolves inside the root should be allowed, \
+         exit={:?} stderr={}",
+        linked.code(),
+        linked.stderr_str().unwrap_or("")
+    );
+
+    let target = rootfs.join("work/orig.txt");
+    let alias = rootfs.join("work/alias.txt");
+    assert!(
+        !fs::symlink_metadata(&alias).unwrap().file_type().is_symlink(),
+        "the flag was dropped: the new name copied the symlink instead of \
+         linking its target"
+    );
+    assert_eq!(
+        fs::metadata(&target).unwrap().ino(),
+        fs::metadata(&alias).unwrap().ino(),
+        "the new name should be a second name for the target's inode"
+    );
+
+    cleanup_rootfs(&rootfs);
+}

--- a/crates/sandlock-core/tests/integration/test_chroot.rs
+++ b/crates/sandlock-core/tests/integration/test_chroot.rs
@@ -2020,3 +2020,232 @@ async fn test_chroot_hardlink_follow_cannot_alias_a_denied_path_under_a_mount() 
     cleanup_rootfs(&rootfs);
     let _ = fs::remove_dir_all(&work_dir);
 }
+
+/// A copy-on-write branch stages writes in an upper layer and, under
+/// BranchAction::Abort, throws them away. A hard link cannot be half staged:
+/// with one name inside the workdir and the other below it, there is nothing
+/// to stage, and performing the link for real would create the name in the
+/// pristine workdir instead. EXDEV is the kernel's own word for a link that
+/// cannot span two sides.
+#[tokio::test]
+async fn test_chroot_hardlink_into_a_branch_is_refused() {
+    let rootfs = build_test_rootfs("hardlink-branch-in");
+    let tmp_dir = rootfs.join("tmp");
+    fs::create_dir_all(rootfs.join("work")).unwrap();
+
+    let policy = Sandbox::builder()
+        .chroot(&rootfs)
+        .fs_read("/usr")
+        .fs_read("/bin")
+        .fs_read("/etc")
+        .fs_read("/proc")
+        .fs_read("/dev")
+        .fs_read("/work")
+        .fs_write("/work")
+        .fs_write("/tmp")
+        .workdir(&tmp_dir)
+        .on_exit(BranchAction::Abort)
+        .build()
+        .unwrap();
+
+    let result = policy
+        .clone()
+        .run(&[
+            "rootfs-helper",
+            "sh",
+            "-c",
+            "write /work/a.txt LEAKED && ln /work/a.txt /tmp/pulled-in.txt",
+        ])
+        .await;
+    match result {
+        Ok(r) => {
+            assert!(
+                !r.success(),
+                "a hard link into the branch should be refused, exit={:?} stderr={}",
+                r.code(),
+                r.stderr_str().unwrap_or("")
+            );
+            assert!(
+                r.stderr_str().unwrap_or("").contains("Invalid cross-device link"),
+                "the refusal should read as a cross-device link, stderr={}",
+                r.stderr_str().unwrap_or("")
+            );
+            assert!(
+                !tmp_dir.join("pulled-in.txt").exists(),
+                "the branch was aborted, yet the link landed in the workdir itself"
+            );
+        }
+        Err(e) => eprintln!("Chroot test skipped: {}", e),
+    }
+
+    cleanup_rootfs(&rootfs);
+}
+
+/// The other direction, and the damaging one: a name taken out of the workdir
+/// aliases the *lower* inode, so a write through it edits the very file the
+/// branch promised to leave alone, and the edit outlives the abort.
+#[tokio::test]
+async fn test_chroot_hardlink_out_of_a_branch_is_refused() {
+    let rootfs = build_test_rootfs("hardlink-branch-out");
+    let tmp_dir = rootfs.join("tmp");
+    fs::create_dir_all(rootfs.join("work")).unwrap();
+    fs::write(tmp_dir.join("orig.txt"), "ORIGINAL").unwrap();
+
+    let policy = Sandbox::builder()
+        .chroot(&rootfs)
+        .fs_read("/usr")
+        .fs_read("/bin")
+        .fs_read("/etc")
+        .fs_read("/proc")
+        .fs_read("/dev")
+        .fs_read("/work")
+        .fs_write("/work")
+        .fs_write("/tmp")
+        .workdir(&tmp_dir)
+        .on_exit(BranchAction::Abort)
+        .build()
+        .unwrap();
+
+    let result = policy
+        .clone()
+        .run(&[
+            "rootfs-helper",
+            "sh",
+            "-c",
+            "ln /tmp/orig.txt /work/alias.txt && write /work/alias.txt OVERWRITTEN",
+        ])
+        .await;
+    match result {
+        Ok(r) => {
+            assert!(
+                !r.success(),
+                "a hard link out of the branch should be refused, exit={:?} stderr={}",
+                r.code(),
+                r.stderr_str().unwrap_or("")
+            );
+            assert!(
+                !rootfs.join("work/alias.txt").exists(),
+                "the second name was created outside the branch"
+            );
+            assert_eq!(
+                fs::read_to_string(tmp_dir.join("orig.txt")).unwrap().trim(),
+                "ORIGINAL",
+                "the aborted branch still edited the file it was staging over"
+            );
+        }
+        Err(e) => eprintln!("Chroot test skipped: {}", e),
+    }
+
+    cleanup_rootfs(&rootfs);
+}
+
+/// Both names inside the workdir is the case the branch can stage, so it must
+/// keep working, and it must stay in the branch: after an abort neither the
+/// second name nor the copy of the first is left in the workdir.
+#[tokio::test]
+async fn test_chroot_hardlink_within_a_branch_stays_in_the_branch() {
+    let rootfs = build_test_rootfs("hardlink-branch-within");
+    let tmp_dir = rootfs.join("tmp");
+    fs::write(tmp_dir.join("orig.txt"), "ORIGINAL").unwrap();
+
+    let policy = Sandbox::builder()
+        .chroot(&rootfs)
+        .fs_read("/usr")
+        .fs_read("/bin")
+        .fs_read("/etc")
+        .fs_read("/proc")
+        .fs_read("/dev")
+        .fs_write("/tmp")
+        .workdir(&tmp_dir)
+        .on_exit(BranchAction::Abort)
+        .build()
+        .unwrap();
+
+    let result = policy
+        .clone()
+        .run(&[
+            "rootfs-helper",
+            "sh",
+            "-c",
+            "ln /tmp/orig.txt /tmp/alias.txt && cat /tmp/alias.txt",
+        ])
+        .await;
+    match result {
+        Ok(r) => {
+            assert!(
+                r.success(),
+                "a link between two names inside the workdir should be allowed, \
+                 exit={:?} stderr={}",
+                r.code(),
+                r.stderr_str().unwrap_or("")
+            );
+            assert!(
+                r.stdout_str().unwrap_or("").contains("ORIGINAL"),
+                "the second name should read as the file it links, stdout={}",
+                r.stdout_str().unwrap_or("")
+            );
+            assert!(
+                !tmp_dir.join("alias.txt").exists(),
+                "the aborted branch left its second name in the workdir"
+            );
+        }
+        Err(e) => eprintln!("Chroot test skipped: {}", e),
+    }
+
+    cleanup_rootfs(&rootfs);
+}
+
+/// A file deleted in the branch is a whiteout: the lower entry is still on
+/// disk with its pre-delete bytes. Linking it must answer ENOENT rather than
+/// resurrect it, which is the same rule the read-open path already follows.
+#[tokio::test]
+async fn test_chroot_hardlink_to_a_file_deleted_in_the_branch_is_enoent() {
+    let rootfs = build_test_rootfs("hardlink-branch-whiteout");
+    let tmp_dir = rootfs.join("tmp");
+    fs::write(tmp_dir.join("orig.txt"), "PREDELETE").unwrap();
+
+    let policy = Sandbox::builder()
+        .chroot(&rootfs)
+        .fs_read("/usr")
+        .fs_read("/bin")
+        .fs_read("/etc")
+        .fs_read("/proc")
+        .fs_read("/dev")
+        .fs_write("/tmp")
+        .workdir(&tmp_dir)
+        .on_exit(BranchAction::Abort)
+        .build()
+        .unwrap();
+
+    let result = policy
+        .clone()
+        .run(&[
+            "rootfs-helper",
+            "sh",
+            "-c",
+            "rm /tmp/orig.txt && ln /tmp/orig.txt /tmp/alias.txt",
+        ])
+        .await;
+    match result {
+        Ok(r) => {
+            assert!(
+                !r.success(),
+                "linking a file the branch deleted should be refused, exit={:?} stderr={}",
+                r.code(),
+                r.stderr_str().unwrap_or("")
+            );
+            assert!(
+                r.stderr_str().unwrap_or("").contains("No such file or directory"),
+                "the deleted file should read as absent, stderr={}",
+                r.stderr_str().unwrap_or("")
+            );
+            assert!(
+                !tmp_dir.join("alias.txt").exists(),
+                "the pre-delete inode came back under a second name in the workdir"
+            );
+        }
+        Err(e) => eprintln!("Chroot test skipped: {}", e),
+    }
+
+    cleanup_rootfs(&rootfs);
+}

--- a/crates/sandlock-core/tests/integration/test_chroot.rs
+++ b/crates/sandlock-core/tests/integration/test_chroot.rs
@@ -1694,3 +1694,329 @@ async fn test_chroot_hardlink_follow_links_the_target_inode() {
 
     cleanup_rootfs(&rootfs);
 }
+
+/// A hard link hands out a second name for an inode, so after link(2) the
+/// authority over that inode is the union of the policy on both names. Under
+/// chroot the supervisor performs the link itself, so nothing downstream can
+/// re-check it: if only the destination is gated, a guest can name a file it
+/// may read but not write under a writable prefix and then write to it there.
+///
+/// Read-only mount flavour: /ro is readable (so the source resolves) but never
+/// writable, /rw is writable.
+#[tokio::test]
+async fn test_chroot_hardlink_cannot_escalate_read_only_mount() {
+    let rootfs = build_test_rootfs("hardlink-ro-mount");
+    fs::create_dir_all(rootfs.join("ro")).unwrap();
+    fs::create_dir_all(rootfs.join("rw")).unwrap();
+
+    // Both host directories sit under the same temp base and therefore on the
+    // same filesystem. A cross-filesystem pair would fail with EXDEV and the
+    // escalation could not be attempted at all, making the test vacuous.
+    let ro_dir = temp_dir("hardlink-ro-src");
+    let rw_dir = temp_dir("hardlink-ro-dst");
+    let secret = ro_dir.join("secret.txt");
+    fs::write(&secret, "SECRET").unwrap();
+
+    let policy = minimal_exec_policy(&rootfs)
+        .fs_read("/ro")
+        .fs_read("/rw")
+        .fs_write("/rw")
+        .fs_mount_ro("/ro", &ro_dir)
+        .fs_mount("/rw", &rw_dir)
+        .build()
+        .unwrap();
+
+    let direct = match policy
+        .clone()
+        .run(&["rootfs-helper", "write", "/ro/secret.txt", "PWNED"])
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Chroot test skipped: {}", e);
+            cleanup_rootfs(&rootfs);
+            let _ = fs::remove_dir_all(&ro_dir);
+            let _ = fs::remove_dir_all(&rw_dir);
+            return;
+        }
+    };
+    // Baseline: the policy grants no write on the source name. Without this
+    // the link denial below would prove nothing.
+    assert!(
+        !direct.success(),
+        "writing a read-only mount directly should fail, exit={:?}",
+        direct.code()
+    );
+
+    let linked = policy
+        .clone()
+        .run(&["rootfs-helper", "ln", "/ro/secret.txt", "/rw/alias"])
+        .await
+        .expect("second run should launch once the first did");
+    assert!(
+        !linked.success(),
+        "hard-linking a read-only mount into a writable mount should be \
+         refused, exit={:?} stderr={}",
+        linked.code(),
+        linked.stderr_str().unwrap_or("")
+    );
+
+    // The consequence, spelled out: whatever now lives at the destination name
+    // must not be the protected inode. Writing through it is allowed by policy
+    // (/rw is writable), so this run must succeed on its own terms; if it ever
+    // stops doing so, the host-side check below would hold for a reason that
+    // has nothing to do with the escalation.
+    let through_alias = policy
+        .clone()
+        .run(&["rootfs-helper", "write", "/rw/alias", "PWNED"])
+        .await
+        .expect("third run should launch once the first did");
+    assert!(
+        through_alias.success(),
+        "the escalation attempt itself must run, exit={:?} stderr={}",
+        through_alias.code(),
+        through_alias.stderr_str().unwrap_or("")
+    );
+    assert_eq!(
+        fs::read_to_string(&secret).unwrap().trim(),
+        "SECRET",
+        "a write to the destination name reached the read-only mount, so the \
+         link aliased the protected inode"
+    );
+
+    cleanup_rootfs(&rootfs);
+    let _ = fs::remove_dir_all(&ro_dir);
+    let _ = fs::remove_dir_all(&rw_dir);
+}
+
+/// fs_deny flavour of the same escalation: aliasing a denied file needs write
+/// authority on the denied name, which fs_deny withholds, so the chain never
+/// starts. Both the read and the write escalation are checked.
+#[tokio::test]
+async fn test_chroot_hardlink_cannot_alias_denied_path() {
+    let rootfs = build_test_rootfs("hardlink-fs-deny");
+    fs::create_dir_all(rootfs.join("work")).unwrap();
+
+    let work_dir = temp_dir("hardlink-deny-work");
+    let secret = work_dir.join("secret.txt");
+    fs::write(&secret, "SECRET").unwrap();
+
+    let policy = minimal_exec_policy(&rootfs)
+        .fs_read("/work")
+        .fs_write("/work")
+        .fs_mount("/work", &work_dir)
+        .fs_deny("/work/secret.txt")
+        .build()
+        .unwrap();
+
+    let direct = match policy
+        .clone()
+        .run(&["rootfs-helper", "cat", "/work/secret.txt"])
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Chroot test skipped: {}", e);
+            cleanup_rootfs(&rootfs);
+            let _ = fs::remove_dir_all(&work_dir);
+            return;
+        }
+    };
+    // Baseline: fs_deny wins over the surrounding writable mount.
+    assert!(
+        !direct.success(),
+        "fs_deny should block reading the file by its own name, exit={:?} stdout={}",
+        direct.code(),
+        direct.stdout_str().unwrap_or("")
+    );
+
+    let linked = policy
+        .clone()
+        .run(&["rootfs-helper", "ln", "/work/secret.txt", "/work/alias.txt"])
+        .await
+        .expect("second run should launch once the first did");
+    assert!(
+        !linked.success(),
+        "hard-linking a denied path to an allowed name should be refused, \
+         exit={:?} stderr={}",
+        linked.code(),
+        linked.stderr_str().unwrap_or("")
+    );
+
+    let via_alias = policy
+        .clone()
+        .run(&["rootfs-helper", "cat", "/work/alias.txt"])
+        .await
+        .expect("third run should launch once the first did");
+    assert!(
+        !via_alias.stdout_str().unwrap_or("").contains("SECRET"),
+        "the denied file became readable under a second name: {}",
+        via_alias.stdout_str().unwrap_or("")
+    );
+
+    // /work is writable, so this run must succeed whichever inode the second
+    // name turns out to hold. Asserting that keeps the host-side check below
+    // from passing because the write never happened.
+    let through_alias = policy
+        .clone()
+        .run(&["rootfs-helper", "write", "/work/alias.txt", "PWNED"])
+        .await
+        .expect("fourth run should launch once the first did");
+    assert!(
+        through_alias.success(),
+        "the escalation attempt itself must run, exit={:?} stderr={}",
+        through_alias.code(),
+        through_alias.stderr_str().unwrap_or("")
+    );
+    assert_eq!(
+        fs::read_to_string(&secret).unwrap().trim(),
+        "SECRET",
+        "a write to the second name reached the denied inode"
+    );
+
+    cleanup_rootfs(&rootfs);
+    let _ = fs::remove_dir_all(&work_dir);
+}
+
+/// The other side of the predicate: when the policy grants writes on both
+/// names the link must still go through. Uses linkat(2) directly so the *at
+/// entry point is exercised alongside the legacy link(2) the other tests take.
+#[tokio::test]
+async fn test_chroot_hardlink_allowed_when_both_sides_writable() {
+    use std::os::unix::fs::MetadataExt;
+
+    let rootfs = build_test_rootfs("hardlink-allowed");
+    fs::create_dir_all(rootfs.join("work")).unwrap();
+
+    let work_dir = temp_dir("hardlink-allowed-work");
+    fs::write(work_dir.join("orig.txt"), "payload").unwrap();
+
+    let policy = minimal_exec_policy(&rootfs)
+        .fs_read("/work")
+        .fs_write("/work")
+        .fs_mount("/work", &work_dir)
+        .build()
+        .unwrap();
+
+    // A probe run carries the skip convention, so a host that cannot launch
+    // the sandbox at all is the only thing it can hide. The run under test
+    // then has to launch, or this test would be the one place where an
+    // over-denying gate could ship unnoticed.
+    if let Err(e) = policy.clone().run(&["rootfs-helper", "true"]).await {
+        eprintln!("Chroot test skipped: {}", e);
+        cleanup_rootfs(&rootfs);
+        let _ = fs::remove_dir_all(&work_dir);
+        return;
+    }
+
+    let linked = policy
+        .clone()
+        .run(&["rootfs-helper", "linkat", "/work/orig.txt", "/work/alias.txt"])
+        .await
+        .expect("second run should launch once the probe did");
+    assert!(
+        linked.success(),
+        "linking within a writable mount should be allowed, exit={:?} stderr={}",
+        linked.code(),
+        linked.stderr_str().unwrap_or("")
+    );
+    let orig = fs::metadata(work_dir.join("orig.txt")).unwrap();
+    let alias = fs::metadata(work_dir.join("alias.txt")).unwrap();
+    assert_eq!(
+        orig.ino(),
+        alias.ino(),
+        "the second name should be a hard link, not a copy"
+    );
+
+    cleanup_rootfs(&rootfs);
+    let _ = fs::remove_dir_all(&work_dir);
+}
+
+/// The gate has to judge the inode the link will name, which under a mount is
+/// not the name the child spelled: the mount resolver reports the requested
+/// path back, so a symlink to a denied file inside the mount would be checked
+/// as the symlink's own (allowed) name. AT_SYMLINK_FOLLOW is the spelling that
+/// reaches that branch, and it needs no knowledge of any host path: a relative
+/// symlink next to the target is enough.
+#[tokio::test]
+async fn test_chroot_hardlink_follow_cannot_alias_a_denied_path_under_a_mount() {
+    let rootfs = build_test_rootfs("hardlink-follow-deny");
+    fs::create_dir_all(rootfs.join("work")).unwrap();
+
+    let work_dir = temp_dir("hardlink-follow-deny-work");
+    let secret = work_dir.join("secret.txt");
+    fs::write(&secret, "SECRET").unwrap();
+
+    let policy = minimal_exec_policy(&rootfs)
+        .fs_read("/work")
+        .fs_write("/work")
+        .fs_mount("/work", &work_dir)
+        .fs_deny("/work/secret.txt")
+        .build()
+        .unwrap();
+
+    let planted = match policy
+        .clone()
+        .run(&["rootfs-helper", "ln", "-s", "secret.txt", "/work/s"])
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Chroot test skipped: {}", e);
+            cleanup_rootfs(&rootfs);
+            let _ = fs::remove_dir_all(&work_dir);
+            return;
+        }
+    };
+    // fs_deny covers the file, not the name of a symlink beside it, so
+    // planting the bait is allowed and the refusal below is about the target.
+    assert!(
+        planted.success(),
+        "planting the symlink should be allowed, exit={:?} stderr={}",
+        planted.code(),
+        planted.stderr_str().unwrap_or("")
+    );
+
+    let followed = policy
+        .clone()
+        .run(&["rootfs-helper", "linkat", "/work/s", "/work/alias.txt", "follow"])
+        .await
+        .expect("second run should launch once the first did");
+    assert!(
+        !followed.success(),
+        "following a symlink to a denied file should be refused, exit={:?} stderr={}",
+        followed.code(),
+        followed.stderr_str().unwrap_or("")
+    );
+
+    let via_alias = policy
+        .clone()
+        .run(&["rootfs-helper", "cat", "/work/alias.txt"])
+        .await
+        .expect("third run should launch once the first did");
+    assert!(
+        !via_alias.stdout_str().unwrap_or("").contains("SECRET"),
+        "the denied file became readable under a second name: {}",
+        via_alias.stdout_str().unwrap_or("")
+    );
+
+    let through_alias = policy
+        .clone()
+        .run(&["rootfs-helper", "write", "/work/alias.txt", "PWNED"])
+        .await
+        .expect("fourth run should launch once the first did");
+    assert!(
+        through_alias.success(),
+        "the escalation attempt itself must run, exit={:?} stderr={}",
+        through_alias.code(),
+        through_alias.stderr_str().unwrap_or("")
+    );
+    assert_eq!(
+        fs::read_to_string(&secret).unwrap().trim(),
+        "SECRET",
+        "a write to the second name reached the denied inode"
+    );
+
+    cleanup_rootfs(&rootfs);
+    let _ = fs::remove_dir_all(&work_dir);
+}

--- a/crates/sandlock-core/tests/integration/test_cow.rs
+++ b/crates/sandlock-core/tests/integration/test_cow.rs
@@ -1284,3 +1284,94 @@ async fn test_cow_child_rmdir_nonempty_fails() {
 
     let _ = fs::remove_dir_all(&workdir);
 }
+
+/// A hard link cannot be half staged. With one name inside the workdir and the
+/// other below it there is nothing for the branch to copy up, and letting the
+/// child's own linkat run instead puts the name in the pristine workdir (or
+/// hands out an alias for the lower inode that outlives the abort). Both
+/// directions have to be refused, and the proof is the link count: neither
+/// original may gain a second name.
+#[tokio::test]
+async fn test_seccomp_cow_hardlink_cannot_cross_the_workdir_boundary() {
+    use std::os::unix::fs::MetadataExt;
+
+    let workdir = temp_dir("seccomp-link-inside");
+    let outside = temp_dir("seccomp-link-outside");
+    for d in [&workdir, &outside] {
+        let _ = fs::remove_dir_all(d);
+        fs::create_dir_all(d).unwrap();
+    }
+    fs::write(workdir.join("inside.txt"), "INSIDE").unwrap();
+    fs::write(outside.join("outside.txt"), "OUTSIDE").unwrap();
+
+    let policy = Sandbox::builder()
+        .fs_read("/usr").fs_read("/lib").fs_read_if_exists("/lib64").fs_read("/bin").fs_read("/etc")
+        .fs_read("/proc")
+        .fs_write(&workdir)
+        .fs_write(&outside)
+        .workdir(&workdir)
+        .on_exit(BranchAction::Abort)
+        .build()
+        .unwrap();
+
+    let pull_in = format!(
+        "ln {}/outside.txt {}/pulled-in.txt",
+        outside.display(),
+        workdir.display()
+    );
+    let result = policy.clone().run(&["sh", "-c", &pull_in]).await;
+    let pulled = match result {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Seccomp COW test skipped: {}", e);
+            let _ = fs::remove_dir_all(&workdir);
+            let _ = fs::remove_dir_all(&outside);
+            return;
+        }
+    };
+    assert!(
+        !pulled.success(),
+        "a hard link into the workdir should be refused, exit={:?} stderr={}",
+        pulled.code(),
+        pulled.stderr_str().unwrap_or("")
+    );
+
+    let push_out = format!(
+        "ln {}/inside.txt {}/pushed-out.txt",
+        workdir.display(),
+        outside.display()
+    );
+    let pushed = policy
+        .clone()
+        .run(&["sh", "-c", &push_out])
+        .await
+        .expect("second run should launch once the first did");
+    assert!(
+        !pushed.success(),
+        "a hard link out of the workdir should be refused, exit={:?} stderr={}",
+        pushed.code(),
+        pushed.stderr_str().unwrap_or("")
+    );
+
+    assert_eq!(
+        fs::metadata(outside.join("outside.txt")).unwrap().nlink(),
+        1,
+        "the file outside the workdir gained a second name inside it"
+    );
+    assert_eq!(
+        fs::metadata(workdir.join("inside.txt")).unwrap().nlink(),
+        1,
+        "the file the branch was staging over gained a second name outside it"
+    );
+    assert!(
+        !workdir.join("pulled-in.txt").exists(),
+        "the aborted branch left a name in the workdir"
+    );
+    assert!(
+        !outside.join("pushed-out.txt").exists(),
+        "the aborted branch left a name outside the workdir"
+    );
+
+    let _ = fs::remove_dir_all(&workdir);
+    let _ = fs::remove_dir_all(&outside);
+}

--- a/tests/rootfs-helper.c
+++ b/tests/rootfs-helper.c
@@ -206,6 +206,41 @@ static int cmd_ln_s(int argc, char **argv) {
     return 0;
 }
 
+/* ── ln (hard link) ─────────────────────────────────────────── */
+/* link(2). On architectures that still carry the legacy syscall this
+ * reaches the dispatcher through SYS_link; elsewhere the libc maps it
+ * onto linkat(2). Use the "linkat" command to pin the *at form. */
+static int cmd_ln(int argc, char **argv) {
+    if (argc < 2) { fprintf(stderr, "ln: missing operand\n"); return 1; }
+    if (link(argv[0], argv[1]) < 0) {
+        fprintf(stderr, "ln: %s: %s\n", argv[1], strerror(errno));
+        return 1;
+    }
+    return 0;
+}
+
+/* ── linkat (hard link via the *at syscall) ─────────────────── */
+/* linkat target link [follow]. The optional third word sets
+ * AT_SYMLINK_FOLLOW, which is the only way to ask for the inode a
+ * symlink points at: link(2) and plain linkat(2) always take the
+ * source name itself. */
+static int cmd_linkat(int argc, char **argv) {
+    if (argc < 2) { fprintf(stderr, "linkat: missing operand\n"); return 1; }
+    int flags = 0;
+    if (argc >= 3) {
+        if (strcmp(argv[2], "follow") != 0) {
+            fprintf(stderr, "linkat: unknown flag: %s\n", argv[2]);
+            return 1;
+        }
+        flags = AT_SYMLINK_FOLLOW;
+    }
+    if (linkat(AT_FDCWD, argv[0], AT_FDCWD, argv[1], flags) < 0) {
+        fprintf(stderr, "linkat: %s: %s\n", argv[1], strerror(errno));
+        return 1;
+    }
+    return 0;
+}
+
 /* ── access ─────────────────────────────────────────────────── */
 static int cmd_access(int argc, char **argv) {
     if (argc < 1) { fprintf(stderr, "access: missing operand\n"); return 1; }
@@ -821,12 +856,12 @@ static int dispatch(const char *cmd, int argc, char **argv) {
     if (strcmp(cmd, "rm") == 0)             return cmd_rm(argc, argv);
     if (strcmp(cmd, "mv") == 0)             return cmd_mv(argc, argv);
     if (strcmp(cmd, "ln") == 0) {
-        /* ln -s target link */
+        /* ln -s target link (symlink), ln target link (hard link) */
         if (argc >= 1 && strcmp(argv[0], "-s") == 0)
             return cmd_ln_s(argc - 1, argv + 1);
-        fprintf(stderr, "ln: only -s supported\n");
-        return 1;
+        return cmd_ln(argc, argv);
     }
+    if (strcmp(cmd, "linkat") == 0)         return cmd_linkat(argc, argv);
     if (strcmp(cmd, "access") == 0)         return cmd_access(argc, argv);
     if (strcmp(cmd, "getxattr") == 0)       return cmd_getxattr(argc, argv);
     if (strcmp(cmd, "setxattr") == 0)       return cmd_setxattr(argc, argv);


### PR DESCRIPTION
Closes #179.

The predicate is the one you specified in that issue, `can_write(old) && can_write(new)`, and the regression tests live in the chroot suite because you pointed at `tests/rootfs-helper.c` as the place to make that possible. Thank you for both, they saved a detour.

Two things turned up while building the test for it, and they are why this is four commits rather than one. Your audit was right that `linkat` is a single site rather than a pattern. It just has three independent ways to fail, and #179 describes one of them.

## 1. The gate from #179

Under chroot the handler resolved the source only to obtain a host path and gated the destination alone. After the call the authority over the inode is the union of the policy on both names, so a guest could name a file it may read but not write, under a read-only mount or an `fs_deny` path, place the new name under a writable prefix, and write to it there. The supervisor performs the link itself, so the child's Landlock never sees the operation and there is no backstop.

Gated on `can_write(old) && can_write(new)`, which is the rule `rename` already applies to the name it destroys, and which brings chroot in line with the non-chroot path where Landlock requires `REFER` on both sides.

One detail worth calling out, because a gate is only as good as the name it reads: for a followed source under a mount, the mount resolver reports the requested path back rather than the one it reached. The source's virtual path therefore has to be derived from the resolved host path. Without that, a symlink planted beside a denied file is judged by the symlink's own allowed name and the escalation walks straight through the new gate.

## 2. `AT_SYMLINK_FOLLOW` reaches any file on the host

This one is heavier than #179 and is independent of it.

`linkat` with `AT_SYMLINK_FOLLOW` asks for the inode a symlink points at. The handler resolved that source with the `O_CREAT`-style resolver, which walks the parent and appends the last component verbatim when the full path does not exist. A symlink whose target does not exist inside the root takes exactly that fallback, so the source came back as the symlink itself, and the flag was then forwarded to the supervisor's own `linkat`. The supervisor runs outside the chroot, so the host kernel resolved the guest's symlink a second time against the real root and hard-linked whatever it named into the sandbox.

No mount and no unusual grant are needed. Any host file the supervisor may link becomes readable and writable from inside, and the child's Landlock never sees it, because the supervisor performs the link.

A followed source is now resolved with the existing-path resolver, which is `openat2(RESOLVE_IN_ROOT)` with no fallback: it hands back a path the kernel already confined, or nothing. Failure answers ENOENT, which is what the kernel reports natively for `AT_SYMLINK_FOLLOW` on a dangling symlink, and it keeps the sandbox telling one story about the outside, that it is not there. Neither `linkat` flag is forwarded any more.

## 3. Hard links crossed the copy-on-write boundary

A branch stages writes in an upper layer and, under `BranchAction::Abort`, throws them away. Hard links were the one operation that walked out of that arrangement. Both dispatchers asked only whether the destination belonged to the branch, and when the answer was no, or when the branch declined, the original syscall ran against the paths below: the chroot dispatcher did the `linkat` itself on the lower host paths, and the async one returned `Continue` and let the child's own call through.

Both directions break the promise. Linking a file from outside into the workdir creates the name in the workdir itself, so an aborted branch leaves a file behind. Linking a file out of the workdir is worse: the alias names the lower inode, not the staged copy, so writing through it edits the file the branch was protecting and the edit outlives the abort.

A hard link cannot be half staged, and copying is not a substitute for one, so the boundary is not something to translate across: it answers EXDEV, the kernel's own word for a link that cannot span two sides. When the branch owns both names it also owns the answer, so a declined link reports EPERM, which is what the kernel gives for the case that motivated the fall-through.

## Why one PR

All three are the same syscall, and the first fix alone leaves the other two open. Splitting them would mean shipping a gate whose source name cannot be trusted, or a boundary that leaks the moment the gate lets a legitimate link through. Happy to split if you would rather review them separately.

## Not included

The `renameat2` and `fs_deny` escape you described at the end of #179 (renaming a directory moves a file out from under a deny rule) is not here. You said you would file it separately and it needs its own predicate on rename sources, so folding it in would blur two fixes together.

## Testing

`tests/rootfs-helper.c` gains `ln target link` next to the existing `ln -s`, plus a `linkat` command that calls the `*at` syscall explicitly and takes an optional `follow` word. Both entry points earn their place: on architectures that still carry the legacy syscall, libc `link()` reaches the dispatcher as `SYS_link` and is funnelled into the `linkat` block through a synthetic notification, while `linkat` pins the `*at` form everywhere. `AT_SYMLINK_FOLLOW` is the only way to reach the follow branch at all, since both other spellings link the source name itself.

Eleven tests across the chroot and COW suites: the read-only mount escalation, the `fs_deny` alias, the permitted case where both sides are writable, the followed source reaching a host file, a followed source aliasing a denied path under a mount, the followed link resolving to the target inode, links into and out of a branch, a link within a branch staying there, a link to a file the branch deleted, and the async dispatcher's workdir boundary.

Each was written red first, and the red phase proved a real escape rather than a return code: with the refusal assertions relaxed, the host file under a read-only mount read `PWNED` instead of `SECRET`, and the `fs_deny` file was readable through its alias. Both sides of the predicate were then mutation-checked, an always-refusing source gate turns the permitted test red, and the original code turns both negative tests red.

The read-only and writable directories are deliberately on one filesystem, since EXDEV would otherwise make the test vacuous.

`cargo test -p sandlock-core --lib`: 710 pass.
`cargo test -p sandlock-core --test integration`: green, including the eleven above.
CI is green on the full matrix on my fork: x86 and arm, Python 3.10 to 3.12, low-ABI on ubuntu-22.04, riscv64 cross-build, cbindgen gate.
