### PR TITLE
ci: test the Python versions the release already builds wheels for

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
       fail-fast: false
       matrix:
         runner: [ubuntu-latest, ubuntu-24.04-arm]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
One line in `ci.yml`.

## The gap

`release.yml` builds cp313 and cp314 wheels and runs the release test matrix on 3.13 and 3.14, since #157. `ci.yml` has tested 3.10 to 3.12 since the very first commit and has never been touched.

So the two newest interpreters the project ships wheels for are exercised only while a release is being cut. That is the worst moment to find out one of them is broken: the tag is already pushed, and whoever is cutting the release gets to choose between holding it and publishing a wheel whose tests nobody ran. A PR that breaks 3.14 goes green today and stays green until release day.

The exposure is not hypothetical for this SDK specifically. It drives `libsandlock_ffi` through ctypes, hands the library Python-owned buffers and callbacks, and frees what the C ABI returns from `__del__` and from context managers. Those are exactly the parts of the language that shift between versions.

## Verified before proposing it

Full Python suite on this host, same tree, five interpreters:

```
3.10   34 failed, 364 passed
3.11   34 failed, 364 passed
3.12   34 failed, 364 passed
3.13   34 failed, 364 passed
3.14   34 failed, 364 passed
```

Identical counts, and the failing test names match byte for byte across all five, so this widens coverage without widening the red.

Those 34 are an artifact of how I ran them rather than anything about the versions. Each of those interpreters is a uv-managed build whose stdlib lives outside its own `sys.prefix`, and the suite grants `sys.prefix` to the sandbox, so a guest that re-executes `sys.executable` cannot import anything. Running the same tree against the distribution interpreter gives 396 passed, 2 failed, and both of those are packages I could not install into it (PEP 668). The point stands either way: the five interpreters agree with each other exactly.

On my fork the extended matrix is green on the real runners: all four new jobs, 3.13 and 3.14 on both ubuntu-latest and ubuntu-24.04-arm, pass.

## Cost

Four extra jobs, since the matrix crosses two runners. If that is more than it is worth, this would still catch an interpreter regression while adding only two:

```yaml
        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
        exclude:
          - runner: ubuntu-24.04-arm
            python-version: "3.13"
          - runner: ubuntu-24.04-arm
            python-version: "3.14"
```

Happy to switch to that, or to drop this entirely if the release matrix is deliberately the only place those versions are checked.
