### PR TITLE
Fix thread-id misuse in the execve freeze and per-pid network overrides

### DIFF
--- a/crates/sandlock-core/src/freeze.rs
+++ b/crates/sandlock-core/src/freeze.rs
@@ -280,7 +280,7 @@ pub(crate) fn freeze_sandbox_for_execve(
 ) -> Result<SandboxFreeze, FreezeError> {
     let no_pending = |error| FreezeError { error, pending_tids: Vec::new() };
     let caller_tgid = read_tgid_of_tid(caller_tid).map_err(no_pending)?;
-    let mut tgids: HashSet<i32> = processes.pids_snapshot();
+    let mut tgids: HashSet<i32> = processes.tgids_snapshot();
     tgids.insert(caller_tgid);
 
     let mut sibling_tids: Vec<i32> = Vec::new();
@@ -511,5 +511,87 @@ mod tests {
         let _ = peer.wait();
         let _ = caller.kill();
         let _ = caller.wait();
+    }
+
+    /// Re-executed by `freeze_sandbox_tolerates_thread_tids_in_index` as a
+    /// multi-threaded peer; a no-op in a normal test run.
+    #[test]
+    fn freeze_helper_multithreaded_child() {
+        if std::env::var_os("SANDLOCK_FREEZE_HELPER").is_none() {
+            return;
+        }
+        std::thread::spawn(|| loop {
+            std::thread::sleep(std::time::Duration::from_secs(60));
+        });
+        loop {
+            std::thread::sleep(std::time::Duration::from_secs(60));
+        }
+    }
+
+    /// Issue #212: the index is keyed by notifying tid, so one thread group
+    /// can appear under several entries, and re-seizing a thread the freeze
+    /// already holds fails with EPERM.
+    #[test]
+    fn freeze_sandbox_tolerates_thread_tids_in_index() {
+        use std::process::{Command, Stdio};
+
+        let mut caller = Command::new("/bin/sleep")
+            .arg("60")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn caller sleep");
+        let caller_tid = caller.id() as i32;
+
+        let mut peer = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "freeze::tests::freeze_helper_multithreaded_child",
+                "--test-threads=1",
+            ])
+            .env("SANDLOCK_FREEZE_HELPER", "1")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn multi-threaded peer");
+        let peer_pid = peer.id() as i32;
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let tids = loop {
+            let tids = list_threads_of_tgid(peer_pid).unwrap_or_default();
+            if tids.len() >= 2 {
+                break tids;
+            }
+            assert!(std::time::Instant::now() < deadline, "peer never became multi-threaded");
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        };
+
+        let processes = ProcessIndex::new();
+        for tid in &tids {
+            processes.register(*tid).expect("register peer tid");
+        }
+
+        let outcome = freeze_sandbox_for_execve(&processes, caller_tid);
+        if let Ok(freeze) = &outcome {
+            // Detach before killing: a traced thread that dies stays a
+            // zombie until its tracer reaps it, and that would wedge wait().
+            detach_peers(&freeze.peer_tids);
+        }
+        let _ = peer.kill();
+        let _ = caller.kill();
+        let _ = peer.wait();
+        let _ = caller.wait();
+
+        let outcome = outcome.expect("freeze with duplicate thread-group entries");
+        for tid in &tids {
+            assert!(
+                outcome.peer_tids.contains(tid),
+                "peer tid {} missing from {:?}",
+                tid,
+                outcome.peer_tids
+            );
+        }
     }
 }

--- a/crates/sandlock-core/src/policy_fn.rs
+++ b/crates/sandlock-core/src/policy_fn.rs
@@ -86,7 +86,8 @@ pub struct SyscallEvent {
     pub syscall: String,
     /// High-level category.
     pub category: SyscallCategory,
-    /// PID of the process that made the syscall.
+    /// PID of the process that made the syscall. Notifications name the
+    /// calling thread; this is its thread-group id.
     pub pid: u32,
     /// Parent PID (read from /proc/{pid}/stat).
     pub parent_pid: Option<u32>,

--- a/crates/sandlock-core/src/seccomp/notif.rs
+++ b/crates/sandlock-core/src/seccomp/notif.rs
@@ -1843,6 +1843,7 @@ fn decode_sendmmsg_extras(
     nr: i64,
     name: &str,
     category: crate::policy_fn::SyscallCategory,
+    event_pid: u32,
     parent_pid: Option<u32>,
     denied: bool,
     protocol: &Option<String>,
@@ -1862,7 +1863,7 @@ fn decode_sendmmsg_extras(
         extras.push(crate::policy_fn::SyscallEvent {
             syscall: name.to_string(),
             category,
-            pid: notif.pid,
+            pid: event_pid,
             parent_pid,
             host,
             port,
@@ -1900,6 +1901,8 @@ async fn emit_policy_event(
         .ok()
         .and_then(crate::seccomp::state::read_ppid)
         .and_then(|p| u32::try_from(p).ok());
+    let event_pid = crate::seccomp::state::read_tgid_of_tid(notif.pid as i32)
+        .map_or(notif.pid, |t| t as u32);
 
     // Extract metadata based on syscall type.
     //
@@ -2023,7 +2026,7 @@ async fn emit_policy_event(
     
     // Decode remaining sendmmsg entries before unblocking the child.
     let sendmmsg_extras = decode_sendmmsg_extras(
-        notif, notif_fd, nr, name, category, parent_pid, denied, &protocol,
+        notif, notif_fd, nr, name, category, event_pid, parent_pid, denied, &protocol,
     );
 
     let sock_fd = if nr == libc::SYS_connect || nr == libc::SYS_sendto
@@ -2038,7 +2041,7 @@ async fn emit_policy_event(
     let event = crate::policy_fn::SyscallEvent {
         syscall: name.to_string(),
         category,
-        pid: notif.pid,
+        pid: event_pid,
         parent_pid,
         host,
         port,

--- a/crates/sandlock-core/src/seccomp/state.rs
+++ b/crates/sandlock-core/src/seccomp/state.rs
@@ -368,6 +368,15 @@ impl ProcessIndex {
             .unwrap_or_default()
     }
 
+    /// Distinct thread groups in the index. Entries are keyed by the
+    /// notifying task's tid, so one group can appear under several keys.
+    pub fn tgids_snapshot(&self) -> HashSet<i32> {
+        self.inner
+            .read()
+            .map(|g| g.values().map(|e| e.tgid).collect())
+            .unwrap_or_default()
+    }
+
     /// Remove a process from the index. The per-process state's
     /// `Arc` reference held by the index drops here; remaining clones
     /// (e.g. a handler that's mid-execution for that pid) will drop

--- a/crates/sandlock-core/src/seccomp/state.rs
+++ b/crates/sandlock-core/src/seccomp/state.rs
@@ -494,7 +494,7 @@ impl NetworkState {
         }
     }
 
-    /// Get the effective network policy for a PID and protocol.
+    /// Get the effective network policy for the task `tid` and protocol.
     ///
     /// Priority: per-PID override > live policy (from PolicyFnState) >
     /// the per-protocol allowlist for `protocol`.
@@ -503,7 +503,7 @@ impl NetworkState {
     /// protocols, since the legacy API didn't distinguish them.
     pub fn effective_network_policy(
         &self,
-        pid: u32,
+        tid: u32,
         protocol: crate::sandbox::Protocol,
         live_policy: Option<&std::sync::Arc<std::sync::RwLock<crate::policy_fn::LivePolicy>>>,
     ) -> crate::seccomp::notif::NetworkPolicy {
@@ -518,8 +518,12 @@ impl NetworkState {
             }
         };
         if let Ok(overrides) = self.pid_ip_overrides.read() {
-            if let Some(ips) = overrides.get(&pid) {
-                return ip_only_allow(ips);
+            // Overrides are keyed by process; the notification names a thread.
+            if !overrides.is_empty() {
+                let tgid = read_tgid_of_tid(tid as i32).map_or(tid, |t| t as u32);
+                if let Some(ips) = overrides.get(&tgid) {
+                    return ip_only_allow(ips);
+                }
             }
         }
         if let Some(lp) = live_policy {
@@ -932,5 +936,32 @@ mod tests {
         let key = idx.register(self_pid).unwrap();
         idx.prune_dead();
         assert_eq!(idx.key_for(self_pid), Some(key));
+    }
+
+    /// The override is set from a policy event's pid and consulted on every
+    /// thread's syscalls, so it must be keyed by process, not by task.
+    #[test]
+    fn pid_override_applies_to_every_thread_of_the_process() {
+        use crate::seccomp::notif::NetworkPolicy;
+        let ns = NetworkState::new();
+        let tgid = std::process::id();
+        let ip: std::net::IpAddr = "10.0.0.1".parse().unwrap();
+        ns.pid_ip_overrides
+            .write()
+            .unwrap()
+            .insert(tgid, HashSet::from([ip]));
+
+        let policy = std::thread::spawn(move || {
+            let tid = unsafe { libc::syscall(libc::SYS_gettid) } as u32;
+            assert_ne!(tid, tgid);
+            ns.effective_network_policy(tid, crate::sandbox::Protocol::Tcp, None)
+        })
+        .join()
+        .unwrap();
+
+        match policy {
+            NetworkPolicy::AllowList { per_ip, .. } => assert!(per_ip.contains_key(&ip)),
+            other => panic!("override ignored for a non-leader thread: {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
Fixes #212.

Seccomp notifications carry the calling thread's id, not the process id. Two places treated that value as a process.

**freeze: walk each thread group once.** `ProcessIndex` is keyed by the notifying tid, so a multi-threaded sandboxed process appears under several entries. The execve argv-safety freeze walked `/proc/<entry>/task` for each one, and the kernel resolves that path to the whole thread group for any member, so the same threads were enumerated twice. The second `PTRACE_SEIZE` of a thread the supervisor already held failed with EPERM and the freeze denied the execve. Any program spawning subprocesses from more than one thread lost most of its execs under `policy_fn`, which is what the reporter saw with `sandlock learn` around Claude Code. The freeze now walks a distinct thread-group snapshot; each entry already records its tgid, so no extra `/proc` reads. A regression test re-executes the test binary as a multi-threaded peer, registers every one of its thread ids, and expects the freeze to succeed. It fails with the issue's EPERM without the fix.

**policy_fn: key per-pid network overrides by process.** `SyscallEvent.pid` documented itself as the process pid but carried the thread id, and `restrict_pid_network` stored the override under it. The lookup on connect and sendto used the calling thread's id, so in a multi-threaded process an override set after seeing one thread's connect never applied to its siblings. Events now carry the thread-group id, and the lookup resolves the notifying thread to its group, only while an override exists so the common path pays nothing.

Verified with the reporter's reproducer: 38 to 40 freeze failures per run before, none across three runs after, with all 48 spawns running. The sandlock-core lib suite passes (743 tests), as do the policy_fn, chroot, and procfs integration subsets.
