### PR TITLE
checkpoint: riscv64 post-merge review follow-ups

### DIFF
--- a/crates/sandlock-core/src/checkpoint/capture.rs
+++ b/crates/sandlock-core/src/checkpoint/capture.rs
@@ -423,14 +423,8 @@ pub(crate) fn capture(pid: i32, policy: &Sandbox) -> Result<Checkpoint, Sandlock
         // while the tell-tale sentinel is still in `a0`. This saves the memory
         // dump and surfaces the error at the actionable moment.
         #[cfg(target_arch = "riscv64")]
-        if let Some(sentinel) = super::restore_blob::restart_sentinel_in_a0(&regs) {
-            return Err(SandlockError::Runtime(SandboxRuntimeError::Child(format!(
-                "checkpoint captured an interrupted restartable syscall \
-                 (a0 = {sentinel}); riscv64 cannot recover its original argument, \
-                 so restore would resume with a corrupt return value — retry \
-                 while the workload is not blocked in a syscall"
-            ))));
-        }
+        super::restore_blob::reject_restart_sentinel(&regs)
+            .map_err(|e| SandlockError::Runtime(SandboxRuntimeError::Child(e)))?;
         // FP state is best-effort: an image without it still restores.
         let fpregs = ptrace_getfpregs(pid).unwrap_or_default();
         let maps =

--- a/crates/sandlock-core/src/checkpoint/restore-stub.c
+++ b/crates/sandlock-core/src/checkpoint/restore-stub.c
@@ -261,6 +261,10 @@ struct sigctx {
     u8  fpregs[528];         /* sc_fpregs: union __riscv_fp_state (kernel 528 byte union) */
 };
 
+/* The sc_fpregs memcpy is bounded only by validate's FP_MAX check. */
+_Static_assert(FP_MAX <= sizeof((struct sigctx){0}.fpregs),
+               "FP_MAX must not exceed sc_fpregs");
+
 struct uctx {
     u64 uc_flags;            /* 0x00 */
     u64 uc_link;             /* 0x08 */

--- a/crates/sandlock-core/src/checkpoint/restore_blob.rs
+++ b/crates/sandlock-core/src/checkpoint/restore_blob.rs
@@ -372,12 +372,27 @@ fn is_restart_sentinel(v: i64) -> bool {
 /// `user_regs_struct`, so neither capture nor restore can recover it. Callers
 /// reject the checkpoint rather than resume with a corrupt return value.
 #[cfg(target_arch = "riscv64")]
-pub(crate) fn restart_sentinel_in_a0(regs: &[u64]) -> Option<i64> {
+fn restart_sentinel_in_a0(regs: &[u64]) -> Option<i64> {
     // riscv64 user_regs_struct order: pc, ra, sp, gp, tp, t0-t2, s0-s1,
     // a0-a7, s2-s11, t3-t6 — so a0 is index 10.
     const A0: usize = 10;
     let a0 = *regs.get(A0)? as i64;
     if is_restart_sentinel(a0) { Some(a0) } else { None }
+}
+
+/// Refuse a riscv64 register file whose `a0` holds a restart sentinel, with
+/// the shared error text; both capture and restore reject through here.
+#[cfg(target_arch = "riscv64")]
+pub(crate) fn reject_restart_sentinel(regs: &[u64]) -> Result<(), String> {
+    match restart_sentinel_in_a0(regs) {
+        Some(sentinel) => Err(format!(
+            "checkpoint captured an interrupted restartable syscall \
+             (a0 = {sentinel}); riscv64 cannot recover its original argument, \
+             so restore would resume with a corrupt return value; retry the \
+             checkpoint while the workload is not blocked in a syscall"
+        )),
+        None => Ok(()),
+    }
 }
 
 /// Re-arm an interrupted, restartable syscall in the saved register file.
@@ -420,15 +435,7 @@ fn rearm_restartable_syscall(regs: &mut [u64]) -> Result<(), String> {
 /// syscall result.
 #[cfg(target_arch = "riscv64")]
 fn rearm_restartable_syscall(regs: &mut [u64]) -> Result<(), String> {
-    if let Some(sentinel) = restart_sentinel_in_a0(regs) {
-        return Err(format!(
-            "checkpoint captured an interrupted restartable syscall \
-             (a0 = {sentinel}); riscv64 cannot recover its original argument, \
-             so restore would resume with a corrupt return value. Retry the \
-             checkpoint while the workload is not blocked in a syscall"
-        ));
-    }
-    Ok(())
+    reject_restart_sentinel(regs)
 }
 
 /// Build the FP image the stub points the signal frame's `fpstate` at.


### PR DESCRIPTION
Two follow-ups from the post-merge review of #192.

**Assert FP_MAX fits sc_fpregs in the restore stub.** The riscv64 sc_fpregs memcpy has no bound of its own: it is safe because validate rejects fpstate_len > FP_MAX and FP_MAX (516) fits the 528-byte field, but nothing enforced that relation. Raising FP_MAX or shrinking the struct would silently turn the copy into a stack overflow inside the signal frame, so a _Static_assert now pins it at the struct definition.

**Share the riscv64 restart-sentinel rejection.** Capture and rearm_restartable_syscall each carried their own copy of the sentinel check plus a near-identical multi-line error, and the two messages had already drifted. Both now route through one reject_restart_sentinel helper so the check and its wording cannot diverge again.

Verified locally: the stub compiles for riscv64 (clang -fsyntax-only cross-check, which also proves the assert holds) and the 38 checkpoint lib tests pass on x86_64. The riscv64 Rust paths rely on the cross-build CI job, as usual on this machine.