### PR TITLE
deps: move to rustls 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,9 +264,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -651,18 +651,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
  "hyper-util",
  "log",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1047,9 +1045,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "pathdiff"
@@ -1291,11 +1289,12 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
@@ -1305,12 +1304,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -1336,9 +1334,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1473,9 +1471,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1801,12 +1799,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
- "rustls-pki-types",
  "tokio",
 ]
 

--- a/crates/sandlock-core/Cargo.toml
+++ b/crates/sandlock-core/Cargo.toml
@@ -25,13 +25,13 @@ walkdir = "2"
 toml = "0.8"
 jiff = "0.2"
 pathdiff = "0.2"
-tokio-rustls = "0.25"
-rustls = "0.22"
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
 rcgen = { version = "0.13", features = ["pem", "x509-parser"] }
 hyper = { version = "1", features = ["server", "client", "http1"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "http1", "tokio"] }
 http-body-util = "0.1"
-hyper-rustls = "0.26"
+hyper-rustls = { version = "0.27", default-features = false, features = ["ring", "native-tokio", "http1", "tls12", "logging"] }
 tar = "0.4"
 clap = { version = "4", features = ["derive"], optional = true }
 bollard = "0.21"

--- a/crates/sandlock-core/src/transparent_proxy/mod.rs
+++ b/crates/sandlock-core/src/transparent_proxy/mod.rs
@@ -54,7 +54,6 @@ pub(crate) async fn spawn_transparent_proxy(
     ca_key_pem: Option<&str>,
     log_fn: Option<Arc<dyn Fn(&str, &str, &str) + Send + Sync>>,
 ) -> std::io::Result<HttpAclProxyHandle> {
-    // rustls 0.22 builder() uses the ring provider directly; no provider install needed.
     let orig_dest: OrigDestMap =
         Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
     let forwarder = Forwarder::new()?;
@@ -191,7 +190,10 @@ mod tests {
         // rustls client that trusts only the generated CA.
         let mut roots = rustls::RootCertStore::empty();
         roots.add(first_cert_der(&ca.cert_pem)).expect("add CA root");
-        let client_cfg = rustls::ClientConfig::builder()
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        let client_cfg = rustls::ClientConfig::builder_with_provider(provider)
+            .with_safe_default_protocol_versions()
+            .expect("ring supports default protocol versions")
             .with_root_certificates(roots)
             .with_no_client_auth();
         let connector = TlsConnector::from(Arc::new(client_cfg));

--- a/crates/sandlock-core/src/transparent_proxy/tls.rs
+++ b/crates/sandlock-core/src/transparent_proxy/tls.rs
@@ -58,7 +58,12 @@ impl CertSigner {
         // rcgen serialize_der() returns PKCS#8 DER.
         let key_der = PrivateKeyDer::Pkcs8(leaf_key.serialize_der().into());
 
-        let mut cfg = ServerConfig::builder()
+        // Explicit provider: the process-wide default is ambiguous whenever a
+        // downstream crate compiles in a second rustls backend.
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        let mut cfg = ServerConfig::builder_with_provider(provider)
+            .with_safe_default_protocol_versions()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("server cfg: {e}")))?
             .with_no_client_auth()
             .with_single_cert(chain, key_der)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("server cfg: {e}")))?;
@@ -74,8 +79,6 @@ mod tests {
     use super::*;
 
     fn test_ca() -> (String, String) {
-        // rustls 0.22 ServerConfig::builder() uses crypto::ring::default_provider()
-        // directly (no process-wide install needed, unlike rustls 0.23).
         let m = crate::transparent_proxy::resolve_ca(None, None, true).unwrap().unwrap();
         (m.cert_pem, m.key_pem)
     }

--- a/crates/sandlock-core/src/transparent_proxy/upstream.rs
+++ b/crates/sandlock-core/src/transparent_proxy/upstream.rs
@@ -25,7 +25,7 @@ impl Forwarder {
         // with_native_roots validates upstream against the host's system trust
         // store (default feature native-tokio). Returns io::Result.
         let connector = hyper_rustls::HttpsConnectorBuilder::new()
-            .with_native_roots()?
+            .with_provider_and_native_roots(rustls::crypto::ring::default_provider())?
             .https_or_http()
             .enable_http1()
             .build();


### PR DESCRIPTION
## Summary

Bumps rustls 0.22 to 0.23 (with tokio-rustls 0.26 and hyper-rustls 0.27) so rustls-webpki can move to the 0.103 line. The lockfile now carries rustls-webpki 0.103.15, which covers all four advisories from #214:

- GHSA-82j2-j2ch-gfr8 (High, fixed 0.103.13)
- GHSA-pwjx-qhcg-rvj4 (Medium, fixed 0.103.10)
- GHSA-xgp8-3hg3-c2mh (Low, fixed 0.103.12)
- GHSA-965h-392x-2mh5 (Low, fixed 0.103.12)

The 0.22 pin was inherited from hudsucker, which was dropped earlier, so nothing else held it.

## Provider handling

rustls 0.23 picks a crypto provider at runtime and panics if more than one is compiled in with none installed process-wide. The three builder sites (server config, upstream connector, test client) now pass the ring provider explicitly, so a downstream crate that also enables aws-lc-rs is unaffected. Our own features keep aws-lc-rs out of the tree, so the build still needs no cmake or C toolchain.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p sandlock-core --lib transparent_proxy` (8 passed)
- [x] `cargo test -p sandlock-core --test integration http` (16 passed, covers HTTP ACL, HTTPS MITM, credential injection, CA injection)

Fixes #214
