### PR TITLE
cow: leave kernel objects to the kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,9 @@ Copy-on-write filesystem isolation via seccomp notification: when
 `workdir` is set, sandlock intercepts filesystem syscalls and stages
 writes in an upper directory; reads resolve upper-then-lower. No mount
 namespace, no user namespace, no root. Committed on exit, aborted on
-error.
+error. Only regular files, directories, and symlinks are staged: a FIFO,
+socket, or device node is a kernel object, so opens and metadata changes
+on one go to the kernel under the Landlock policy and are never reverted.
 
 **Dry-run mode**: `--dry-run` runs the command, inspects the COW layer
 for changes (added/modified/deleted files), prints a summary, then

--- a/crates/sandlock-cli/src/learn.rs
+++ b/crates/sandlock-cli/src/learn.rs
@@ -74,6 +74,7 @@ fn collapse_write_paths(writes: &BTreeSet<PathBuf>) -> Vec<PathBuf> {
     let mut out: BTreeSet<PathBuf> = BTreeSet::new();
     for p in writes {
         if is_junk_path(p) { continue; }
+        let p = &fold_session_path(p.clone());
         if p.exists() {
             out.insert(p.clone());
             continue;
@@ -186,18 +187,18 @@ fn collapse_by_threshold(
     out.into_iter().collect()
 }
 
-/// Returns true for pid/session-specific paths that are meaningless across runs.
+/// Returns true for pid-specific paths that are meaningless across runs.
 fn is_junk_path(p: &std::path::Path) -> bool {
     let b = p.as_os_str().as_encoded_bytes();
-    // /proc/self/... and /proc/<pid>/... are pid-specific;
-    let proc_pid = b.starts_with(b"/proc/self")
-        || (b.starts_with(b"/proc/") && b.get(6).map_or(false, u8::is_ascii_digit));
-    // Only the controlling terminal is session-specific; hardware serial
-    // devices (/dev/ttyS*, /dev/ttyUSB*, ...) are stable paths a workload
-    // may legitimately need.
-    proc_pid
-        || b.starts_with(b"/dev/pts/") || b == b"/dev/pts"
-        || b == b"/dev/tty"
+    b.starts_with(b"/proc/self")
+        || (b.starts_with(b"/proc/") && b.get(6).map_or(false, u8::is_ascii_digit))
+}
+
+/// A pty's number changes between sessions; granting the directory is
+/// what lets the next run reopen whichever slave it gets. /dev/tty needs
+/// no folding: the path is stable even though the device behind it is not.
+fn fold_session_path(p: PathBuf) -> PathBuf {
+    if p.starts_with("/dev/pts") { PathBuf::from("/dev/pts") } else { p }
 }
 
 use crate::LearnArgs;
@@ -635,6 +636,7 @@ pub async fn run(args: LearnArgs) -> Result<()> {
 
     let reads_raw: Vec<PathBuf> = observer.reads.lock().unwrap().iter()
         .filter(|p| p.exists() && !is_junk_path(p))
+        .map(|p| fold_session_path(p.clone()))
         .filter(|p| {
             // Same guard the write side has: "/" is never a grant. A child
             // whose cwd is the workdir root lists it routinely (python's -c
@@ -648,7 +650,6 @@ pub async fn run(args: LearnArgs) -> Result<()> {
             }
             true
         })
-        .cloned()
         .collect();
     let writes_raw = observer.writes.lock().unwrap();
     let observed_all: BTreeSet<PathBuf> = reads_raw.iter()
@@ -879,5 +880,36 @@ fn max_opt(a: Option<u32>, b: Option<u32>) -> Option<u32> {
         (None, None) => None,
         (Some(v), None) | (None, Some(v)) => Some(v),
         (Some(va), Some(vb)) => Some(va.max(vb)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A slave pty path, guaranteed to exist for the duration of the test.
+    fn open_pts() -> (libc::c_int, libc::c_int, PathBuf) {
+        let (mut master, mut slave) = (-1, -1);
+        let rc = unsafe {
+            libc::openpty(&mut master, &mut slave, std::ptr::null_mut(),
+                          std::ptr::null_mut(), std::ptr::null_mut())
+        };
+        assert_eq!(rc, 0, "openpty: {}", std::io::Error::last_os_error());
+        let name = unsafe { std::ffi::CStr::from_ptr(libc::ttyname(slave)) };
+        (master, slave, PathBuf::from(name.to_str().unwrap()))
+    }
+
+    #[test]
+    fn controlling_terminal_is_granted_and_pts_folds_to_its_directory() {
+        // /dev/tty is a stable path (it always means "my terminal"), so a
+        // profile that omits it denies ncurses apps their screen. The pts
+        // number is what changes between sessions.
+        let (master, slave, pts) = open_pts();
+        assert!(pts.starts_with("/dev/pts/"), "unexpected pts name {}", pts.display());
+        let writes: BTreeSet<PathBuf> =
+            [PathBuf::from("/dev/tty"), pts].into_iter().collect();
+        let out = collapse_write_paths(&writes);
+        unsafe { libc::close(slave); libc::close(master); }
+        assert_eq!(out, vec![PathBuf::from("/dev/pts"), PathBuf::from("/dev/tty")]);
     }
 }

--- a/crates/sandlock-cli/src/learn.rs
+++ b/crates/sandlock-cli/src/learn.rs
@@ -535,6 +535,9 @@ pub async fn run(args: LearnArgs) -> Result<()> {
         .name(format!("learn-{}", std::process::id()))
         .mode("learn")
         .fs_read("/")
+        // Device opens bypass COW and land on the real node, so a terminal
+        // or `> /dev/null` needs Landlock write on /dev to keep working.
+        .fs_write("/dev")
         .workdir("/")
         // Discard all COW changes after observation; learn is read-only from
         // the real filesystem's perspective.

--- a/crates/sandlock-cli/tests/learn_test.rs
+++ b/crates/sandlock-cli/tests/learn_test.rs
@@ -521,6 +521,29 @@ fn test_learn_captures_resource_limits() {
 
 // ── Path collapse and dedup ───────────────────────────────────────────────────
 
+/// A write-open of a device node under learn reaches the real device: a COW
+/// stub in the upper layer would leave ncurses apps without a tty.
+#[test]
+fn test_learn_device_write_open_reaches_real_device() {
+    let output = sandlock_bin()
+        .args([
+            "learn", "--", "python3", "-c",
+            "import os, stat; fd = os.open('/dev/null', os.O_RDWR); \
+             print('ISCHR', stat.S_ISCHR(os.fstat(fd).st_mode))",
+        ])
+        .output()
+        .expect("failed to run sandlock learn");
+    assert!(
+        output.status.success(),
+        "sandlock learn failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("ISCHR True"), "expected a real character device, got:\n{stdout}");
+    let write_line = stdout.lines().find(|l| l.starts_with("write = [")).unwrap_or("");
+    assert!(write_line.contains("/dev/null"), "expected /dev/null in writes, got: {write_line}");
+}
+
 /// Dedup removes a path when an ancestor is already in the read set.
 #[test]
 fn test_read_dedup_removes_leaf_when_ancestor_present() {

--- a/crates/sandlock-core/src/cow/dispatch.rs
+++ b/crates/sandlock-core/src/cow/dispatch.rs
@@ -489,6 +489,7 @@ fn cow_result(r: Result<bool, crate::error::BranchError>) -> NotifAction {
         // Whiteouted source: Continue would let the kernel act on the lower
         // entry, which still exists with its pre-delete content.
         Err(crate::error::BranchError::Deleted) => NotifAction::Errno(libc::ENOENT),
+        Err(crate::error::BranchError::NotOwned) => NotifAction::Continue,
         _ => NotifAction::Continue,
     }
 }
@@ -588,6 +589,16 @@ pub(crate) async fn handle_cow_write(
                 match cow.prepare_copy(rel) {
                     Ok(plan) => (Some(plan), workdir, upper, rel.clone()),
                     Err(crate::error::BranchError::QuotaExceeded) => return NotifAction::Errno(libc::ENOSPC),
+                    // A kernel object: its metadata is the kernel's to change,
+                    // but it cannot be staged under a new name.
+                    Err(crate::error::BranchError::NotOwned) => {
+                        return match op {
+                            CowWriteOp::Rename { .. } | CowWriteOp::Link { .. } => {
+                                NotifAction::Errno(libc::EXDEV)
+                            }
+                            _ => NotifAction::Continue,
+                        }
+                    }
                     Err(_) => return NotifAction::Continue,
                 }
             }

--- a/crates/sandlock-core/src/cow/result.rs
+++ b/crates/sandlock-core/src/cow/result.rs
@@ -19,6 +19,7 @@ pub(crate) fn link_result(r: Result<bool, BranchError>) -> NotifAction {
         Err(BranchError::Deleted) => NotifAction::Errno(libc::ENOENT),
         Err(BranchError::Denied) => NotifAction::Errno(libc::EPERM),
         Err(BranchError::Exists) => NotifAction::Errno(libc::EEXIST),
+        Err(BranchError::NotOwned) => NotifAction::Errno(libc::EXDEV),
         Err(_) => NotifAction::Errno(libc::EIO),
     }
 }

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -741,6 +741,17 @@ impl SeccompCowBranch {
         crate::sys::fs::statat_in_root(&self.upper, rel, false).is_ok()
     }
 
+    /// A device node is not filesystem data: an upper stub cannot stand in
+    /// for a terminal or a GPU, so its open must reach the
+    /// kernel, where Landlock decides.
+    fn lower_is_device(&self, rel: &str) -> bool {
+        !self.upper_has(rel)
+            && matches!(
+                crate::sys::fs::statat_in_root(&self.workdir, rel, false),
+                Ok(st) if matches!(st.st_mode & libc::S_IFMT, libc::S_IFCHR | libc::S_IFBLK)
+            )
+    }
+
     /// Check if a relative path is hidden by a whiteout in the merged view.
     /// A whiteout covers its whole subtree; an entry re-created in the upper
     /// shadows the whiteout and is visible again.
@@ -860,14 +871,13 @@ impl SeccompCowBranch {
         }
 
         if kind != libc::S_IFREG {
-            // Non-regular lower (FIFO, socket, device node): its content is
+            // Non-regular lower (FIFO, socket, or a device reached through a
+            // metadata op; device opens pass through instead): its content is
             // not filesystem data, and reading it can block forever (issue
             // #158: a FIFO open waits for a writer). Virtualize the write
             // like any other COW write, onto an empty regular stub in the
-            // upper, WITHOUT reading the source. Under a COW workdir a
-            // write must never need real permission on the lower entry
-            // (learn mode COWs whole trees, so `> /dev/null` lands here)
-            // and must never touch the real device.
+            // upper, WITHOUT reading the source, so it never needs real
+            // permission on the lower entry.
             self.check_quota(0)?;
             let fd = crate::sys::fs::openat2_in_root(
                 &self.upper,
@@ -1113,6 +1123,9 @@ impl SeccompCowBranch {
         }
 
         if is_write {
+            if self.lower_is_device(&rel) {
+                return Ok(None);
+            }
             self.ensure_cow_copy(&rel).map(Some)
         } else {
             let resolved = self.resolve_read(&rel);
@@ -1187,6 +1200,9 @@ impl SeccompCowBranch {
         }
 
         if is_write {
+            if self.lower_is_device(&rel) {
+                return Ok(CowOpenPlan::Skip);
+            }
             self.prepare_cow_copy(&rel)
         } else {
             let resolved = self.resolve_read(&rel);
@@ -4935,10 +4951,27 @@ mod tests {
     }
 
     #[test]
+    fn write_open_of_device_node_passes_through_to_kernel() {
+        // A terminal, /dev/null, or a GPU node cannot be virtualized: a stub
+        // in the upper is a regular file the program cannot ioctl, so
+        // ncurses apps lose their tty under a COW workdir of "/".
+        // Device opens go to the kernel, where Landlock decides.
+        let storage = tempfile::tempdir().unwrap();
+        let mut branch = SeccompCowBranch::create(Path::new("/"), Some(storage.path()), 0).unwrap();
+        let flags = (libc::O_WRONLY | libc::O_CREAT | libc::O_TRUNC) as u64;
+        assert_eq!(branch.handle_open("/dev/null", flags).unwrap(), None);
+        assert!(matches!(branch.prepare_open("/dev/null", flags).unwrap(), CowOpenPlan::Skip));
+        assert!(
+            !branch.upper_dir().join("dev/null").exists(),
+            "no stub may be created for a device node",
+        );
+    }
+
+    #[test]
     fn write_open_of_fifo_virtualizes_to_upper_stub() {
         // A write-open of a FIFO under the COW tree keeps the virtualization
-        // contract (`> /dev/null` in a learn-mode tree must not need real
-        // write permission on /dev), and must not block the supervisor.
+        // contract (it must not need real write permission on the FIFO),
+        // and must not block the supervisor.
         let (workdir, storage) = setup_workdir();
         let fifo = workdir.path().join("pipe");
         let c = std::ffi::CString::new(fifo.to_str().unwrap()).unwrap();

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -37,6 +37,9 @@ fn branch_errno(e: BranchError) -> i32 {
         BranchError::Denied => libc::EPERM,
         BranchError::Deleted => libc::ENOENT,
         BranchError::Exists => libc::EEXIST,
+        // A kernel object cannot be staged in the upper; EXDEV makes mv and
+        // ln fall back to mknod plus unlink, which the branch virtualizes.
+        BranchError::NotOwned => libc::EXDEV,
         BranchError::Operation(_) | BranchError::Conflict(_) => libc::EIO,
     }
 }
@@ -742,14 +745,22 @@ impl SeccompCowBranch {
         crate::sys::fs::statat_in_root(&self.upper, rel, false).is_ok()
     }
 
-    /// A device node is not filesystem data: an upper stub cannot stand in
-    /// for a terminal or a GPU, so its open must reach the
-    /// kernel, where Landlock decides.
-    fn lower_is_device(&self, rel: &str) -> bool {
+    /// The branch owns filesystem data: regular files, directories, and
+    /// symlinks. A FIFO, socket, or device is a kernel object that merely
+    /// has a name in the tree; a copy of it is meaningless (a stub cannot be
+    /// a terminal) and opening it can block the supervisor (issue #158), so
+    /// its content and metadata stay with the kernel and Landlock.
+    fn is_kernel_object_kind(kind: libc::mode_t) -> bool {
+        matches!(kind, libc::S_IFIFO | libc::S_IFSOCK | libc::S_IFCHR | libc::S_IFBLK)
+    }
+
+    /// True when the merged entry at `rel` is a lower kernel object. An
+    /// entry the branch materialized itself (a FIFO it mknod'ed) is owned.
+    fn is_kernel_object(&self, rel: &str) -> bool {
         !self.upper_has(rel)
             && matches!(
                 crate::sys::fs::statat_in_root(&self.workdir, rel, false),
-                Ok(st) if matches!(st.st_mode & libc::S_IFMT, libc::S_IFCHR | libc::S_IFBLK)
+                Ok(st) if Self::is_kernel_object_kind(st.st_mode & libc::S_IFMT)
             )
     }
 
@@ -871,30 +882,8 @@ impl SeccompCowBranch {
             return Ok(CowCopyPlan::Ready(upper_file));
         }
 
-        if kind != libc::S_IFREG {
-            // Non-regular lower (FIFO, socket, or a device reached through a
-            // metadata op; device opens pass through instead): its content is
-            // not filesystem data, and reading it can block forever (issue
-            // #158: a FIFO open waits for a writer). Virtualize the write
-            // like any other COW write, onto an empty regular stub in the
-            // upper, WITHOUT reading the source, so it never needs real
-            // permission on the lower entry.
-            self.check_quota(0)?;
-            let fd = crate::sys::fs::openat2_in_root(
-                &self.upper,
-                rel_path,
-                libc::O_WRONLY | libc::O_CREAT | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-                0o600,
-            )
-            .map_err(|e| BranchError::Operation(format!("create cow stub: {}", e)))?;
-            unsafe { libc::close(fd) };
-            // Whiteout the lower entry the stub replaces. The stub already
-            // shadows it in the merged view; the whiteout makes commit
-            // unlink it before the publish walk, which would otherwise
-            // O_WRONLY-open the surviving FIFO and block on a reader that
-            // never comes (the publish half of issue #158).
-            self.mark_deleted(rel_path);
-            return Ok(CowCopyPlan::Ready(upper_file));
+        if Self::is_kernel_object_kind(kind) {
+            return Err(BranchError::NotOwned);
         }
 
         // Regular file — defer the potentially expensive copy. Size comes from
@@ -1109,6 +1098,10 @@ impl SeccompCowBranch {
             return Err(BranchError::Deleted);
         }
 
+        if self.is_kernel_object(&rel) {
+            return Ok(None);
+        }
+
         // O_EXCL: fail if file already exists (in upper or lower)
         if flags & O_CREAT != 0 && flags & O_EXCL != 0 {
             // Confined existence check: a symlinked parent component must not
@@ -1124,9 +1117,6 @@ impl SeccompCowBranch {
         }
 
         if is_write {
-            if self.lower_is_device(&rel) {
-                return Ok(None);
-            }
             self.ensure_cow_copy(&rel).map(Some)
         } else {
             let resolved = self.resolve_read(&rel);
@@ -1187,6 +1177,10 @@ impl SeccompCowBranch {
             return Ok(CowOpenPlan::Deleted);
         }
 
+        if self.is_kernel_object(&rel) {
+            return Ok(CowOpenPlan::Skip);
+        }
+
         // O_EXCL: fail if file already exists
         if flags & O_CREAT != 0 && flags & O_EXCL != 0 {
             // Confined existence check: a symlinked parent component must not
@@ -1201,9 +1195,6 @@ impl SeccompCowBranch {
         }
 
         if is_write {
-            if self.lower_is_device(&rel) {
-                return Ok(CowOpenPlan::Skip);
-            }
             self.prepare_cow_copy(&rel)
         } else {
             let resolved = self.resolve_read(&rel);
@@ -4940,31 +4931,114 @@ mod tests {
         assert!(!branch.upper_dir().join("d").exists());
     }
 
+    fn make_fifo(path: &Path) {
+        let c = std::ffi::CString::new(path.to_str().unwrap()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(c.as_ptr(), 0o644) }, 0);
+    }
+
     #[test]
-    fn copy_up_of_fifo_does_not_block() {
+    fn copy_up_of_fifo_is_refused_without_blocking() {
         // Issue #158: opening a FIFO O_RDONLY blocks until a writer appears,
-        // so the copy-up path must never stream a non-regular file. The probe
+        // so the copy-up path must never touch a non-regular file. The probe
         // runs on a thread with a timeout so a regression hangs the test, not
         // the suite.
         let (workdir, storage) = setup_workdir();
-        let fifo = workdir.path().join("pipe");
-        let c = std::ffi::CString::new(fifo.to_str().unwrap()).unwrap();
-        assert_eq!(unsafe { libc::mkfifo(c.as_ptr(), 0o644) }, 0);
-
+        make_fifo(&workdir.path().join("pipe"));
         let wd = workdir.path().to_path_buf();
         let sd = storage.path().to_path_buf();
         let (tx, rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
             let mut b = SeccompCowBranch::create(&wd, Some(&sd), 0).unwrap();
-            let _ = tx.send(b.ensure_cow_copy("pipe").map(|p| fs::read(p).map(|b| b.len())));
+            let _ = tx.send(b.ensure_cow_copy("pipe"));
         });
         match rx.recv_timeout(std::time::Duration::from_secs(5)) {
-            // The FIFO is virtualized as an empty regular stub in the upper,
-            // created without ever opening the FIFO itself.
-            Ok(Ok(Ok(0))) => {}
-            Ok(other) => panic!("expected an empty upper stub for a FIFO, got {:?}", other),
+            Ok(Err(BranchError::NotOwned)) => {}
+            Ok(other) => panic!("expected NotOwned for a FIFO, got {:?}", other),
             Err(_) => panic!("copy-up of a FIFO hung"),
         }
+    }
+
+    #[test]
+    fn open_of_fifo_passes_through_to_kernel() {
+        // A FIFO is a rendezvous, not data: an upper stub would discard what
+        // the writer sends, and a supervisor-side open would block the
+        // supervisor instead of the child.
+        let (workdir, storage) = setup_workdir();
+        make_fifo(&workdir.path().join("pipe"));
+        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        let path = format!("{}/pipe", branch.workdir_str());
+        for flags in [libc::O_RDONLY as u64, libc::O_WRONLY as u64] {
+            assert_eq!(branch.handle_open(&path, flags).unwrap(), None);
+            assert!(matches!(branch.prepare_open(&path, flags).unwrap(), CowOpenPlan::Skip));
+        }
+        assert!(!branch.upper_dir().join("pipe").exists(), "no stub may be created");
+    }
+
+    #[test]
+    fn commit_leaves_lower_fifo_alone() {
+        // Commit runs on a thread with a timeout: a stub or whiteout for the
+        // FIFO would make the publish walk open it and block (issue #158).
+        let (workdir, storage) = setup_workdir();
+        make_fifo(&workdir.path().join("pipe"));
+        let wd = workdir.path().to_path_buf();
+        let sd = storage.path().to_path_buf();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let mut b = SeccompCowBranch::create(&wd, Some(&sd), 0).unwrap();
+            let path = format!("{}/pipe", b.workdir_str());
+            assert_eq!(b.handle_open(&path, libc::O_WRONLY as u64).unwrap(), None);
+            let _ = tx.send(b.commit());
+        });
+        match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => panic!("commit failed: {:?}", e),
+            Err(_) => panic!("commit hung on the lower FIFO"),
+        }
+        let ft = fs::symlink_metadata(workdir.path().join("pipe")).unwrap().file_type();
+        assert!(std::os::unix::fs::FileTypeExt::is_fifo(&ft), "lower FIFO must survive as a FIFO");
+    }
+
+    #[test]
+    fn chmod_of_fifo_passes_through_to_kernel() {
+        let (workdir, storage) = setup_workdir();
+        let fifo = workdir.path().join("pipe");
+        make_fifo(&fifo);
+        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        let path = format!("{}/pipe", branch.workdir_str());
+        assert!(matches!(branch.handle_chmod(&path, 0o600), Err(BranchError::NotOwned)));
+        assert!(!branch.upper_dir().join("pipe").exists(), "no stub may be created");
+        let lower_mode = fs::metadata(&fifo).unwrap().permissions();
+        assert_eq!(std::os::unix::fs::PermissionsExt::mode(&lower_mode) & 0o777, 0o644);
+    }
+
+    #[test]
+    fn rename_of_fifo_reports_exdev() {
+        // A kernel object cannot be staged in the upper. EXDEV is the answer
+        // mv already handles: it falls back to mknod plus unlink, both of
+        // which the branch virtualizes.
+        let (workdir, storage) = setup_workdir();
+        make_fifo(&workdir.path().join("pipe"));
+        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        let wd = branch.workdir_str().to_string();
+        assert_eq!(
+            branch.handle_rename(&format!("{wd}/pipe"), &format!("{wd}/pipe2")),
+            Err(libc::EXDEV),
+        );
+        assert!(!branch.upper_dir().join("pipe").exists(), "no stub may be created");
+    }
+
+    #[test]
+    fn fifo_created_in_branch_stays_virtualized() {
+        // Ownership is about the lower tree: a FIFO the workload itself made
+        // lives in the upper and keeps resolving there.
+        let (workdir, storage) = setup_workdir();
+        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
+        let path = format!("{}/made", branch.workdir_str());
+        assert!(branch.handle_mknod(&path, libc::S_IFIFO as u32 | 0o644, 0).unwrap());
+        assert_eq!(
+            branch.handle_open(&path, libc::O_WRONLY as u64).unwrap(),
+            Some(branch.upper_dir().join("made")),
+        );
     }
 
     #[test]
@@ -5010,72 +5084,15 @@ mod tests {
     }
 
     #[test]
-    fn write_open_of_fifo_virtualizes_to_upper_stub() {
-        // A write-open of a FIFO under the COW tree keeps the virtualization
-        // contract (it must not need real write permission on the FIFO),
-        // and must not block the supervisor.
-        let (workdir, storage) = setup_workdir();
-        let fifo = workdir.path().join("pipe");
-        let c = std::ffi::CString::new(fifo.to_str().unwrap()).unwrap();
-        assert_eq!(unsafe { libc::mkfifo(c.as_ptr(), 0o644) }, 0);
-        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
-        let wd = branch.workdir_str().to_string();
-        let flags = libc::O_WRONLY as u64;
-        let resolved = branch.handle_open(&format!("{}/pipe", wd), flags).unwrap();
-        assert_eq!(resolved, Some(branch.upper_dir().join("pipe")));
-        let meta = fs::metadata(branch.upper_dir().join("pipe")).unwrap();
-        assert!(meta.file_type().is_file(), "upper stub must be a regular file");
-        assert_eq!(meta.len(), 0);
-    }
-
-    #[test]
-    fn commit_replaces_lower_fifo_with_stub_bytes() {
-        // The publish half of issue #158: the stub must whiteout the lower
-        // FIFO so commit's deletion pass unlinks it. Without the whiteout
-        // the publish walk O_WRONLY-opens the surviving FIFO as its
-        // destination and blocks on a reader that never comes. Commit runs
-        // on a thread with a timeout so a regression fails the test
-        // instead of hanging the suite.
-        let (workdir, storage) = setup_workdir();
-        let fifo = workdir.path().join("pipe");
-        let c = std::ffi::CString::new(fifo.to_str().unwrap()).unwrap();
-        assert_eq!(unsafe { libc::mkfifo(c.as_ptr(), 0o644) }, 0);
-
-        let wd = workdir.path().to_path_buf();
-        let sd = storage.path().to_path_buf();
-        let (tx, rx) = std::sync::mpsc::channel();
-        std::thread::spawn(move || {
-            let mut b = SeccompCowBranch::create(&wd, Some(&sd), 0).unwrap();
-            let wds = b.workdir_str().to_string();
-            let resolved = b
-                .handle_open(&format!("{}/pipe", wds), libc::O_WRONLY as u64)
-                .unwrap()
-                .unwrap();
-            fs::write(&resolved, "published").unwrap();
-            let _ = tx.send(b.commit());
-        });
-        match rx.recv_timeout(std::time::Duration::from_secs(10)) {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => panic!("commit failed: {:?}", e),
-            Err(_) => panic!("commit hung on the lower FIFO (issue #158)"),
-        }
-        let meta = fs::symlink_metadata(workdir.path().join("pipe")).unwrap();
-        assert!(meta.file_type().is_file(), "lower FIFO must be replaced by the stub");
-        assert_eq!(fs::read_to_string(workdir.path().join("pipe")).unwrap(), "published");
-    }
-
-    #[test]
-    fn chmod_of_fifo_stays_in_upper() {
-        let (workdir, storage) = setup_workdir();
-        let fifo = workdir.path().join("pipe");
-        let c = std::ffi::CString::new(fifo.to_str().unwrap()).unwrap();
-        assert_eq!(unsafe { libc::mkfifo(c.as_ptr(), 0o644) }, 0);
-        let mut branch = SeccompCowBranch::create(workdir.path(), Some(storage.path()), 0).unwrap();
-        let wd = branch.workdir_str().to_string();
-        assert_eq!(branch.handle_chmod(&format!("{}/pipe", wd), 0o600).unwrap(), true);
-        // The chmod landed on the upper stub, not the real FIFO.
-        let lower_mode = fs::metadata(&fifo).unwrap().permissions();
-        assert_eq!(std::os::unix::fs::PermissionsExt::mode(&lower_mode) & 0o777, 0o644);
+    fn metadata_op_on_device_does_not_bring_back_a_stub() {
+        // chmod/utimes on a device used to stage a stub that every later
+        // open then resolved to, undoing the passthrough.
+        let storage = tempfile::tempdir().unwrap();
+        let mut branch = SeccompCowBranch::create(Path::new("/"), Some(storage.path()), 0).unwrap();
+        assert!(matches!(branch.handle_chmod("/dev/null", 0o666), Err(BranchError::NotOwned)));
+        assert!(matches!(branch.handle_utimensat("/dev/null"), Err(BranchError::NotOwned)));
+        assert_eq!(branch.handle_open("/dev/null", libc::O_RDWR as u64).unwrap(), None);
+        assert!(!branch.upper_dir().join("dev/null").exists());
     }
 
     #[test]

--- a/crates/sandlock-core/src/cow/seccomp.rs
+++ b/crates/sandlock-core/src/cow/seccomp.rs
@@ -7,6 +7,7 @@
 use std::collections::HashSet;
 use std::fs;
 use std::os::unix::ffi::OsStringExt;
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::os::unix::io::FromRawFd;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -2137,6 +2138,22 @@ impl SeccompCowBranch {
                     &target.to_string_lossy(),
                 )
                 .map_err(|e| BranchError::Operation(format!("symlink: {}", e)))?;
+                self.drop_merged_entry(entry.path());
+                synced_dirs.insert(dest.parent().unwrap().to_path_buf());
+            } else if entry.file_type().is_fifo() || entry.file_type().is_socket() {
+                // A node the workload mknod'ed carries no bytes, and opening a
+                // FIFO to copy it would block on a peer that never comes.
+                if let Some(p) = parent_rel(rel_str) {
+                    let _ = crate::sys::fs::mkdirp_in_root(&self.workdir, p, 0o755);
+                }
+                let mode = entry
+                    .metadata()
+                    .map(|m| m.mode())
+                    .map_err(|e| BranchError::Operation(format!("stat: {}", e)))?;
+                let _ = crate::sys::fs::unlinkat_in_root(&self.workdir, rel_str, false);
+                crate::sys::fs::mknod_in_root(&self.workdir, rel_str, mode, 0)
+                    .map_err(|e| BranchError::Operation(format!("mknod: {}", e)))?;
+                let _ = crate::sys::fs::chmod_in_root(&self.workdir, rel_str, mode & 0o7777);
                 self.drop_merged_entry(entry.path());
                 synced_dirs.insert(dest.parent().unwrap().to_path_buf());
             } else {
@@ -4948,6 +4965,31 @@ mod tests {
             Ok(other) => panic!("expected an empty upper stub for a FIFO, got {:?}", other),
             Err(_) => panic!("copy-up of a FIFO hung"),
         }
+    }
+
+    #[test]
+    fn commit_publishes_a_fifo_the_branch_made() {
+        // The branch lets the workload mknod a FIFO, so commit must be able
+        // to publish one. Byte-copying it opens the FIFO and blocks forever;
+        // commit runs on a thread with a timeout so that shows as a failure.
+        let (workdir, storage) = setup_workdir();
+        let wd = workdir.path().to_path_buf();
+        let sd = storage.path().to_path_buf();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let mut b = SeccompCowBranch::create(&wd, Some(&sd), 0).unwrap();
+            let path = format!("{}/made", b.workdir_str());
+            assert!(b.handle_mknod(&path, libc::S_IFIFO as u32 | 0o640, 0).unwrap());
+            let _ = tx.send(b.commit());
+        });
+        match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => panic!("commit failed: {:?}", e),
+            Err(_) => panic!("commit hung publishing a FIFO"),
+        }
+        let meta = fs::symlink_metadata(workdir.path().join("made")).unwrap();
+        assert!(std::os::unix::fs::FileTypeExt::is_fifo(&meta.file_type()), "published as a FIFO");
+        assert_eq!(std::os::unix::fs::PermissionsExt::mode(&meta.permissions()) & 0o777, 0o640);
     }
 
     #[test]

--- a/crates/sandlock-core/src/error.rs
+++ b/crates/sandlock-core/src/error.rs
@@ -130,6 +130,12 @@ pub enum BranchError {
     /// async `CowOpenPlan::Deleted`.
     #[error("file was deleted in this branch")]
     Deleted,
+
+    /// The lower entry is a kernel object (FIFO, socket, device node) that
+    /// merely has a name in the tree. The branch owns regular files,
+    /// directories, and symlinks; everything else stays with the kernel.
+    #[error("entry is not owned by this branch")]
+    NotOwned,
 }
 
 /// Convenience type alias.

--- a/docs/sandbox-reference.md
+++ b/docs/sandbox-reference.md
@@ -525,7 +525,11 @@ parse_ports([80, "443", "8000-8005"])
 2. **Seccomp COW with `workdir`.** When `workdir` is set, the
    seccomp-based COW path intercepts writes under `workdir` and stages
    them in an upper layer, committed or aborted on exit per `on_exit` /
-   `on_error`.
+   `on_error`. Staging covers regular files, directories, and symlinks.
+   A FIFO, socket, or device node under `workdir` is a kernel object:
+   opening it or changing its metadata goes to the kernel under the
+   Landlock rules, renaming or hard-linking it returns `EXDEV`, and
+   nothing about it is reverted on abort.
 3. **HTTP host auto-expansion.** HTTP rules referencing concrete hosts
    auto-add corresponding TCP entries on `http_ports` (and on `443`
    when `http_ca` is set). Wildcard hosts add the equivalent any-IP


### PR DESCRIPTION
## Summary

Started from #208 (`sandlock learn` makes mc unusable). The root cause was in COW, and fixing it properly led to a small redesign of what the COW branch owns.

- **cow: pass device opens through to the kernel.** A write-open of a device under a COW workdir was virtualized onto an empty regular stub, the treatment #158 gave FIFOs. A stub cannot be a terminal: `/dev/tty` failed `isatty()` and every ioctl, so ncurses apps lost their screen under `learn`, `/dev/ptmx` could not allocate a pty, and bytes written to `/dev/null` piled up on disk. `learn` grants Landlock write on `/dev` so the passthrough works under its read-only root policy.
- **learn: record the terminal in the profile.** `is_junk_path` dropped `/dev/tty` and `/dev/pts/*`, so a profile learned from an interactive program never granted the terminal and `run` under it failed with EACCES. `/dev/tty` is a stable path; only the pty number changes, so `/dev/pts/N` folds to `/dev/pts`.
- **cow: publish FIFOs and sockets by mknod at commit.** Commit byte-copied every non-directory upper entry, so a FIFO the workload created wedged commit forever after the deletion pass had already landed. Pre-existing, reachable with plain `mkfifo` under a committing workdir.
- **cow: leave kernel objects to the kernel.** The branch now owns regular files, directories, and symlinks only. `prepare_copy` returns `NotOwned` for a FIFO, socket, or device, so every open and metadata handler agrees in one place: those go to the kernel under Landlock, and rename or hard link of one returns `EXDEV`, which `mv` and `ln` answer with mknod plus unlink, both virtualized. Documented in README and the sandbox reference.

## Behavior change

Under a COW workdir, writes to FIFOs, sockets, and devices now need a real Landlock grant instead of silently landing on a stub, and are not reverted on abort. A silent success that did nothing was the worse outcome, especially for a profile generator.

## Testing

- Nine new COW unit tests (device and FIFO open, chmod, rename, copy-up refusal, commit of lower and branch-made FIFOs, chmod-then-open regression), each watched failing first.
- New `learn_test` case: an `O_RDWR` fd on `/dev/null` under `learn` is a real character device and is recorded under `write`.
- New `learn` unit test with a real pty: `/dev/tty` is granted, `/dev/pts/N` folds to `/dev/pts`.
- Manual: `/dev/tty` probe and `less` learned under a pty then run under the learned profile; `mv` of a FIFO and `mkfifo` under a committing workdir complete with FIFOs intact.

Not addressed here: `fchmodat2` is not intercepted by COW, so `mkfifo -m` and `chmod -h` on a branch-created entry report ENOENT. Pre-existing and separate.

Fixes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)
