### PR TITLE
cli: drop the inert -i/--interactive flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ cargo install --path crates/sandlock-cli
 # Basic confinement
 sandlock run -r /usr -r /lib -w /tmp -- ls /tmp
 
-# Interactive shell
-sandlock run -i -r /usr -r /lib -r /lib64 -r /bin -r /etc -w /tmp -- /bin/sh
+# Interactive shell (the sandboxed command inherits the terminal)
+sandlock run -r /usr -r /lib -r /lib64 -r /bin -r /etc -w /tmp -- /bin/sh
 
 # Resource limits + timeout
 sandlock run -m 512M -P 20 -t 30 -- ./compute.sh

--- a/crates/sandlock-cli/src/main.rs
+++ b/crates/sandlock-cli/src/main.rs
@@ -140,9 +140,6 @@ struct RunArgs {
     #[arg(short = 'e', long = "exec-shell", value_name = "CMD")]
     exec_shell: Option<String>,
 
-    #[arg(short = 'i', long)]
-    interactive: bool,
-
     /// Use a local Docker image as chroot rootfs, given by reference
     /// (e.g. `python:3.12-slim`, a digest, or an image id). The image
     /// must already be present in local Docker storage; sandlock never


### PR DESCRIPTION
Fixes #177.

`RunArgs::interactive` was parsed and never read. `sandlock run` has a single run path, `policy.run_interactive(&cmd_strs)` (`crates/sandlock-cli/src/main.rs:757`, `:766`, plus the `--dry-run` pair at `:733`/`:742`), which wires the child to `StdioSpec::inherit()`: the sandboxed process keeps the CLI's own fds 0/1/2. A shell is therefore interactive with or without the flag.

The capture alternative (`Sandbox::run()` → `StdioSpec::capture()`, output returned in `RunResult.stdout`/`stderr`) exists for library callers, which run the sandbox in their own process and cannot redirect fd 1 to a pipe without clobbering their own stdout. A CLI caller has already chosen its stdio before exec, so there is nothing left for a flag to select. The CLI never reads `result.stdout`/`result.stderr`, only `result.code()`.

The flag also appeared in `sandlock run --help` with an empty description, the only `RunArgs` field without a doc comment, reading as a behaviour switch that does not exist.

## Behaviour change

`sandlock run -i ...` now fails with clap's `error: unexpected argument '-i' found` (exit 2) instead of being silently accepted. Anyone with `-i` in their fingers from `docker run -i` will see an immediate error and retype. Nothing else changes: the outer `docker run -i/-t` still decides whether stdin and a pty reach the container, and sandlock inherits whatever it is given.

## Verification

- `cargo test -p sandlock-cli --test cli_test`: 31 passed, 0 failed.
- Same command with and without the flag previously produced byte-identical stdout, stderr and exit status.
- Under a pty (`script -qec`), inside the sandbox `test -t 0` and `test -t 1` both succeed and `tty` reports the caller's terminal.
- Driven from Python with pipes, all four caller-side wirings work unchanged: separate capture, `stdin=DEVNULL` (child sees EOF), `input=` (child reads it), `stderr=STDOUT` (merged).

README's interactive-shell example drops the flag.